### PR TITLE
Look at monsters in detail command

### DIFF
--- a/characters/base.js
+++ b/characters/base.js
@@ -47,8 +47,8 @@ class BaseCharacter extends BaseCreature {
 		this.emit('cardAdded', { card });
 	}
 
-	lookAtMonsters (channel) {
-		const monstersDisplay = this.monsters.reduce((monsters, monster) => monsters + monsterCard(monster, true), '');
+	lookAtMonsters (channel, description) {
+		const monstersDisplay = this.monsters.reduce((monsters, monster) => monsters + monsterCard(monster, description), '');
 
 		if (monstersDisplay) {
 			return Promise

--- a/game.js
+++ b/game.js
@@ -571,7 +571,11 @@ ${monsterCard(monster)}`
 						.catch(err => log(err));
 				},
 				lookAtMonsters () {
-					return character.lookAtMonsters(channel)
+					return character.lookAtMonsters(channel, false)
+						.catch(err => log(err));
+				},
+				lookAtMonstersInDetail () {
+					return character.lookAtMonsters(channel, true)
 						.catch(err => log(err));
 				},
 				lookAtRing ({ ringName } = {}) {

--- a/helpers/choices.js
+++ b/helpers/choices.js
@@ -6,7 +6,7 @@ const getCardChoices = remainingCards => getChoices(Object.keys(remainingCards).
 
 const getFinalCardChoices = deck => getChoices(deck.map(card => card.cardType));
 
-const getMonsterChoices = monsters => getChoices(monsters.map(monster => monsterCard(monster)));
+const getMonsterChoices = monsters => getChoices(monsters.map(monster => monsterCard(monster, false)));
 
 const getCreatureTypeChoices = creatures => getChoices(creatures.map(creature => creature.creatureType));
 

--- a/player-handbook.js
+++ b/player-handbook.js
@@ -50,6 +50,8 @@ class PlayerHandbook extends BaseClass {
 
     \`look at monsters\` - Looks at monsters
 
+	\`look at monsters in detail\` - Looks at monsters with their description
+
     \`look at [monster name]\` - Look at specified monster
 
     \`look at cards\` - Look at your cards


### PR DESCRIPTION
I use `look at monsters` to see if my monsters have enough health to go back into the ring. With the monster descriptions I have to scroll up to look at all my monsters (especially when I'm on my phone). 

This changes `look at monsters` to hide the description, and adds the command `look at monsters in detail` to see the description.