### PR TITLE
Limit the supply of cards at the store somewhat

### DIFF
--- a/cards/base.js
+++ b/cards/base.js
@@ -2,8 +2,6 @@ const Promise = require('bluebird');
 
 const BaseItem = require('../items/base');
 
-const { max } = require('../helpers/chance');
-
 class BaseCard extends BaseItem {
 	constructor (options) {
 		super(options);

--- a/cards/blast-2.js
+++ b/cards/blast-2.js
@@ -26,6 +26,7 @@ Blast2Card.cardType = 'Blast II';
 Blast2Card.probability = 50;
 Blast2Card.level = 1;
 Blast2Card.cost = 50;
+Blast2Card.notForSale = true;
 
 Blast2Card.defaults = {
 	damage: 3

--- a/cards/survival-knife.js
+++ b/cards/survival-knife.js
@@ -35,6 +35,7 @@ SurvivalKnifeCard.description = 'If times get too rough, stab yourself in the th
 SurvivalKnifeCard.permittedClassesAndTypes = [FIGHTER];
 SurvivalKnifeCard.level = 1;
 SurvivalKnifeCard.cost = 15;
+SurvivalKnifeCard.notForSale = true;
 
 SurvivalKnifeCard.defaults = {
 	...HitCard.defaults,

--- a/items/store/shop.js
+++ b/items/store/shop.js
@@ -30,6 +30,6 @@ const getShop = throttle(() => {
 	};
 
 	return currentShop;
-}, 7200000);
+}, 28800000); // Eight hours
 
 module.exports = getShop;

--- a/items/store/shop.mocha.node.js
+++ b/items/store/shop.mocha.node.js
@@ -21,7 +21,8 @@ describe('./items/store/shop.js', () => {
 		expect(shop.priceOffset).to.be.below(1);
 		expect(shop.backRoomOffset).to.be.below(10);
 		expect(shop.items).to.be.an.instanceof(Array);
-		expect(shop.cards.length).to.equal(20);
+		expect(shop.cards.length).to.be.above(4);
+		expect(shop.cards.length).to.be.below(21);
 		expect(shop.backRoom.length).to.equal(1);
 	});
 
@@ -32,10 +33,10 @@ describe('./items/store/shop.js', () => {
 		expect(shop).to.equal(shop2);
 	});
 
-	it('gets a different shop after 2 hours', () => {
+	it('gets a different shop after 8 hours', () => {
 		const shop = getShop();
 
-		clock.tick(7200001);
+		clock.tick(28800001);
 
 		const shop2 = getShop();
 

--- a/items/store/stock.js
+++ b/items/store/stock.js
@@ -1,6 +1,9 @@
+const random = require('lodash.random');
+
 const drawCard = require('../../cards/helpers/draw');
 
-const DEFAULT_CARD_INVENTORY_SIZE = 20;
+const DEFAULT_MIN_CARD_INVENTORY_SIZE = 5;
+const DEFAULT_MAX_CARD_INVENTORY_SIZE = 20;
 
 const canHoldBackRoom = {
 	canHoldCard: card => card.notForSale && !card.neverForSale
@@ -24,8 +27,9 @@ const canHoldStandard = {
 
 const getCards = () => {
 	const cards = [];
+	const cardInventorySize = random(DEFAULT_MIN_CARD_INVENTORY_SIZE, DEFAULT_MAX_CARD_INVENTORY_SIZE);
 
-	while (cards.length < DEFAULT_CARD_INVENTORY_SIZE) {
+	while (cards.length < cardInventorySize) {
 		cards.push(drawCard({}, canHoldStandard));
 	}
 

--- a/items/store/stock.mocha.node.js
+++ b/items/store/stock.mocha.node.js
@@ -20,7 +20,8 @@ describe('./items/store/stock.js', () => {
 		it('can get a set of cards', () => {
 			const cards = getCards();
 
-			expect(cards.length).to.equal(20);
+			expect(cards.length).to.be.above(4);
+			expect(cards.length).to.be.below(21);
 
 			cards.forEach((item) => {
 				expect(item.constructor.notForSale).to.not.equal(true);


### PR DESCRIPTION
Store now refreshes every 8 hours instead of every two and starts with anywhere from 5 to 20 items instead of an automatic 20. Also makes some newer cards Not For Sale for now, we'll turn them back on in a week or so.