### PR TITLE
Spawn gives a bit more guidance when spawning monsters

### DIFF
--- a/battlefield.js
+++ b/battlefield.js
@@ -52,10 +52,10 @@ const charAnnouncer = what => announcer('charlemagne', what);
 let char;
 let charCards;
 
-const BOSS_ID = 666;
-const bossAnnouncer = what => announcer('boss', what);
-let boss;
-let bossCards;
+// const BOSS_ID = 666;
+// const bossAnnouncer = what => announcer('boss', what);
+// let boss;
+// let bossCards;
 
 return Promise
 	.resolve()
@@ -75,13 +75,7 @@ return Promise
 		// const destroy = new DestroyCard();
 		// charCards = [destroy, destroy, destroy, destroy];
 	})
-	.then(() => slackdem.getCharacter(bossAnnouncer, BOSS_ID, {
-		id: BOSS_ID, name: 'boss', type: 0, gender: 0, icon: 0, xp: 500
-	}))
-	.then((character) => {
-		boss = character;
-		bossCards = [...shuffle(boss.character.deck).slice(0, 9)];
-	})
+	// .then(() => vlad.spawnMonster())
 	.then(() => vlad.spawnMonster({
 		type: 0, name: 'jerry', color: 'gray', gender: 1, cards: vladCards, xp: 100
 	}))
@@ -95,9 +89,6 @@ return Promise
 	.then(() => char.spawnMonster({
 		type: 3, name: 'dbb', color: 'brown', gender: 0, cards: charCards, xp: 200
 	}))
-	.then(() => boss.spawnMonster({
-		type: 0, name: 'king', color: 'brown', gender: 1, cards: bossCards, xp: 500
-	}))
 	.then(() => vlad.lookAtCard({ cardName: 'brain drain' }))
 	.then(() => vlad.lookAtCard({ cardName: 'pick pocket' }))
 	.then(() => vlad.lookAtCards())
@@ -105,4 +96,4 @@ return Promise
 	.then(() => vlad.lookAtMonster({ monsterName: 'jerry' }))
 	.then(() => vlad.sendMonsterToTheRing())
 	.then(() => char.sendMonsterToTheRing())
-	.then(() => boss.sendMonsterToTheRing());
+	.then(() => slackdem.getRing().spawnBoss())

--- a/helpers/names.js
+++ b/helpers/names.js
@@ -3,7 +3,7 @@ const fantasyNames = require('fantasy-names');
 const GENDERS = Object.keys(require('./pronouns'));
 const TYPES = require('./creature-types');
 
