### PR TITLE
Add classes for differentiating cards based on monster type

### DIFF
--- a/cards/base.js
+++ b/cards/base.js
@@ -32,6 +32,10 @@ class BaseCard extends BaseClass {
 		return this.constructor.level;
 	}
 
+	get permittedClasses () {
+		return this.constructor.permittedClasses;
+	}
+
 	get probability () {
 		return this.constructor.probability;
 	}

--- a/cards/flee.js
+++ b/cards/flee.js
@@ -58,6 +58,6 @@ FleeCard.cardType = 'Flee';
 FleeCard.probability = 40;
 FleeCard.description = 'There is no shame in living to fight another day.';
 FleeCard.cost = 3;
-FleeCard.level = 1;
+FleeCard.level = 0;
 
 module.exports = FleeCard;

--- a/cards/heal.js
+++ b/cards/heal.js
@@ -55,6 +55,6 @@ HealCard.cardType = 'Heal';
 HealCard.probability = 60;
 HealCard.description = 'A well-timed healing can be the difference between sweet victory and devastating defeat.';
 HealCard.cost = 3;
-HealCard.level = 1;
+HealCard.level = 0;
 
 module.exports = HealCard;

--- a/cards/hit-harder.js
+++ b/cards/hit-harder.js
@@ -6,6 +6,7 @@
 
 const HitCard = require('./hit');
 const { roll, max } = require('../helpers/chance');
