### PR TITLE
Update hp calculations to increase overall hp

### DIFF
--- a/characters/index.js
+++ b/characters/index.js
@@ -1,5 +1,6 @@
 const { randomColor } = require('grab-color-names');
 const emoji = require('node-emoji');
+const sample = require('lodash.sample');
 const shuffle = require('lodash.shuffle');
 
 const { getChoices, getCreatureTypeChoices } = require('../helpers/choices');
@@ -110,7 +111,7 @@ const randomCharacter = ({
 
 	const xp = XP_PER_VICTORY * battles.wins;
 
-	const monsters = (Monsters || [shuffle(allMonsters)[0]]).map((Monster) => {
+	const monsters = (Monsters || [sample(allMonsters)]).map((Monster) => {
 		const monster = new Monster({
 			battles,
 			color: randomColor()[1].toLowerCase(),

--- a/monsters/basilisk.js
+++ b/monsters/basilisk.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-const random = require('lodash.sample');
+const sample = require('lodash.sample');
 
 const BaseMonster = require('./base');
 
@@ -28,8 +28,8 @@ class Basilisk extends BaseMonster {
 			attackModifier: -1,
 			damageModifier: 3,
 			color: DEFAULT_COLOR,
-			location: random(LOCATIONS),
-			size: random(SIZES),
+			location: sample(LOCATIONS),
+			size: sample(SIZES),
 			icon: '🐍'
 		};
 
@@ -55,6 +55,7 @@ class Basilisk extends BaseMonster {
 
 Basilisk.creatureType = BASILISK;
 Basilisk.class = BARBARIAN;
+Basilisk.acVariance = 2;
 Basilisk.description =
 `
 The basilisk, often called the “King of Serpents,” is in fact not a serpent at all, but rather an eight-legged reptile with a nasty disposition and the ability to turn creatures to stone with its gaze. Folklore holds that, much like the cockatrice, the first basilisks hatched from eggs laid by snakes and incubated by roosters, but little in the basilisk’s physiology lends any credence to this claim.

--- a/monsters/gladiator.js
+++ b/monsters/gladiator.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-const random = require('lodash.sample');
+const sample = require('lodash.sample');
 
 const BaseMonster = require('./base');
 
@@ -28,8 +28,8 @@ class Gladiator extends BaseMonster {
 			attackModifier: 1,
 			damageModifier: 1,
 			color: DEFAULT_COLOR,
-			location: random(LOCATIONS),
-			size: random(SIZES),
+			location: sample(LOCATIONS),
+			size: sample(SIZES),
 			icon: '💪'
 		};
 
@@ -55,6 +55,7 @@ class Gladiator extends BaseMonster {
 
 Gladiator.creatureType = GLADIATOR;
 Gladiator.class = FIGHTER;
+Gladiator.hpVariance = 2;
 Gladiator.description =
 `
 The gladiator is a professional duelist. Many are born slaves and reared in gladiatorial schools, until such time as they earn their freedom in battle, escape, or rebel. Some join dueling academies voluntarily, seeking fame or fortune in prize fights and honor matches. Some gladiators began as warriors from faroff lands, captured in battle and forced to fight to the death, while others are condemned criminals, paying their debt to society by participating in ritual combat for the public. Whatever their station or background, the gladiator has been hardened by combat and has learned to anticipate a wily foe. While gladiatorial matches often follow a prescribed, even ritual format, the gladiator must always be ready for the possibility that they will be thrown into a situation with unusual weapons, conditions, or opponents. Some arena fighters specialize in fighting exotic animals and monsters.

--- a/monsters/minotaur.js
+++ b/monsters/minotaur.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-const random = require('lodash.sample');
+const sample = require('lodash.sample');
 
 const BaseMonster = require('./base');
 
@@ -26,8 +26,8 @@ class Minotaur extends BaseMonster {
 		const defaultOptions = {
 			damageModifier: 2,
 			color: DEFAULT_COLOR,
-			pattern: random(PATTERNS),
-			descriptor: random(DESCRIPTORS),
+			pattern: sample(PATTERNS),
+			descriptor: sample(DESCRIPTORS),
 			icon: '🐗'
 		};
 
@@ -53,6 +53,8 @@ class Minotaur extends BaseMonster {
 
 Minotaur.creatureType = MINOTAUR;
 Minotaur.class = BARBARIAN;
+Minotaur.acVariance = -1;
+Minotaur.hpVariance = 3;
 Minotaur.description =
 `
 The bull-folk have many of the same characteristics as the bulls they resemble. Both genders have horned heads covered with shaggy hair. Warriors braid their hair with teeth or other tokens of fallen enemies. The thick hair covering their large bodies varies widely in color, from bright white to medium red-browns to dark brown and black. Many minotaurs shave or dye their fur in patterns signifying their allegiances and beliefs. Other methods of decoration include brands, ritual scars, and gilding or carving their horns.

--- a/monsters/weeping-angel.js
+++ b/monsters/weeping-angel.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-const random = require('lodash.sample');
+const sample = require('lodash.sample');
 
 const BaseMonster = require('./base');
 
@@ -26,8 +26,8 @@ class WeepingAngel extends BaseMonster {
 			attackModifier: 3,
 			damageModifier: -1,
 			color: DEFAULT_COLOR,
-			nationality: random(NATIONALITIES),
-			descriptor: random(DESCRIPTORS),
+			nationality: sample(NATIONALITIES),
+			descriptor: sample(DESCRIPTORS),
 			icon: '🌟'
 		};
 
@@ -53,6 +53,8 @@ class WeepingAngel extends BaseMonster {
 
 WeepingAngel.creatureType = WEEPING_ANGEL;
 WeepingAngel.class = CLERIC;
+WeepingAngel.acVariance = 1;
+WeepingAngel.hpVariance = 1;
 WeepingAngel.description =
 `
 The Weeping Angels are an extremely powerful species of quantum-locked humanoids (sufficient observation changes the thing being observed), so called because their unique nature necessitates that they often cover their faces with their hands to prevent trapping each other in petrified form for eternity by looking at one another. This gives the Weeping Angels their distinct "weeping" appearance. They are known for being "kind" murderous psychopaths, eradicating their victims "mercifully" by dropping them into the past and letting them live out their full lives, just in a different time period. This, in turn, allows them to live off the remaining time energy of the victim's life. However, when this potential energy pales in comparison to an alternative power source to feed on, the Angels are sometimes known to kill by other means, such as snapping their victims' necks.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@salesforce-mc/devscripts": "^3.2.0",
     "@salesforce-mc/devtest": "^4.1.0",
-    "@salesforce-mc/eslint-config-sfmc": "^3.0.1",
+    "@salesforce-mc/eslint-config-sfmc": "^3.0.2",
     "prompt": "^1.0.0"
   }
 }


### PR DESCRIPTION
Increases the base hp/ac slightly, increases the hp/ac per level slightly, adds some modifiers to hp/ac based on class, and changes how ac/hp are stored. None of this is too ground-breaking right now but it lays the foundation for more advanced modifications to these values.