-module.exports = (type, gender) => {
+const chooseName = (type, gender, alreadyTaken = []) => {
 	let args;
 
 	switch (type) {
@@ -43,5 +43,13 @@ module.exports = (type, gender) => {
 		args.push(numericGender);
 	}
 
-	return fantasyNames(...args);
-};
+	const name = fantasyNames(...args);
+
+	if (alreadyTaken.includes(name)) {
+		return chooseName(type, gender, alreadyTaken);
+	}
+
+	return name;
+}
+
+module.exports = chooseName;

--- a/monsters/helpers/spawn.js
+++ b/monsters/helpers/spawn.js
@@ -59,8 +59,8 @@ ${getCreatureTypeChoices(allMonsters)}`,
 			let question = '';
 			if (alreadyTaken) question += 'That name is already taken, please choose a different name. ';
 
-			const name1 = names(Monster.creatureType.toLowerCase(), options.gender, monsterNames);
-			const name2 = names(Monster.creatureType.toLowerCase(), options.gender, [ name1, ...monsterNames ]);
+			const name1 = names(Monster.creatureType, options.gender, monsterNames);
+			const name2 = names(Monster.creatureType, options.gender, [ name1, ...monsterNames ]);
 
 			question += `What would you like to name ${PRONOUNS[options.gender].him}? ${name1}? ${name2}? Something else?`;
 
@@ -86,20 +86,20 @@ ${getCreatureTypeChoices(allMonsters)}`,
 
 			let example;
 			let descriptor;
-			switch (Monster.creatureType.toLowerCase()) {
-				case CREATURE_TYPES.BASILISK.toLowerCase():
+			switch (Monster.creatureType) {
+				case CREATURE_TYPES.BASILISK:
 					example = 'gold and black diamond patterned';
 					descriptor = 'skin look like';
 					break;
-				case CREATURE_TYPES.MINOTAUR.toLowerCase():
+				case CREATURE_TYPES.MINOTAUR:
 					example = 'scarred, wrinkled, and beautifully auburn';
 					descriptor = 'skin and hair look like';
 					break;
-				case CREATURE_TYPES.GLADIATOR.toLowerCase():
+				case CREATURE_TYPES.GLADIATOR:
 					example = 'tattered rags';
 					descriptor = 'garments look like';
 					break;
-				case CREATURE_TYPES.WEEPING_ANGEL.toLowerCase():
+				case CREATURE_TYPES.WEEPING_ANGEL:
 					example = 'deceptively glorious';
 					descriptor = 'raiment be';
 					break;

--- a/monsters/helpers/spawn.js
+++ b/monsters/helpers/spawn.js
@@ -1,6 +1,10 @@
 const { getChoices, getCreatureTypeChoices } = require('../../helpers/choices');
 const PRONOUNS = require('../../helpers/pronouns');
 
+const CREATURE_TYPES = require('../../helpers/creature-types');
+
+const names = require('../../helpers/names');
+
 const allMonsters = require('./all');
 
 const genders = Object.keys(PRONOUNS);
@@ -55,7 +59,10 @@ ${getCreatureTypeChoices(allMonsters)}`,
 			let question = '';
 			if (alreadyTaken) question += 'That name is already taken, please choose a different name. ';
 
-			question += `What would you like to name your new ${Monster.creatureType.toLowerCase()}?`;
+			const name1 = names(Monster.creatureType.toLowerCase(), options.gender, monsterNames);
+			const name2 = names(Monster.creatureType.toLowerCase(), options.gender, [ name1, ...monsterNames ]);
+
+			question += `What would you like to name ${PRONOUNS[options.gender].him}? ${name1}? ${name2}? Something else?`;
 
 			return channel({
 				question
@@ -77,8 +84,32 @@ ${getCreatureTypeChoices(allMonsters)}`,
 				return color;
 			}
 
+			let example;
+			let descriptor;
+			switch (Monster.creatureType.toLowerCase()) {
+				case CREATURE_TYPES.BASILISK.toLowerCase():
+					example = 'gold and black diamond patterned';
+					descriptor = 'skin look like';
+					break;
+				case CREATURE_TYPES.MINOTAUR.toLowerCase():
+					example = 'scarred, wrinkled, and beautifully auburn';
+					descriptor = 'skin and hair look like';
+					break;
+				case CREATURE_TYPES.GLADIATOR.toLowerCase():
+					example = 'tattered rags';
+					descriptor = 'garments look like';
+					break;
+				case CREATURE_TYPES.WEEPING_ANGEL.toLowerCase():
+					example = 'deceptively glorious';
+					descriptor = 'raiment be';
+					break;
+				default:
+					example = 'blue';
+					descriptor = 'clothing look like'
+			}
+
 			return channel({
-				question: `What color should ${options.name} be?`
+				question: `What should ${PRONOUNS[options.gender].his} ${descriptor}? (eg: ${example})`
 			});
 		})
 		.then((answer) => {
@@ -95,7 +126,7 @@ ${getCreatureTypeChoices(allMonsters)}`,
 
 			return channel({
 				question:
-`What gender is ${options.name} the ${options.color} ${Monster.creatureType.toLowerCase()}?
+`What gender should your ${Monster.creatureType.toLowerCase()} be?
 
 ${getChoices(genders)}`,
 				choices: Object.keys(genders)
@@ -115,8 +146,8 @@ ${getChoices(genders)}`,
 
 			return Monster;
 		})
+		.then(() => askForGender(Monster))
 		.then(() => askForName(Monster))
 		.then(askForColor)
-		.then(() => askForGender(Monster))
 		.then(() => new Monster(options));
 };

--- a/monsters/weeping-angel.js
+++ b/monsters/weeping-angel.js
@@ -20,21 +20,12 @@ const DESCRIPTORS = [
 	'nuttier'
 ];
 
-const COLOR_FLAVOR = [
-	'deceptively',
-	'sneakily',
-	'frighteningly',
-	'gloriously',
-	'horrifyingly'
-]
-
 class WeepingAngel extends BaseMonster {
 	constructor (options) {
 		const defaultOptions = {
 			dexModifier: 1,
 			strModifier: -1,
 			intModifier: 2,
-			colorFlavor: sample(COLOR_FLAVOR),
 			color: DEFAULT_COLOR,
 			nationality: sample(NATIONALITIES),
 			descriptor: sample(DESCRIPTORS),
@@ -42,10 +33,6 @@ class WeepingAngel extends BaseMonster {
 		};
 
 		super(Object.assign(defaultOptions, options));
-	}
-
-	get colorFlavor () {
-		return this.options.colorFlavor;
 	}
 
 	get color () {
@@ -61,7 +48,7 @@ class WeepingAngel extends BaseMonster {
 	}
 
 	get description () {
-		return `a ${this.colorFlavor} ${this.color} weeping angel. On meeting ${this.pronouns.him} one might form the following three impressions: that ${this.pronouns.he} was ${this.nationality}, that ${this.pronouns.he} was intelligent, and that ${this.pronouns.he} was ${this.descriptor} than a treeful of monkeys on nitrous oxide.`;
+		return `A${this.color[0].match(/[aeiou]/i) ? 'n' : ''} ${this.color} weeping angel. On meeting ${this.pronouns.him} one might form the following three impressions: that ${this.pronouns.he} was ${this.nationality}, that ${this.pronouns.he} was intelligent, and that ${this.pronouns.he} was ${this.descriptor} than a treeful of monkeys on nitrous oxide.`;
 	}
 }
 

--- a/monsters/weeping-angel.js
+++ b/monsters/weeping-angel.js
@@ -20,12 +20,21 @@ const DESCRIPTORS = [
 	'nuttier'
 ];
 
+const COLOR_FLAVOR = [
+	'deceptively',
+	'sneakily',
+	'frighteningly',
+	'gloriously',
+	'horrifyingly'
+]
+
 class WeepingAngel extends BaseMonster {
 	constructor (options) {
 		const defaultOptions = {
 			dexModifier: 1,
 			strModifier: -1,
 			intModifier: 2,
+			colorFlavor: sample(COLOR_FLAVOR),
 			color: DEFAULT_COLOR,
 			nationality: sample(NATIONALITIES),
 			descriptor: sample(DESCRIPTORS),
@@ -33,6 +42,10 @@ class WeepingAngel extends BaseMonster {
 		};
 
 		super(Object.assign(defaultOptions, options));
+	}
+
+	get colorFlavor () {
+		return this.options.colorFlavor;
 	}
 
 	get color () {
@@ -48,7 +61,7 @@ class WeepingAngel extends BaseMonster {
 	}
 
 	get description () {
-		return `a ${this.color} weeping angel. On meeting ${this.pronouns.him} one might form the following three impressions: that ${this.pronouns.he} was ${this.nationality}, that ${this.pronouns.he} was intelligent, and that ${this.pronouns.he} was ${this.descriptor} than a treeful of monkeys on nitrous oxide.`;
+		return `a ${this.colorFlavor} ${this.color} weeping angel. On meeting ${this.pronouns.him} one might form the following three impressions: that ${this.pronouns.he} was ${this.nationality}, that ${this.pronouns.he} was intelligent, and that ${this.pronouns.he} was ${this.descriptor} than a treeful of monkeys on nitrous oxide.`;
 	}
 }
 


### PR DESCRIPTION
Gives more specific signals around character spawning, including suggesting names and "colors", to help avoid the confusion that currently happens when someone is being asked the spawn questions.

Makes gender the second question you are asked since you are asked to make historically gender-based decisions (name, color) _before_ being asked gender currently.

The changes in weeping angel protect against "a" being followed by a word that begins with a vowel, eg: "a auburn".

The changes in battlefield cause an actual boss to be spawned instead of the left-over pre-boss "boss" we used to spawn.