+const { BARBARIAN, FIGHTER } = require('../helpers/classes');
 
 class HitHarder extends HitCard {
 	// Set defaults for these values that can be overridden by the options passed in
@@ -63,5 +64,6 @@ HitHarder.probability = 20;
 HitHarder.description = 'You hit just a little bit harder than the average bear... Roll for damage twice, and use the best result.';
 HitHarder.cost = 6;
 HitHarder.level = 2;
+HitHarder.permittedClasses = [BARBARIAN, FIGHTER];
 
 module.exports = HitHarder;

--- a/cards/hit.js
+++ b/cards/hit.js
@@ -129,6 +129,6 @@ HitCard.cardType = 'Hit';
 HitCard.probability = 80;
 HitCard.description = 'A basic attack, the staple of all good monsters.';
 HitCard.cost = 4;
-HitCard.level = 1;
+HitCard.level = 0;
 
 module.exports = HitCard;

--- a/cards/index.js
+++ b/cards/index.js
@@ -26,39 +26,44 @@ const all = [
 	RehitCard
 ];
 
-const draw = ({ level = 1 } = {}) => {
-	const shuffledDeck = shuffle(all);
-	const filteredDeck = shuffledDeck.filter(card => level >= card.level);
+const draw = (options, monster) => {
+	let deck = shuffle(all);
 
-	const Card = filteredDeck.find(isProbable);
+	if (monster) {
+		deck = deck.filter(card => monster.canHoldCard(card));
+	}
 
-	if (!Card) return draw({ level });
+	const Card = deck.find(isProbable);
+
+	if (!Card) return draw(options, monster);
 
 	// In the future we may want to pass some options to the cards,
 	// but we need to make sure that we only pass card-related options.
 	// For example, the level is not meant to passed to the card.
-	return new Card();
+	return new Card(options);
 };
 
 // fills deck up with random cards appropriate for player's level
-const fillDeck = (deck, options) => {
+const fillDeck = (deck, options, monster) => {
 	while (deck.length < DEFAULT_MINIMUM_CARDS) {
-		deck.push(draw(options));
+		deck.push(draw(options, monster));
 	}
 
 	return deck;
 };
 
-const getInitialDeck = (options) => {
+const getInitialDeck = (options, monster) => {
 	// See above re: options
 	const deck = [
+		new HitCard(),
+		new HitCard(),
 		new HitCard(),
 		new HitCard(),
 		new HealCard(),
 		new FleeCard()
 	];
 
-	return fillDeck(deck, options);
+	return fillDeck(deck, options, monster);
 };
 
 const getCardCounts = cards =>
@@ -76,14 +81,19 @@ const getUniqueCards = cards =>
 		, []
 	);
 
-const hydrateCard = (cardObj) => {
+const hydrateCard = (cardObj, monster) => {
 	const Card = all.find(({ name }) => name === cardObj.name);
-	return new Card(cardObj.options);
+
+	if (Card) {
+		return new Card(cardObj.options);
+	}
+
+	return draw({}, monster);
 };
 
-const hydrateDeck = deckJSON => JSON
+const hydrateDeck = (deckJSON, monster) => JSON
 	.parse(deckJSON)
-	.map(hydrateCard);
+	.map(cardObj => hydrateCard(cardObj, monster));
 
 module.exports = {
 	all,

--- a/cards/lucky-strike.js
+++ b/cards/lucky-strike.js
@@ -8,6 +8,7 @@
 
 const HitCard = require('./hit');
 const { roll } = require('../helpers/chance');
+const { CLERIC, FIGHTER } = require('../helpers/classes');
 
 class LuckyStrike extends HitCard {
 	// Set defaults for these values that can be overridden by the options passed in
@@ -65,5 +66,6 @@ LuckyStrike.probability = 20;
 LuckyStrike.description = 'Roll for attack twice, use the best roll to see if you hit.';
 LuckyStrike.cost = 6;
 LuckyStrike.level = 2;
+LuckyStrike.permittedClasses = [CLERIC, FIGHTER];
 
 module.exports = LuckyStrike;

--- a/cards/pound.js
+++ b/cards/pound.js
@@ -1,4 +1,5 @@
 const HitCard = require('./hit');
+const { BARBARIAN } = require('../helpers/classes');
 
 class PoundCard extends HitCard {
 	// Set defaults for these values that can be overridden by the options passed in
@@ -16,5 +17,6 @@ PoundCard.probability = 10;
 PoundCard.description = 'You wield the mighty pound card and can do double the damage.';
 PoundCard.cost = 8;
 PoundCard.level = 3;
+PoundCard.permittedClasses = [BARBARIAN];
 
 module.exports = PoundCard;

--- a/cards/rehit.js
+++ b/cards/rehit.js
@@ -7,6 +7,7 @@
 
 const HitCard = require('./hit');
 const { roll } = require('../helpers/chance');
+const { CLERIC } = require('../helpers/classes');
 
 class Rehit extends HitCard {
 	// Set defaults for these values that can be overridden by the options passed in
@@ -67,5 +68,6 @@ Rehit.probability = 20;
 Rehit.description = 'Roll for attack, if you roll less than 10, roll again and use the second roll no matter what.';
 Rehit.cost = 5;
 Rehit.level = 2;
+Rehit.permittedClasses = [CLERIC];
 
 module.exports = Rehit;

--- a/cards/revive.js
+++ b/cards/revive.js
@@ -1,4 +1,5 @@
 const HealCard = require('./heal');
+const { CLERIC, WIZARD } = require('../helpers/classes');
 
 class ReviveCard extends HealCard {
 	// Set defaults for these values that can be overridden by the options passed in
@@ -22,5 +23,6 @@ ReviveCard.probability = 10;
 ReviveCard.description = 'Luckily, you happened to have a fairy in your pocket.';
 ReviveCard.cost = 5;
 ReviveCard.level = 3;
+ReviveCard.permittedClasses = [CLERIC, WIZARD];
 
 module.exports = ReviveCard;

--- a/characters/base.js
+++ b/characters/base.js
@@ -18,7 +18,7 @@ class BaseCharacter extends BaseCreature {
 
 	get deck () {
 		if (this.options.deck === undefined || this.options.deck.length <= 0) {
-			this.deck = getInitialDeck({ level: this.options.level });
+			this.deck = getInitialDeck();
 		}
 
 		return this.options.deck || [];

--- a/characters/index.js
+++ b/characters/index.js
@@ -100,7 +100,7 @@ const hydrateCharacter = (characterObj) => {
 	const character = new Character(options);
 
 	// if deck minimum changes, and player now has fewer than minimum cards in already initialized deck, fill them up! (yes, this has happened)
-	character.deck = fillDeck(options.deck, { level: character.level });
+	character.deck = fillDeck(options.deck, options);
 
 	return character;
 };

--- a/creatures/base.js
+++ b/creatures/base.js
@@ -37,6 +37,10 @@ class BaseCreature extends BaseClass {
 		}, TIME_TO_HEAL);
 	}
 
+	get class () {
+		return this.constructor.class;
+	}
+
 	get icon () {
 		return this.options.icon;
 	}
@@ -72,7 +76,7 @@ Battles won: ${this.battles.wins}`;
 	}
 
 	get individualDescription () {
-		return this.options.description;
+		return this.options.description || this.description;
 	}
 
 	get gender () {

--- a/game.js
+++ b/game.js
@@ -359,7 +359,7 @@ ${monsterCard(monster)}`
 		contestant.character.xp += XP_PER_VICTORY;
 
 		// Also draw a new card for the player
-		const card = this.drawCard({ level: contestant.character.level });
+		const card = this.drawCard({}, contestant.monster);
 		contestant.character.addCard(card);
 
 		this.emit('cardDrop', {
@@ -617,8 +617,8 @@ ${monsterCard(monster)}`
 		}));
 	}
 
-	drawCard (options) {
-		const card = draw(options);
+	drawCard (options, monster) {
+		const card = draw(options, monster);
 
 		this.emit('cardDrawn', { card });
 

--- a/game.mocha.node.js
+++ b/game.mocha.node.js
@@ -75,4 +75,14 @@ describe('./game.js', () => {
 		expect(card.name).to.not.equal(BaseCard.name);
 		expect(card.options.useless).to.be.undefined;
 	});
+
+	it('can draw a card for a specific monster', () => {
+		const game = new Game(publicChannelStub);
+		const canHoldCard = sinon.stub().returns(true);
+		const monster = { canHoldCard };
+		const card = game.drawCard({ useless: 'option' }, monster);
+
+		expect(card).to.be.an.instanceof(BaseCard);
+		expect(canHoldCard).to.have.been.called;
+	});
 });

--- a/helpers/classes.js
+++ b/helpers/classes.js
@@ -1,0 +1,6 @@
+module.exports = {
+	BARBARIAN: 'BARBARIAN',
+	CLERIC: 'CLERIC',
+	FIGHTER: 'FIGHTER',
+	WIZARD: 'WIZARD'
+};

--- a/monsters/base.js
+++ b/monsters/base.js
@@ -39,6 +39,13 @@ class BaseMonster extends BaseCreature {
 		});
 	}
 
+	canHoldCard (card) {
+		const appropriateLevel = (!card.level || card.level <= this.level);
+		const appropriateClass = (!card.permittedClasses || card.permittedClasses.includes[this.class]);
+
+		return appropriateLevel && appropriateClass;
+	}
+
 	edit (channel) {
 		return Promise
 			.resolve()

--- a/monsters/basilisk.js
+++ b/monsters/basilisk.js
@@ -3,6 +3,7 @@
 const random = require('lodash.sample');
 
 const BaseMonster = require('./base');
+const { BARBARIAN } = require('../helpers/classes');
 
 const DEFAULT_COLOR = 'tan';
 const DEFAULT_NAME = 'Cyris';
@@ -33,10 +34,6 @@ class Basilisk extends BaseMonster {
 		};
 
 		super(Object.assign(defaultOptions, options));
-
-		this.setOptions({
-			description: `a ${this.size.adjective}, ${this.color}, ${this.location}-dwelling basilisk with a nasty disposition and the ability to turn creatures to stone with ${this.pronouns[2]} gaze. In the forest ${this.pronouns[0]} is king and (weighing ${this.size.weight}) in the ring ${this.pronouns[0]} is much to be feared. See how ${this.pronouns[0]} rears ${this.pronouns[2]} head, and rolls about ${this.pronouns[2]} dreadful eyes, to drive all virtue out, or look it dead!`
-		});
 	}
 
 	get size () {
@@ -50,9 +47,14 @@ class Basilisk extends BaseMonster {
 	get location () {
 		return this.options.location;
 	}
+
+	get description () {
+		return `a ${this.size.adjective}, ${this.color}, ${this.location}-dwelling basilisk with a nasty disposition and the ability to turn creatures to stone with ${this.pronouns[2]} gaze. In the forest ${this.pronouns[0]} is king and (weighing ${this.size.weight}) in the ring ${this.pronouns[0]} is much to be feared. See how ${this.pronouns[0]} rears ${this.pronouns[2]} head, and rolls about ${this.pronouns[2]} dreadful eyes, to drive all virtue out, or look it dead!`;
+	}
 }
 
 Basilisk.creatureType = 'Basilisk';
+Basilisk.class = BARBARIAN;
 Basilisk.description =
 `
 The basilisk, often called the “King of Serpents,” is in fact not a serpent at all, but rather an eight-legged reptile with a nasty disposition and the ability to turn creatures to stone with its gaze. Folklore holds that, much like the cockatrice, the first basilisks hatched from eggs laid by snakes and incubated by roosters, but little in the basilisk’s physiology lends any credence to this claim.

--- a/monsters/index.js
+++ b/monsters/index.js
@@ -199,17 +199,19 @@ ${getFinalCardChoices(cards)}`
 				}));
 			}
 
-			const nowRemainingCards = [...deck].sort((a, b) => {
-				if (a.cardType > b.cardType) {
-					return 1;
-				}
+			const nowRemainingCards = [...deck]
+				.filter(card => monster.canHoldCard(card))
+				.sort((a, b) => {
+					if (a.cardType > b.cardType) {
+						return 1;
+					}
 
-				if (a.cardType < b.cardType) {
-					return -1;
-				}
-				
-				return 0;
-			});
+					if (a.cardType < b.cardType) {
+						return -1;
+					}
+
+					return 0;
+				});
 
 			if (cardSelection) {
 				cardSelection.forEach((card) => {
@@ -240,11 +242,16 @@ ${getFinalCardChoices(cards)}`
 
 const hydrateMonster = (monsterObj) => {
 	const Monster = all.find(({ name }) => name === monsterObj.name);
-	const options = Object.assign({ cards: [] }, monsterObj.options);
+	const options = {
+		...monsterObj.options,
+		cards: []
+	};
 
-	options.cards = options.cards.map(hydrateCard);
+	const monster = new Monster(options);
 
-	return new Monster(options);
+	monster.cards = monsterObj.options.cards.map(cardObj => hydrateCard(cardObj, monster));
+
+	return monster;
 };
 
 const hydrateMonsters = monstersJSON => JSON

--- a/monsters/minotaur.js
+++ b/monsters/minotaur.js
@@ -3,6 +3,7 @@
 const random = require('lodash.sample');
 
 const BaseMonster = require('./base');
+const { BARBARIAN } = require('../helpers/classes');
 
 const DEFAULT_COLOR = 'angry red';
 const DEFAULT_NAME = 'Taurus';
@@ -30,10 +31,6 @@ class Minotaur extends BaseMonster {
 		};
 
 		super(Object.assign(defaultOptions, options));
-
-		this.setOptions({
-			description: `a battle-hardened, ${this.color} minotaur with a ${this.pattern} pattern shaved into ${this.pronouns[2]} thick fur. Make no mistake, despite ${this.pronouns[2]} ${this.descriptor} bulk ${this.pronouns[0]} is a first-class host who has never been put to shame at a dinner party.`
-		});
 	}
 
 	get color () {
@@ -47,9 +44,14 @@ class Minotaur extends BaseMonster {
 	get descriptor () {
 		return this.options.descriptor;
 	}
+
+	get description () {
+		return `a battle-hardened, ${this.color} minotaur with a ${this.pattern} pattern shaved into ${this.pronouns[2]} thick fur. Make no mistake, despite ${this.pronouns[2]} ${this.descriptor} bulk ${this.pronouns[0]} is a first-class host who has never been put to shame at a dinner party.`;
+	}
 }
 
 Minotaur.creatureType = 'Minotaur';
+Minotaur.class = BARBARIAN;
 Minotaur.description =
 `
 The bull-folk have many of the same characteristics as the bulls they resemble. Both genders have horned heads covered with shaggy hair. Warriors braid their hair with teeth or other tokens of fallen enemies. The thick hair covering their large bodies varies widely in color, from bright white to medium red-browns to dark brown and black. Many minotaurs shave or dye their fur in patterns signifying their allegiances and beliefs. Other methods of decoration include brands, ritual scars, and gilding or carving their horns.

--- a/monsters/weeping-angel.js
+++ b/monsters/weeping-angel.js
@@ -3,6 +3,7 @@
 const random = require('lodash.sample');
 
 const BaseMonster = require('./base');
+const { CLERIC } = require('../helpers/classes');
 
 const DEFAULT_COLOR = 'stone gray';
 const DEFAULT_NAME = 'Aziraphale';
@@ -31,10 +32,6 @@ class WeepingAngel extends BaseMonster {
 		};
 
 		super(Object.assign(defaultOptions, options));
-
-		this.setOptions({
-			description: `a ${this.color} weeping angel. On meeting ${this.pronouns[1]} one might form the following three impressions: that ${this.pronouns[0]} was ${this.nationality}, that ${this.pronouns[0]} was intelligent, and that ${this.pronouns[0]} was ${this.descriptor} than a treeful of monkeys on nitrous oxide.`
-		});
 	}
 
 	get color () {
@@ -48,9 +45,14 @@ class WeepingAngel extends BaseMonster {
 	get descriptor () {
 		return this.options.descriptor;
 	}
+
+	get description () {
+		return `a ${this.color} weeping angel. On meeting ${this.pronouns[1]} one might form the following three impressions: that ${this.pronouns[0]} was ${this.nationality}, that ${this.pronouns[0]} was intelligent, and that ${this.pronouns[0]} was ${this.descriptor} than a treeful of monkeys on nitrous oxide.`;
+	}
 }
 
 WeepingAngel.creatureType = 'Weeping Angel';
+WeepingAngel.class = CLERIC;
 WeepingAngel.description =
 `
 The Weeping Angels are an extremely powerful species of quantum-locked humanoids (sufficient observation changes the thing being observed), so called because their unique nature necessitates that they often cover their faces with their hands to prevent trapping each other in petrified form for eternity by looking at one another. This gives the Weeping Angels their distinct "weeping" appearance. They are known for being "kind" murderous psychopaths, eradicating their victims "mercifully" by dropping them into the past and letting them live out their full lives, just in a different time period. This, in turn, allows them to live off the remaining time energy of the victim's life. However, when this potential energy pales in comparison to an alternative power source to feed on, the Angels are sometimes known to kill by other means, such as snapping their victims' necks.


### PR DESCRIPTION
Allows for the creation of special cards for each class of monster. Some monsters might be able to do heavier melee damage while others might have magical abilities that offset weaker frames.