### PR TITLE
Make invisibility effects less over-powered

### DIFF
--- a/battlefield.js
+++ b/battlefield.js
@@ -7,6 +7,9 @@ const { Game } = require('./index.js');
 const pause = require('./helpers/pause');
 
 // const DestroyCard = require('./cards/destroy.js');
+const Cloak = require('./cards/cloak-of-invisibility.js');
+const Hit = require('./cards/hit.js');
+const Heal = require('./cards/heal.js');
 
 pause.setTimeout = func => setTimeout(func, 5);
 
@@ -64,6 +67,10 @@ return Promise
 	}))
 	.then((character) => {
 		vlad = character;
+		const cloak = new Cloak();
+		const hit = new Hit();
+		const heal = new Heal();
+		vlad.character.deck = [cloak, cloak, cloak, cloak, cloak, cloak, cloak, cloak, cloak];
 		vladCards = [...shuffle(vlad.character.deck).slice(0, 9)];
 	})
 	.then(() => slackdem.getCharacter(charAnnouncer, CHAR_ID, {
@@ -71,9 +78,13 @@ return Promise
 	}))
 	.then((character) => {
 		char = character;
-		charCards = [...shuffle(char.character.deck).slice(0, 9)];
+		// charCards = [...shuffle(char.character.deck).slice(0, 9)];
 		// const destroy = new DestroyCard();
 		// charCards = [destroy, destroy, destroy, destroy];
+		const cloak = new Cloak();
+		const hit = new Hit();
+		const heal = new Heal();
+		charCards = [cloak, heal, heal, heal, hit, cloak, heal, heal, hit];
 	})
 	// .then(() => vlad.spawnMonster())
 	.then(() => vlad.spawnMonster({
@@ -92,11 +103,11 @@ return Promise
 	.then(() => char.spawnMonster({
 		type: 4, name: 'king', color: 'brown', gender: 1, cards: charCards, xp: 300
 	}))
-	.then(() => vlad.lookAtCard({ cardName: 'brain drain' }))
-	.then(() => vlad.lookAtCard({ cardName: 'pick pocket' }))
-	.then(() => vlad.lookAtCards())
-	.then(() => vlad.lookAt('player handbook'))
-	.then(() => vlad.lookAtMonster({ monsterName: 'jerry' }))
+	// .then(() => vlad.lookAtCard({ cardName: 'brain drain' }))
+	// .then(() => vlad.lookAtCard({ cardName: 'pick pocket' }))
+	// .then(() => vlad.lookAtCards())
+	// .then(() => vlad.lookAt('player handbook'))
+	// .then(() => vlad.lookAtMonster({ monsterName: 'jerry' }))
 	.then(() => vlad.sendMonsterToTheRing())
 	.then(() => char.sendMonsterToTheRing())
 	.then(() => slackdem.getRing().spawnBoss());

--- a/battlefield.js
+++ b/battlefield.js
@@ -55,11 +55,6 @@ const charAnnouncer = what => announcer('charlemagne', what);
 let char;
 let charCards;
 
-// const BOSS_ID = 666;
-// const bossAnnouncer = what => announcer('boss', what);
-// let boss;
-// let bossCards;
-
 return Promise
 	.resolve()
 	.then(() => slackdem.getCharacter(vladAnnouncer, VLAD_ID, {
@@ -67,10 +62,7 @@ return Promise
 	}))
 	.then((character) => {
 		vlad = character;
-		const cloak = new Cloak();
-		const hit = new Hit();
-		const heal = new Heal();
-		vlad.character.deck = [cloak, cloak, cloak, cloak, cloak, cloak, cloak, cloak, cloak];
+		vlad.character.deck = [new Cloak(), new Cloak(), new Cloak(), new Cloak(), new Cloak(), new Hit(), new Heal(), new Hit(), new Heal()];
 		vladCards = [...shuffle(vlad.character.deck).slice(0, 9)];
 	})
 	.then(() => slackdem.getCharacter(charAnnouncer, CHAR_ID, {

--- a/battlefield.js
+++ b/battlefield.js
@@ -7,9 +7,6 @@ const { Game } = require('./index.js');
 const pause = require('./helpers/pause');
 
 // const DestroyCard = require('./cards/destroy.js');
-const Cloak = require('./cards/cloak-of-invisibility.js');
-const Hit = require('./cards/hit.js');
-const Heal = require('./cards/heal.js');
 
 pause.setTimeout = func => setTimeout(func, 5);
 
@@ -55,6 +52,11 @@ const charAnnouncer = what => announcer('charlemagne', what);
 let char;
 let charCards;
 
+// const BOSS_ID = 666;
+// const bossAnnouncer = what => announcer('boss', what);
+// let boss;
+// let bossCards;
+
 return Promise
 	.resolve()
 	.then(() => slackdem.getCharacter(vladAnnouncer, VLAD_ID, {
@@ -62,7 +64,6 @@ return Promise
 	}))
 	.then((character) => {
 		vlad = character;
-		vlad.character.deck = [new Cloak(), new Cloak(), new Cloak(), new Cloak(), new Cloak(), new Hit(), new Heal(), new Hit(), new Heal()];
 		vladCards = [...shuffle(vlad.character.deck).slice(0, 9)];
 	})
 	.then(() => slackdem.getCharacter(charAnnouncer, CHAR_ID, {
@@ -70,13 +71,9 @@ return Promise
 	}))
 	.then((character) => {
 		char = character;
-		// charCards = [...shuffle(char.character.deck).slice(0, 9)];
+		charCards = [...shuffle(char.character.deck).slice(0, 9)];
 		// const destroy = new DestroyCard();
 		// charCards = [destroy, destroy, destroy, destroy];
-		const cloak = new Cloak();
-		const hit = new Hit();
-		const heal = new Heal();
-		charCards = [cloak, heal, heal, heal, hit, cloak, heal, heal, hit];
 	})
 	// .then(() => vlad.spawnMonster())
 	.then(() => vlad.spawnMonster({
@@ -95,11 +92,11 @@ return Promise
 	.then(() => char.spawnMonster({
 		type: 4, name: 'king', color: 'brown', gender: 1, cards: charCards, xp: 300
 	}))
-	// .then(() => vlad.lookAtCard({ cardName: 'brain drain' }))
-	// .then(() => vlad.lookAtCard({ cardName: 'pick pocket' }))
-	// .then(() => vlad.lookAtCards())
-	// .then(() => vlad.lookAt('player handbook'))
-	// .then(() => vlad.lookAtMonster({ monsterName: 'jerry' }))
+	.then(() => vlad.lookAtCard({ cardName: 'brain drain' }))
+	.then(() => vlad.lookAtCard({ cardName: 'pick pocket' }))
+	.then(() => vlad.lookAtCards())
+	.then(() => vlad.lookAt('player handbook'))
+	.then(() => vlad.lookAtMonster({ monsterName: 'jerry' }))
 	.then(() => vlad.sendMonsterToTheRing())
 	.then(() => char.sendMonsterToTheRing())
 	.then(() => slackdem.getRing().spawnBoss());

--- a/cards/base.js
+++ b/cards/base.js
@@ -19,6 +19,10 @@ class BaseCard extends BaseItem {
 		return this.itemType;
 	}
 
+	get isAreaOfEffect () {
+		return !!this.constructor.isAreaOfEffect;
+	}
+
 	checkSuccess (roll, targetNumber) { // eslint-disable-line class-methods-use-this
 		const success = !roll.curseOfLoki && (roll.strokeOfLuck || targetNumber < roll.result);
 

--- a/cards/blast.js
+++ b/cards/blast.js
@@ -43,6 +43,7 @@ BlastCard.probability = 60;
 BlastCard.description = 'A magical blast against every opponent in the encounter.';
 BlastCard.level = 0;
 BlastCard.cost = 30;
+BlastCard.isAreaOfEffect = true;
 
 BlastCard.defaults = {
 	damage: 3,

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -68,7 +68,7 @@ class CloakOfInvisibilityCard extends BaseCard {
 
 							outcome = `${player.givenName} rolled a natural 20. ${capitalize(player.pronouns.he)} immediately realizes exactly where ${invisibilityTarget.givenName} is and strips off ${invisibilityTarget.pronouns.his} ${this.cardType.toLowerCase()}.`;
 						} else if (curseOfLoki) {
-							outcome = `${player.givenName} rolled a 1. While stumbling about looking for ${invisibilityTarget.givenName} ${player.pronouns.he} trips and hits himself instead.`;
+							outcome = `${player.givenName} rolled a 1. While stumbling about looking for ${invisibilityTarget.givenName} ${player.pronouns.he} trips and hits ${player.pronouns.him}self instead.`;
 						} else if (tie) {
 							outcome = `${player.givenName} almost catches a glimpse of ${invisibilityTarget.givenName} but when ${player.pronouns.he} blinks ${invisibilityTarget.givenName} is gone.`;
 						} else if (success) {

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -66,7 +66,7 @@ class CloakOfInvisibilityCard extends BaseCard {
 						});
 
 						const savingThrow = this.getSavingThrow(player);
-						const { success, strokeOfLuck, curseOfLoki, tie } = this.checkSuccess(savingThrow, invisibilityTarget.ac);
+						const { success, strokeOfLuck, curseOfLoki, tie } = this.checkSuccess(savingThrow, invisibilityTarget.int);
 						let outcome;
 
 						if (strokeOfLuck) {
@@ -84,13 +84,13 @@ class CloakOfInvisibilityCard extends BaseCard {
 						}
 
 						this.emit('rolled', {
-							reason: `vs ${invisibilityTarget.givenName}'s ac (${target.ac}) to determine if ${player.pronouns.he} can find ${invisibilityTarget.pronouns.him}.`,
+							reason: `vs ${invisibilityTarget.givenName}'s int (${target.int}) to determine if ${player.pronouns.he} can find ${invisibilityTarget.pronouns.him}.`,
 							card,
 							roll: savingThrow,
 							player,
 							target: invisibilityTarget,
 							outcome,
-							vs: target.ac
+							vs: target.int
 						});
 
 						if (curseOfLoki) {

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -36,13 +36,6 @@ class CloakOfInvisibilityCard extends BaseCard {
 				card.effect = (player, target, ring, activeContestants) => {
 					let finalTarget = target;
 
-					// this.emit('narration', {
-					// 	narration: `REMOVE .
-
-					// effect called on ${target.givenName}
-					// 	`
-					// });
-
 					const targetIsInvisible = !!target.encounterEffects.find(targetEffect => targetEffect.effectType === 'InvisibilityEffect');
 					if (phase === DEFENSE_PHASE && player !== invisibilityTarget && targetIsInvisible) {
 						this.emit('effect', {
@@ -78,35 +71,15 @@ class CloakOfInvisibilityCard extends BaseCard {
 
 						if (!success) {
 							invisibilityTarget.encounterModifiers.alreadyRetargeted = true;
-							// this.emit('narration', {
-							// 	narration: `REMOVE .
 
-							// ==================================================================================
-
-
-							// 	`
-							// });
 							const playerContestant = activeContestants.filter(contestant => contestant.monster === player)[0];
-							const notInvisibilityTarget = contestant =>
-								// this.emit('narration', {
-								// 	narration: `
-								// is visible: ${!contestant.monster.encounterEffects.find(effect => effect.effectType === 'InvisibilityEffect')}
-								// not player: ${contestant.monster !== player}
-								// `
-								// });
-								 (contestant &&
+							const notInvisibilityTarget = contestant => (contestant &&
 									!contestant.monster.dead &&
 									!contestant.monster.fled &&
 									contestant.monster !== invisibilityTarget &&
 									!contestant.monster.encounterEffects.find(targetEffect => targetEffect.effectType === 'InvisibilityEffect') &&
 									contestant.monster !== player);
 							const visibleOtherContestants = activeContestants.filter(notInvisibilityTarget);
-
-							// this.emit('narration', {
-							// 	narration: `
-							// number visible: ${visibleOtherContestants.length}
-							// `
-							// });
 
 							if (visibleOtherContestants.length <= 0 || activeContestants.length <= 2 || invisibilityTarget.encounterModifiers.alreadyRetargeted) {
 								this.emit('narration', {
@@ -118,12 +91,6 @@ class CloakOfInvisibilityCard extends BaseCard {
 							}
 
 							const finalTargetContestant = getTarget({ playerContestant, contestants: visibleOtherContestants, strategy: TARGET_RANDOM_PLAYER });
-
-							// this.emit('narration', {
-							// 	narration: `
-							// final target chosen: ${finalTargetContestant.monster.givenName}
-							// `
-							// });
 
 							finalTarget = finalTargetContestant.monster;
 
@@ -147,9 +114,7 @@ class CloakOfInvisibilityCard extends BaseCard {
 							invisibilityTarget.encounterModifiers.invisibilityTurns += 1;
 						}
 					}
-					// this.emit('narration', {
-					// 	narration: `REMOVE ${player.givenName} about to call effect on ${finalTarget.givenName}.`
-					// });
+
 					return effect.call(card, player, finalTarget, ring, activeContestants);
 				};
 			}

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -33,9 +33,15 @@ class CloakOfInvisibilityCard extends BaseCard {
 
 		const invisibilityEffect = ({
 			card,
-			phase
+			phase,
+			player: effectPlayer
 		}) => {
 			const { effect, isAreaOfEffect } = card;
+
+			// Always increase the count of invisible turns
+			if (phase === ATTACK_PHASE && effectPlayer === invisibilityTarget) {
+				invisibilityTarget.encounterModifiers.invisibilityTurns += 1;
+			}
 
 			if (effect && !isAreaOfEffect) {
 				card.effect = (player, target, ring, activeContestants) => {
@@ -103,8 +109,6 @@ class CloakOfInvisibilityCard extends BaseCard {
 
 								card.invisibilityNarrationEmitted = true;
 							}
-						} else {
-							invisibilityTarget.encounterModifiers.invisibilityTurns += 1;
 						}
 					}
 

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -1,6 +1,8 @@
 /* eslint-disable max-len */
 
 const BaseCard = require('./base');
+const { getTarget, TARGET_RANDOM_PLAYER } = require('../helpers/targeting-strategies');
+const { roll } = require('../helpers/chance');
 
 const { BARD, CLERIC, WIZARD } = require('../helpers/classes');
 const { ATTACK_PHASE, DEFENSE_PHASE } = require('../helpers/phases');
@@ -17,6 +19,10 @@ class CloakOfInvisibilityCard extends BaseCard {
 		return [player];
 	}
 
+	getSavingThrow (player) {
+		return roll({ primaryDice: '1d20', modifier: player.intModifier, crit: true });
+	}
+
 	effect (invisibilityPlayer, invisibilityTarget) { // eslint-disable-line no-unused-vars
 		invisibilityTarget.encounterModifiers.invisibilityTurns = 0;
 
@@ -28,7 +34,17 @@ class CloakOfInvisibilityCard extends BaseCard {
 
 			if (effect) {
 				card.effect = (player, target, ring, activeContestants) => {
-					if (phase === DEFENSE_PHASE && player !== invisibilityTarget && target === invisibilityTarget) {
+					let finalTarget = target;
+
+					// this.emit('narration', {
+					// 	narration: `REMOVE .
+
+					// effect called on ${target.givenName}
+					// 	`
+					// });
+
+					const targetIsInvisible = !!target.encounterEffects.find(targetEffect => targetEffect.effectType === 'InvisibilityEffect');
+					if (phase === DEFENSE_PHASE && player !== invisibilityTarget && targetIsInvisible) {
 						this.emit('effect', {
 							effectResult: `${this.icon} hidden from`,
 							player,
@@ -36,7 +52,86 @@ class CloakOfInvisibilityCard extends BaseCard {
 							ring
 						});
 
-						return Promise.resolve(true);
+						const savingThrow = this.getSavingThrow(player, invisibilityTarget);
+						const { success, strokeOfLuck, curseOfLoki, tie } = this.checkSuccess(savingThrow, 200);// target.int);
+						let commentary;
+
+						if (strokeOfLuck) {
+							invisibilityTarget.encounterModifiers.invisibilityTurns = 3;
+							commentary = `${player.givenName} rolled a natural 20. ${player.pronouns.he} immediately realizes exactly where ${invisibilityTarget.givenName} is.`;
+						} else if (curseOfLoki) {
+							invisibilityTarget.encounterModifiers.invisibilityTurns = 0;
+							commentary = `${player.givenName} rolled a 1. While looking for ${invisibilityTarget.givenName} ${player.pronouns.he} somehow turns ${player.pronouns.his} back to ${invisibilityTarget.pronouns.him}.`;
+						} else if (tie) {
+							commentary = 'Miss... Tie goes to the defender.';
+						}
+
+						this.emit('rolled', {
+							reason: `vs ${invisibilityTarget.givenName}'s int (${target.int}) to determine if ${player.pronouns.he} can see ${player.pronouns.him}.`,
+							card: this,
+							roll: savingThrow,
+							player,
+							target: invisibilityTarget,
+							outcome: success ? commentary || `Success. ${player.givenName} is able to see ${invisibilityTarget.givenName}` : commentary || `Fail. ${invisibilityTarget.givenName} is ${this.icon} still hidden from ${player.givenName}`,
+							vs: target.int
+						});
+
+						if (!success) {
+							invisibilityTarget.encounterModifiers.alreadyRetargeted = true;
+							// this.emit('narration', {
+							// 	narration: `REMOVE .
+
+							// ==================================================================================
+
+
+							// 	`
+							// });
+							const playerContestant = activeContestants.filter(contestant => contestant.monster === player)[0];
+							const notInvisibilityTarget = contestant =>
+								// this.emit('narration', {
+								// 	narration: `
+								// is visible: ${!contestant.monster.encounterEffects.find(effect => effect.effectType === 'InvisibilityEffect')}
+								// not player: ${contestant.monster !== player}
+								// `
+								// });
+								 (contestant &&
+									!contestant.monster.dead &&
+									!contestant.monster.fled &&
+									contestant.monster !== invisibilityTarget &&
+									!contestant.monster.encounterEffects.find(targetEffect => targetEffect.effectType === 'InvisibilityEffect') &&
+									contestant.monster !== player);
+							const visibleOtherContestants = activeContestants.filter(notInvisibilityTarget);
+
+							// this.emit('narration', {
+							// 	narration: `
+							// number visible: ${visibleOtherContestants.length}
+							// `
+							// });
+
+							if (visibleOtherContestants.length <= 0 || activeContestants.length <= 2 || invisibilityTarget.encounterModifiers.alreadyRetargeted) {
+								this.emit('narration', {
+									narration: `All players are currently ${this.icon} hidden from ${player.givenName}`
+								});
+
+								invisibilityTarget.encounterModifiers.alreadyRetargeted = false;
+								return Promise.resolve(true);
+							}
+
+							const finalTargetContestant = getTarget({ playerContestant, contestants: visibleOtherContestants, strategy: TARGET_RANDOM_PLAYER });
+
+							// this.emit('narration', {
+							// 	narration: `
+							// final target chosen: ${finalTargetContestant.monster.givenName}
+							// `
+							// });
+
+							finalTarget = finalTargetContestant.monster;
+
+							this.emit('narration', {
+								narration: `${player.givenName} seeks out a new target and finds a good candidate in ${finalTarget.givenName}`
+							});
+							card.effect = effect;
+						}
 					} else if (phase === ATTACK_PHASE && player === invisibilityTarget) {
 						if (target !== invisibilityTarget || invisibilityTarget.encounterModifiers.invisibilityTurns > 2) {
 							invisibilityTarget.encounterEffects = invisibilityTarget.encounterEffects.filter(encounterEffect => encounterEffect !== invisibilityEffect);
@@ -52,19 +147,29 @@ class CloakOfInvisibilityCard extends BaseCard {
 							invisibilityTarget.encounterModifiers.invisibilityTurns += 1;
 						}
 					}
-
-					return effect.call(card, player, target, ring, activeContestants);
+					// this.emit('narration', {
+					// 	narration: `REMOVE ${player.givenName} about to call effect on ${finalTarget.givenName}.`
+					// });
+					return effect.call(card, player, finalTarget, ring, activeContestants);
 				};
 			}
 
 			return card;
 		};
 
-		invisibilityTarget.encounterEffects = [...invisibilityTarget.encounterEffects, invisibilityEffect];
+		const alreadyInvisible = !!invisibilityTarget.encounterEffects.find(effect => effect.effectType === 'InvisibilityEffect');
+		invisibilityEffect.effectType = 'InvisibilityEffect';
+		if (!alreadyInvisible) {
+			invisibilityTarget.encounterEffects = [...invisibilityTarget.encounterEffects, invisibilityEffect];
 
-		this.emit('narration', {
-			narration: `${invisibilityTarget.identity} dons ${invisibilityTarget.pronouns.his} ${this.cardType.toLowerCase()}.`
-		});
+			this.emit('narration', {
+				narration: `${invisibilityTarget.identity} dons ${invisibilityTarget.pronouns.his} ${this.cardType.toLowerCase()}.`
+			});
+		} else {
+			this.emit('narration', {
+				narration: `${invisibilityTarget.identity} is already hidden.`
+			});
+		}
 
 		return true;
 	}

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -35,9 +35,9 @@ class CloakOfInvisibilityCard extends BaseCard {
 			card,
 			phase
 		}) => {
-			const { effect } = card;
+			const { effect, isAreaOfEffect } = card;
 
-			if (effect) {
+			if (effect && !isAreaOfEffect) {
 				card.effect = (player, target, ring, activeContestants) => {
 					if (phase === DEFENSE_PHASE && player !== invisibilityTarget && target === invisibilityTarget) {
 						const potentialTargets = activeContestants.filter(({ monster }) => (monster !== player && !isInvisible(monster)));

--- a/cards/cloak-of-invisibility.mocha.node.js
+++ b/cards/cloak-of-invisibility.mocha.node.js
@@ -67,21 +67,33 @@ describe('./cards/cloak-of-invisibility.js', () => {
 
 		const player = new WeepingAngel({ name: 'player' });
 		const target = new Basilisk({ name: 'target' });
+		const ring = {
+			contestants: [
+				{ monster: player },
+				{ monster: target }
+			]
+		};
+
+		invisibility.checkSuccess = () => ({
+			strokeOfLuck: false,
+			curseOfLoki: false,
+			success: false
+		});
 
 		expect(player.encounterEffects.length).to.equal(0);
 
 		return card
-			.play(target, player)
+			.play(target, player, ring, ring.contestants)
 			.then(() => {
 				// Card plays normally
 				expect(target.played).to.equal(1);
 				expect(player.targeted).to.equal(1);
 			})
-			.then(() => invisibility.play(player, target))
+			.then(() => invisibility.play(player, target, ring, ring.contestants))
 			// Effect activates when the original player is on the defensive
 			.then(() => player.encounterEffects[0]({ card, phase: ATTACK_PHASE, player: target, target: player }))
 			.then(modifiedCard => player.encounterEffects[0]({ card: modifiedCard, phase: DEFENSE_PHASE, player: target, target: player }))
-			.then(modifiedCard => modifiedCard.play(target, player))
+			.then(modifiedCard => modifiedCard.play(target, player, ring, ring.contestants))
 			.then(() => {
 				// Card is skipped
 				expect(target.played).to.equal(1);
@@ -93,7 +105,7 @@ describe('./cards/cloak-of-invisibility.js', () => {
 			// Effect doesn't clear when the card isn't an attack
 			.then(() => player.encounterEffects[0]({ card, phase: ATTACK_PHASE, player, target }))
 			.then(modifiedCard => player.encounterEffects[0]({ card: modifiedCard, phase: DEFENSE_PHASE, player, target }))
-			.then(modifiedCard => modifiedCard.play(player, player))
+			.then(modifiedCard => modifiedCard.play(player, player, ring, ring.contestants))
 			.then(() => {
 				// Card plays
 				expect(target.played).to.equal(1);
@@ -106,7 +118,7 @@ describe('./cards/cloak-of-invisibility.js', () => {
 			// Effect clears when the card is an attack
 			.then(() => player.encounterEffects[0]({ card, phase: ATTACK_PHASE, player, target }))
 			.then(modifiedCard => player.encounterEffects[0]({ card: modifiedCard, phase: DEFENSE_PHASE, player, target }))
-			.then(modifiedCard => modifiedCard.play(player, target))
+			.then(modifiedCard => modifiedCard.play(player, target, ring, ring.contestants))
 			.then(() => {
 				// Card plays
 				expect(target.played).to.equal(1);

--- a/cards/enchanted-faceswap.js
+++ b/cards/enchanted-faceswap.js
@@ -61,7 +61,7 @@ class EnchantedFaceswapCard extends BaseCard {
 			faceswapTarget.encounterEffects = [...faceswapTarget.encounterEffects, faceswapEffect];
 
 			this.emit('narration', {
-				narration: `${faceswapTarget.identity} prepares to ${this.icon} faceswap the next player who targets them.`
+				narration: `${faceswapTarget.identity} prepares to ${this.icon} faceswap the next player who targets ${faceswapTarget.pronouns.him}.`
 			});
 		} else {
 			this.emit('narration', {

--- a/cards/enchanted-faceswap.js
+++ b/cards/enchanted-faceswap.js
@@ -5,6 +5,10 @@ const BaseCard = require('./base');
 const { BARD, CLERIC } = require('../helpers/classes');
 const { DEFENSE_PHASE } = require('../helpers/phases');
 
+const EFFECT_TYPE = 'FaceswapEffect';
+
+const isFaceswapping = monster => !!monster.encounterEffects.find(encounterEffect => encounterEffect.effectType === EFFECT_TYPE);
+
 class EnchantedFaceswapCard extends BaseCard {
 	// Set defaults for these values that can be overridden by the options passed in
 	constructor ({
@@ -23,13 +27,13 @@ class EnchantedFaceswapCard extends BaseCard {
 			phase
 		}) => {
 			if (phase === DEFENSE_PHASE) {
-				const { effect } = card;
+				const { effect, isAreaOfEffect } = card;
 
 				// The card that is passed in should be a clone already so we're going to edit it directly
-				if (effect) {
+				if (effect && !isAreaOfEffect) {
 					card.effect = (swappedPlayer, swappedTarget, ring, activeContestants) => {
 						if (swappedTarget === faceswapTarget) {
-							faceswapTarget.encounterEffects = faceswapTarget.encounterEffects.filter(encounterEffect => encounterEffect !== faceswapEffect);
+							faceswapTarget.encounterEffects = faceswapTarget.encounterEffects.filter(encounterEffect => encounterEffect.effectType !== EFFECT_TYPE);
 
 							this.emit('effect', {
 								effectResult: `${this.icon} faceswapped by`,
@@ -49,11 +53,21 @@ class EnchantedFaceswapCard extends BaseCard {
 			return card;
 		};
 
-		faceswapTarget.encounterEffects = [...faceswapTarget.encounterEffects, faceswapEffect];
+		faceswapEffect.effectType = EFFECT_TYPE;
 
-		this.emit('narration', {
-			narration: `${faceswapTarget.identity} prepares to ${this.icon} faceswap the next player who targets them.`
-		});
+		const alreadyFaceswapping = isFaceswapping(faceswapTarget);
+
+		if (!alreadyFaceswapping) {
+			faceswapTarget.encounterEffects = [...faceswapTarget.encounterEffects, faceswapEffect];
+
+			this.emit('narration', {
+				narration: `${faceswapTarget.identity} prepares to ${this.icon} faceswap the next player who targets them.`
+			});
+		} else {
+			this.emit('narration', {
+				narration: `${faceswapTarget.identity} already has ${faceswapTarget.pronouns.his} phone out.`
+			});
+		}
 
 		return true;
 	}

--- a/cards/flee.js
+++ b/cards/flee.js
@@ -20,7 +20,7 @@ class FleeCard extends BaseCard {
 
 	effect (player, target, ring, activeContestants) { // eslint-disable-line no-unused-vars
 		if (target.bloodied) {
-			const fleeRoll = roll({ primaryDice: '1d20', modifier: player.dexModifier, crit: true });
+			const fleeRoll = roll({ primaryDice: '1d20', modifier: target.dexModifier, crit: true });
 			const { success } = this.checkSuccess(fleeRoll, 10);
 
 			this.emit('rolled', {

--- a/cards/heal.js
+++ b/cards/heal.js
@@ -46,12 +46,12 @@ class HealCard extends BaseCard {
 
 	// This doesn't have to be static if it needs access to the instance
 	effect (player, target, ring) { // eslint-disable-line no-unused-vars
-		const healRoll = this.getHealRoll(player);
+		const healRoll = this.getHealRoll(target);
 		let healResult = healRoll.result;
 
 		// Stroke of Luck
 		if (isProbable({ probability: 1 })) {
-			healResult = Math.floor(player.maxHp / 2);
+			healResult = Math.floor(target.maxHp / 2);
 			this.emit('narration', {
 				narration: `Stoke of Luck!
 Wait... wasn't this the questionable phial you found on the floor behind the shelf? Is it safe? Desperate times... Down the hatch!`

--- a/cards/horn-gore.js
+++ b/cards/horn-gore.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+const sample = require('lodash.sample');
 
 const ImmobilizeCard = require('./immobilize');
 
@@ -60,7 +61,7 @@ ${super.stats}`;
 				`grab ${player.pronouns.his} tongue and pull for all ${target.pronouns.he}'s worth`
 			];
 			commentary = `${player.givenName} rolled a 1.
-${target.givenName} manages to take the opportunity of such close proximity to ${player.givenName}'s face to ${flavors[Math.random() * flavors.length]}.`;
+${target.givenName} manages to take the opportunity of such close proximity to ${player.givenName}'s face to ${sample(flavors)}.`;
 		}
 
 		return commentary;
@@ -172,9 +173,9 @@ HornGore.defaults = {
 HornGore.flavors = {
 	hits: [
 		['gores', 80],
-		['mercilessly juggles on their mighty horns', 70],
 		['pokes relentlessly', 70],
-		['impales', 50],
+		['impales', 70],
+		['mercilessly juggles (on their mighty horns) the pitiful', 50],
 		['chases down gleefully, stomps on, and then wantonly drives their horns through', 5],
 		['teaches the true meaning of "horny" to', 5]
 	]

--- a/helpers/targeting-strategies.js
+++ b/helpers/targeting-strategies.js
@@ -1,6 +1,7 @@
 const TARGET_HIGHEST_HP_PLAYER = 'TARGET_HIGHEST_HP_PLAYER';
 const TARGET_MAX_HP_PLAYER = 'TARGET_MAX_HP_PLAYER';
 const TARGET_NEXT_PLAYER = 'TARGET_NEXT_PLAYER';
+const TARGET_RANDOM_PLAYER = 'TARGET_RANDOM_PLAYER';
 
 function getTarget ({ playerContestant, contestants = [], strategy = TARGET_NEXT_PLAYER }) {
 	switch (strategy) {
@@ -36,6 +37,10 @@ function getTarget ({ playerContestant, contestants = [], strategy = TARGET_NEXT
 				return potentialTarget;
 			}, defaultTarget);
 		}
+		case TARGET_RANDOM_PLAYER:
+			const potentialTargets = contestants.filter(contestant => (contestant !== playerContestant));
+
+			return potentialTargets[Math.floor(Math.random() * potentialTargets.length)];
 		case TARGET_NEXT_PLAYER:
 		default: {
 			const currentIndex = contestants.indexOf(playerContestant);
@@ -52,5 +57,6 @@ module.exports = {
 	TARGET_HIGHEST_HP_PLAYER,
 	TARGET_MAX_HP_PLAYER,
 	TARGET_NEXT_PLAYER,
+	TARGET_RANDOM_PLAYER,
 	getTarget
 };

--- a/helpers/targeting-strategies.js
+++ b/helpers/targeting-strategies.js
@@ -1,3 +1,5 @@
+const sample = require('lodash.sample');
+
 const TARGET_HIGHEST_HP_PLAYER = 'TARGET_HIGHEST_HP_PLAYER';
 const TARGET_MAX_HP_PLAYER = 'TARGET_MAX_HP_PLAYER';
 const TARGET_NEXT_PLAYER = 'TARGET_NEXT_PLAYER';
@@ -37,10 +39,11 @@ function getTarget ({ playerContestant, contestants = [], strategy = TARGET_NEXT
 				return potentialTarget;
 			}, defaultTarget);
 		}
-		case TARGET_RANDOM_PLAYER:
+		case TARGET_RANDOM_PLAYER: {
 			const potentialTargets = contestants.filter(contestant => (contestant !== playerContestant));
 
-			return potentialTargets[Math.floor(Math.random() * potentialTargets.length)];
+			return sample(potentialTargets);
+		}
 		case TARGET_NEXT_PLAYER:
 		default: {
 			const currentIndex = contestants.indexOf(playerContestant);


### PR DESCRIPTION
Fixes part of #184

If a target is invisible, look for another easy target to attack instead. If no other targets are available, roll to look for them. On success, you see them and can proceed with your attack. On stroke of luck, you proceed and you also take off their cloak. On curse of Loki, you end up hitting yourself instead.