### PR TITLE
Gh23   card pool display

### DIFF
--- a/cards/base.js
+++ b/cards/base.js
@@ -1,6 +1,6 @@
 const BaseClass = require('../baseClass');
 
-const { formatCard } = require('../helpers/card');
+const { actionCard } = require('../helpers/card');
 const { max } = require('../helpers/chance');
 
 class BaseCard extends BaseClass {
@@ -66,11 +66,7 @@ class BaseCard extends BaseClass {
 		return Promise
 			.resolve()
 			.then(() => channel({
-				announce: formatCard({
-					title: `${this.icon}  ${this.cardType}`,
-					description: this.description,
-					stats: this.stats
-				})
+				announce: actionCard(this)
 			}));
 	}
 }

--- a/cards/base.js
+++ b/cards/base.js
@@ -32,6 +32,10 @@ class BaseCard extends BaseClass {
 		return this.constructor.level;
 	}
 
+	get probability () {
+		return this.constructor.probability;
+	}
+
 	checkSuccess (roll, targetNumber) { // eslint-disable-line class-methods-use-this
 		let strokeOfLuck = false;
 		let curseOfLoki = false;

--- a/cards/index.js
+++ b/cards/index.js
@@ -42,6 +42,24 @@ const draw = (opts) => {
 	return new Card(options);
 };
 
+const getCardCounts = (cards) => {
+	const cardCounts = {};
+
+	cards.forEach((card) => {
+		cardCounts[card.cardType] = cardCounts[card.cardType] || 0;
+		cardCounts[card.cardType] += 1;
+	});
+
+	return cardCounts;
+};
+
+const getUniqueCards = cards =>
+	cards.reduce((uniqueCards, card) =>
+		uniqueCards.concat(!uniqueCards.find(possibleCard =>
+			possibleCard.name === card.name
+		) ? [card] : [])
+	, []);
+
 const getInitialDeck = options => [
 	new HitCard(options),
 	new HitCard(options),
@@ -64,5 +82,7 @@ module.exports = {
 	draw,
 	getInitialDeck,
 	hydrateCard,
-	hydrateDeck
+	hydrateDeck,
+	getUniqueCards,
+	getCardCounts
 };

--- a/cards/index.js
+++ b/cards/index.js
@@ -68,16 +68,12 @@ const getInitialDeck = (options) => {
 	return fillDeck(deck, options);
 };
 
-const getCardCounts = (cards) => {
-	const cardCounts = {};
-
-	cards.forEach((card) => {
+const getCardCounts = cards =>
+	cards.reduce((cardCounts, card) => {
 		cardCounts[card.cardType] = cardCounts[card.cardType] || 0;
 		cardCounts[card.cardType] += 1;
-	});
-
-	return cardCounts;
-};
+		return cardCounts;
+	}, {});
 
 const getUniqueCards = cards =>
 	cards.reduce((uniqueCards, card) =>

--- a/characters/base.js
+++ b/characters/base.js
@@ -1,5 +1,7 @@
 const BaseCreature = require('../creatures/base');
-const { getInitialDeck } = require('../cards');
+const { getInitialDeck, getUniqueCards, getCardCounts } = require('../cards');
+const { formatCard } = require('../helpers/card');
+const foreach = require('lodash.foreach');
 
 class BaseCharacter extends BaseCreature {
 	constructor (options) {
@@ -32,6 +34,37 @@ class BaseCharacter extends BaseCreature {
 		this.deck = [...this.deck, card];
 
 		this.emit('cardAdded', { card });
+	}
+
+	lookAtCards (channel) {
+		const cardImages = getUniqueCards(this.deck).reduce((cards, card) =>
+			cards + formatCard({
+				title: `${card.icon}  ${card.cardType}`,
+				description: card.description,
+				stats: card.stats
+			}), '');
+
+		let cardCounts = '';
+		foreach(getCardCounts(this.deck), (count, card) => {
+			cardCounts += `${card} (${count})
+`;
+		});
+
+
+		const deckDisplay = `${cardImages} ${cardCounts}`;
+
+		if (deckDisplay) {
+			return Promise
+				.resolve()
+				.then(() => channel({
+					announce: deckDisplay
+				}));
+		}
+
+		return Promise.reject(channel({
+			announce: "Strangely enough, somehow you don't have any cards.",
+			delay: 'short'
+		}));
 	}
 }
 

--- a/characters/base.js
+++ b/characters/base.js
@@ -1,6 +1,6 @@
 const BaseCreature = require('../creatures/base');
 const { getInitialDeck, getUniqueCards, getCardCounts } = require('../cards');
-const { formatCard } = require('../helpers/card');
+const { formatCard, monsterCard } = require('../helpers/card');
 const foreach = require('lodash.foreach');
 
 class BaseCharacter extends BaseCreature {
@@ -34,6 +34,23 @@ class BaseCharacter extends BaseCreature {
 		this.deck = [...this.deck, card];
 
 		this.emit('cardAdded', { card });
+	}
+
+	lookAtMonsters (channel) {
+		const monstersDisplay = this.monsters.reduce((monsters, monster) => monsters + monsterCard(monster, true), '');
+
+		if (monstersDisplay) {
+			return Promise
+				.resolve()
+				.then(() => channel({
+					announce: monstersDisplay
+				}));
+		}
+
+		return Promise.reject(channel({
+			announce: 'You do not currently have any monsters.',
+			delay: 'short'
+		}));
 	}
 
 	lookAtCards (channel) {

--- a/characters/base.js
+++ b/characters/base.js
@@ -1,6 +1,6 @@
 const BaseCreature = require('../creatures/base');
 const { getInitialDeck, getUniqueCards, getCardCounts } = require('../cards');
-const { formatCard, monsterCard } = require('../helpers/card');
+const { monsterCard, actionCard } = require('../helpers/card');
 const foreach = require('lodash.foreach');
 
 class BaseCharacter extends BaseCreature {
@@ -55,11 +55,7 @@ class BaseCharacter extends BaseCreature {
 
 	lookAtCards (channel) {
 		const cardImages = getUniqueCards(this.deck).reduce((cards, card) =>
-			cards + formatCard({
-				title: `${card.icon}  ${card.cardType}`,
-				description: card.description,
-				stats: card.stats
-			}), '');
+			cards + actionCard(card), '');
 
 		let cardCounts = '';
 		foreach(getCardCounts(this.deck), (count, card) => {

--- a/characters/base.js
+++ b/characters/base.js
@@ -1,7 +1,7 @@
 const BaseCreature = require('../creatures/base');
 const { getInitialDeck, getUniqueCards, getCardCounts } = require('../cards');
 const { monsterCard, actionCard } = require('../helpers/card');
-const foreach = require('lodash.foreach');
+const reduce = require('lodash.reduce');
 
 class BaseCharacter extends BaseCreature {
 	constructor (options) {
@@ -57,11 +57,9 @@ class BaseCharacter extends BaseCreature {
 		const cardImages = getUniqueCards(this.deck).reduce((cards, card) =>
 			cards + actionCard(card), '');
 
-		let cardCounts = '';
-		foreach(getCardCounts(this.deck), (count, card) => {
-			cardCounts += `${card} (${count})
-`;
-		});
+		const cardCounts = reduce(getCardCounts(this.deck), (counts, count, card) =>
+			`${counts}${card} (${count})
+`, '');
 
 
 		const deckDisplay = `${cardImages} ${cardCounts}`;

--- a/game.js
+++ b/game.js
@@ -385,6 +385,18 @@ ${monsterCard(monster)}`
 					return game.lookAtCard(channel, cardName)
 						.catch(err => log(err));
 				},
+				lookAtCards ({ deckName } = {}) {
+					return character.lookAtCards(channel, deckName)
+						.catch(err => log(err));
+				},
+				lookAtMonsters ({ monsterPoolName } = {}) {
+					return character.lookAtMonsters(channel, monsterPoolName)
+						.catch(err => log(err));
+				},
+				lookAtRing ({ ringName } = {}) {
+					return game.lookAtRing(channel, ringName)
+						.catch(err => log(err));
+				},
 				lookAt (thing) {
 					return game.lookAt(channel, thing)
 						.catch(err => log(err));

--- a/game.js
+++ b/game.js
@@ -12,7 +12,7 @@ const PlayerHandbook = require('./player-handbook');
 const ChannelManager = require('./channel');
 
 const { getFlavor } = require('./helpers/flavor');
-const { formatCard, monsterCard } = require('./helpers/card');
+const { actionCard, monsterCard } = require('./helpers/card');
 const { XP_PER_VICTORY, XP_PER_DEFEAT } = require('./helpers/levels');
 
 const noop = () => {};
@@ -90,11 +90,7 @@ class Game extends BaseClass {
 	announceCard (className, card, { player }) {
 		const channel = this.publicChannel;
 
-		const cardPlayed = formatCard({
-			title: `${card.icon}  ${card.cardType}`,
-			description: card.description,
-			stats: card.stats
-		});
+		const cardPlayed = actionCard(card);
 
 		channel({
 			announce:

--- a/game.js
+++ b/game.js
@@ -456,8 +456,8 @@ ${monsterCard(monster)}`
 					return character.lookAtCards(channel, deckName)
 						.catch(err => log(err));
 				},
-				lookAtMonsters ({ monsterPoolName } = {}) {
-					return character.lookAtMonsters(channel, monsterPoolName)
+				lookAtMonsters () {
+					return character.lookAtMonsters(channel)
 						.catch(err => log(err));
 				},
 				lookAtRing ({ ringName } = {}) {

--- a/game.js
+++ b/game.js
@@ -456,6 +456,14 @@ ${monsterCard(monster)}`
 		}));
 	}
 
+	getRing () {
+		return this.ring;
+	}
+
+	lookAtRing (channel, ringName = 'main') {
+		return this.getRing(ringName).look(channel);
+	}
+
 	lookAt (channel, thing) {
 		if (thing) {
 			// What is this thing?

--- a/helpers/card.js
+++ b/helpers/card.js
@@ -49,7 +49,7 @@ const actionCard = card => formatCard({
 });
 
 const monsterCard = (monster, verbose = true) => formatCard({
-	title: `${monster.icon}  ${monster.name} > ${monster.givenName}`,
+	title: `${monster.icon}  ${monster.name} - ${monster.givenName}`,
 	description: verbose ? upperFirst(monster.individualDescription) : '',
 	stats: monster.stats,
 	rankings: verbose ? monster.rankings : ''

--- a/helpers/card.js
+++ b/helpers/card.js
@@ -29,7 +29,6 @@ ${wrap(rankings, { indent: '| ', width: 40 })}`
 );
 
 const cardRarity = (card) => {
-
 	if (card.probability >= 75) {
 		return '•';
 	} else if (card.probability >= 50) {

--- a/helpers/card.js
+++ b/helpers/card.js
@@ -28,8 +28,23 @@ ${wrap(rankings, { indent: '| ', width: 40 })}`
 `.replace(/^\s*[\r\n]/gm, '')
 );
 
+const cardRarity = (card) => {
+
+	if (card.probability >= 75) {
+		return '•';
+	} else if (card.probability >= 50) {
+		return '○';
+	} else if (card.probability >= 20) {
+		return '◆';
+	} else if (card.probability >= 10) {
+		return '★';
+	}
+
+	return '☆';
+};
+
 const actionCard = card => formatCard({
-	title: `${card.icon}  ${card.cardType}`,
+	title: `${card.icon}  ${card.cardType}  ${cardRarity(card)}`,
 	description: card.description,
 	stats: card.stats
 });

--- a/helpers/card.js
+++ b/helpers/card.js
@@ -28,6 +28,12 @@ ${wrap(rankings, { indent: '| ', width: 40 })}`
 `.replace(/^\s*[\r\n]/gm, '')
 );
 
+const actionCard = card => formatCard({
+	title: `${card.icon}  ${card.cardType}`,
+	description: card.description,
+	stats: card.stats
+});
+
 const monsterCard = (monster, verbose = true) => formatCard({
 	title: `${monster.icon}  ${monster.name} > ${monster.givenName}`,
 	description: verbose ? upperFirst(monster.individualDescription) : '',
@@ -35,4 +41,4 @@ const monsterCard = (monster, verbose = true) => formatCard({
 	rankings: verbose ? monster.rankings : ''
 });
 
-module.exports = { formatCard, monsterCard };
+module.exports = { formatCard, monsterCard, actionCard };

--- a/helpers/choices.js
+++ b/helpers/choices.js
@@ -2,7 +2,9 @@ const { monsterCard } = require('../helpers/card');
 
 const getChoices = array => array.map((choice, index) => `${index}) ${choice}`).join('\n');
 
-const getCardChoices = remainingCards => getChoices(remainingCards.map(card => card.cardType));
+const getCardChoices = remainingCards => getChoices(Object.keys(remainingCards).map(card => `${card} [${remainingCards[card]}]`));
+
+const getFinalCardChoices = deck => getChoices(deck.map(card => card.cardType));
 
 const getMonsterChoices = monsters => getChoices(
 	monsters.map(monster => monsterCard(monster))
@@ -13,6 +15,7 @@ const getCreatureTypeChoices = creatures => getChoices(creatures.map(creature =>
 module.exports = {
 	getChoices,
 	getCardChoices,
+	getFinalCardChoices,
 	getMonsterChoices,
 	getCreatureTypeChoices
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
     "event-emitter-es6": "^1.1.5",
+    "lodash.foreach": "^4.5.0",
     "lodash.reduce": "^4.6.0",
     "lodash.sample": "^4.2.1",
     "lodash.shuffle": "^4.2.0",

--- a/ring/index.js
+++ b/ring/index.js
@@ -3,7 +3,8 @@
 const shuffle = require('lodash.shuffle');
 
 const BaseClass = require('../baseClass');
-const delayTimes = require('../helpers/delay-times.js');
+const delayTimes = require('../helpers/delay-times');
+const { monsterCard } = require('../helpers/card');
 
 const MAX_MONSTERS = 2;
 
@@ -68,6 +69,27 @@ class Ring extends BaseClass {
 	monsterIsInRing (monster) {
 		const contestants = this.contestants;
 		return !!contestants.find(contestant => contestant.monster === monster);
+	}
+
+	look (channel) {
+		const ringContentsDisplay = this.contestants.reduce((ringContents, contestant) => {
+			const contestantDisplay = monsterCard(contestant.character, true);
+			const monsterDisplay = monsterCard(contestant.monster, true);
+			return `${ringContents} ${contestantDisplay} sent the following monster into the ring: ${monsterDisplay}`;
+		}, '');
+
+		if (ringContentsDisplay) {
+			return Promise
+				.resolve()
+				.then(() => channel({
+					announce: ringContentsDisplay
+				}));
+		}
+
+		return Promise.reject(channel({
+			announce: 'The ring is empty',
+			delay: 'short'
+		}));
 	}
 
 	// TO-DO: This should probably be an encounter start / end method we call on the creature


### PR DESCRIPTION
fixes #23 
fixes #22 

Allows player to look at all of their cards, monsters, and monsters in ring.

Displays only a single instance of each card type in the equip menu, with counts of how many of each type the player has in brackets.