### PR TITLE
Revert "Add the sandstorm card to all players"

### DIFF
--- a/cards/helpers/hydrate.js
+++ b/cards/helpers/hydrate.js
@@ -1,7 +1,6 @@
 const all = require('./all');
 const draw = require('./draw');
 const isMatchingCard = require('./is-matching');
-const SandstormCard = require('../sandstorm');
 
 const hydrateCard = (cardObj, monster, deck = []) => {
 	const existingCard = deck.find(card => isMatchingCard(card, cardObj)); // restore cards from the players deck if possible
@@ -16,10 +15,6 @@ const hydrateCard = (cardObj, monster, deck = []) => {
 const hydrateDeck = (deckJSON = [], monster) => {
 	let deck = typeof deckJSON === 'string' ? JSON.parse(deckJSON) : deckJSON;
 	deck = deck.map(cardObj => hydrateCard(cardObj, monster));
-
-	if (!deck.find(({ cardType }) => cardType === SandstormCard.cardType)) {
-		deck.push(new SandstormCard());
-	}
 
 	return deck;
 };

--- a/characters/beastmaster.js
+++ b/characters/beastmaster.js
@@ -10,7 +10,7 @@ const { monsterCard } = require('../helpers/card');
 const { spawn, equip } = require('../monsters');
 const TENSE = require('../helpers/tense');
 
-const DEFAULT_MONSTER_SLOTS = 7;
+const DEFAULT_MONSTER_SLOTS = 6;
 
 class Beastmaster extends BaseCharacter {
 	constructor (options) {

--- a/characters/beastmaster.js
+++ b/characters/beastmaster.js
@@ -10,7 +10,7 @@ const { monsterCard } = require('../helpers/card');
 const { spawn, equip } = require('../monsters');
 const TENSE = require('../helpers/tense');
 
-const DEFAULT_MONSTER_SLOTS = 6;
+const DEFAULT_MONSTER_SLOTS = 7;
 
 class Beastmaster extends BaseCharacter {
 	constructor (options) {

--- a/characters/helpers/hydrate.mocha.node.js
+++ b/characters/helpers/hydrate.mocha.node.js
@@ -31,7 +31,7 @@ describe('./characters/helpers/hydrate.js', () => {
 
 		expect(character).to.be.an.instanceof(Beastmaster);
 		expect(character.monsters.length).to.equal(4);
-		expect(character.deck.length).to.equal(36);
+		expect(character.deck.length).to.equal(35);
 
 		const characterKalevala = character.deck.find(card => card.name === 'KalevalaCard');
 		const monsterKalevala = character.monsters[1].cards.find(card => card.name === 'KalevalaCard');


### PR DESCRIPTION
This reverts commit 3ea880bebf48ffbf484d31827727d4f4a0f527a8 so that the sandstorm card isn't re-added on every restart (now that all players should have it).