### PR TITLE
Rolls should message more appropriately when you hit yourself

### DIFF
--- a/announcements/rolled.js
+++ b/announcements/rolled.js
@@ -2,14 +2,16 @@
 const { signedNumber } = require('../helpers/signed-number');
 
 const announceRolled = (publicChannel, channelManager, className, monster, {
+	outcome,
 	reason,
 	roll,
 	vs,
-	outcome
+	who
 }) => {
-	const title = roll.primaryDice || '';
-	const text = `(_${roll.naturalRoll.result}${signedNumber(roll.bonusResult)}${signedNumber(roll.modifier)} on ${title}_) ${reason}`;
+	let rollDesc = `${roll.naturalRoll.result}${signedNumber(roll.bonusResult)}${signedNumber(roll.modifier)}`;
+	if (roll.primaryDice) rollDesc = `${rollDesc} on ${roll.primaryDice}`;
 
+	const text = `${who.givenName} rolled _${rollDesc}_ ${reason}`;
 
 	const vsMsg = vs ? ` v ${vs}` : '';
 	let rollResult = (roll.strokeOfLuck) ? 'Nat 20!' : roll.result;

--- a/cards/bad-batch.js
+++ b/cards/bad-batch.js
@@ -42,14 +42,13 @@ class BadBatchCard extends BaseCard {
 							narration: `${target.givenName} doesn't notice that the seal on ${target.pronouns.his} bottle has been tampered with.`
 						});
 
-						const healRoll = getHealRoll.call(card, player);
+						const healRoll = getHealRoll.call(card, target);
 
 						this.emit('rolled', {
 							reason: 'to measure out a shot of whiskey.',
 							card: this,
 							roll: healRoll,
-							player,
-							target,
+							who: target,
 							outcome: 'Poisoned!'
 						});
 

--- a/cards/blink.js
+++ b/cards/blink.js
@@ -55,12 +55,18 @@ ${player.givenName}'s drain takes from hp instead.`;
 		const attackRoll = this.getAttackRoll(blinkPlayer);
 		const attackSuccess = this.checkSuccess(attackRoll, blinkTarget.int);
 
+		let timeShiftReason;
+		if (blinkPlayer === blinkTarget) {
+			timeShiftReason = `vs ${blinkTarget.pronouns.his} own int (${blinkTarget.int}) in confusion.`;
+		} else {
+			timeShiftReason = `vs ${blinkTarget.givenName}'s int (${blinkTarget.int}) in an attempt to time-shift ${blinkTarget.pronouns.him}.`;
+		}
+
 		this.emit('rolled', {
-			reason: `vs ${blinkTarget.givenName}'s int (${blinkTarget.int}) to time-shift ${blinkTarget.pronouns.him}.`,
+			reason: timeShiftReason,
 			card: this,
 			roll: attackRoll,
-			player: blinkPlayer,
-			target: blinkTarget,
+			who: blinkPlayer,
 			outcome: `Time shift ${attackSuccess.success ? 'succeeded!' : 'failed.'} ${blinkTarget.givenName} ${attackSuccess.success ? 'blinked!' : 'did not blink. The Doctor would be proud.'}`,
 			vs: blinkTarget.int
 		});
@@ -112,12 +118,18 @@ ${player.givenName}'s drain takes from hp instead.`;
 						};
 						this.curseAmount = -xpToSteal.result;
 
+						let potentialEngeryReason;
+						if (blinkPlayer === blinkTarget) {
+							potentialEngeryReason = `to steal potential energy from ${blinkTarget.pronouns.him}self.`;
+						} else {
+							potentialEngeryReason = `to steal potential energy from ${blinkTarget.identityWithHp}.`;
+						}
+
 						this.emit('rolled', {
-							reason: `to steal potential energy from ${blinkTarget.identityWithHp}`,
+							reason: potentialEngeryReason,
 							card: this,
 							roll: combinedRoll,
-							player: blinkPlayer,
-							target: blinkTarget
+							who: blinkPlayer
 						});
 
 						// drain hp

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -87,8 +87,7 @@ class CloakOfInvisibilityCard extends BaseCard {
 							reason: `vs ${invisibilityTarget.givenName}'s int (${target.int}) to determine if ${player.pronouns.he} can find ${invisibilityTarget.pronouns.him}.`,
 							card,
 							roll: savingThrow,
-							player,
-							target: invisibilityTarget,
+							who: player,
 							outcome,
 							vs: target.int
 						});

--- a/cards/flee.js
+++ b/cards/flee.js
@@ -24,11 +24,10 @@ class FleeCard extends BaseCard {
 			const { success } = this.checkSuccess(fleeRoll, 10);
 
 			this.emit('rolled', {
-				reason: 'and needs 10 or higher to flee',
+				reason: 'and needs 10 or higher to flee.',
 				card: this,
 				roll: fleeRoll,
-				player,
-				target,
+				who: target,
 				outcome: success ? 'Success!' : 'Fail!'
 			});
 

--- a/cards/forked-metal-rod.js
+++ b/cards/forked-metal-rod.js
@@ -80,7 +80,8 @@ ForkedMetalRodCard.flavors = {
 		['stabs', 80],
 		['pokes (in a not-so-facebook-flirting kind of way)', 50],
 		['snags and brutally lofts into the air their thoroughly surprised opponent', 5]
-	]
+	],
+	spike: 'prong'
 };
 
 module.exports = ForkedMetalRodCard;

--- a/cards/forked-stick.js
+++ b/cards/forked-stick.js
@@ -44,7 +44,8 @@ ForkedStickCard.flavors = {
 		['hits', 80],
 		['pokes (in a not-so-facebook-flirting kind of way)', 50],
 		['snags and brutally lofts into the air their thoroughly surprised opponent', 5]
-	]
+	],
+	spike: 'branch'
 };
 
 module.exports = ForkedStickCard;

--- a/cards/heal.js
+++ b/cards/heal.js
@@ -68,8 +68,7 @@ Ew... That tasted awful. Almost like... Oh no. Oh _no_. You just drank poison. ð
 				reason: 'to determine how much to heal.',
 				card: this,
 				roll: healRoll,
-				player,
-				target,
+				who: target,
 				outcome: `${target.givenName} grows stronger...`
 			});
 		}

--- a/cards/hit-harder.js
+++ b/cards/hit-harder.js
@@ -39,12 +39,18 @@ class HitHarder extends HitCard {
 				betterRoll.result = 1;
 			}
 
+			let reason;
+			if (player === target) {
+				reason = `for damage against ${target.pronouns.him}self.`;
+			} else {
+				reason = `for damage against ${target.givenName}.`;
+			}
+
 			this.emit('rolled', {
-				reason: `for damage against ${target.givenName}`,
+				reason,
 				card: this,
 				roll: betterRoll,
-				player,
-				target,
+				who: player,
 				outcome: commentary
 			});
 		}

--- a/cards/hit.js
+++ b/cards/hit.js
@@ -49,12 +49,18 @@ class HitCard extends BaseCard {
 			commentary = 'Miss... Tie goes to the defender.';
 		}
 
+		let reason;
+		if (player === target) {
+			reason = `vs ${target.pronouns.his} own ${this.targetProp.toLowerCase()} (${target[this.targetProp]}) in confusion.`;
+		} else {
+			reason = `vs ${target.givenName}'s ${this.targetProp.toLowerCase()} (${target[this.targetProp]}) to determine if the hit was a success.`;
+		}
+
 		this.emit('rolled', {
-			reason: `vs ${target.givenName}'s ${this.targetProp.toLowerCase()} (${target[this.targetProp]}) to determine if the hit was a success.`,
+			reason,
 			card: this,
 			roll: attackRoll,
-			player,
-			target,
+			who: player,
 			outcome: success ? commentary || 'Hit!' : commentary || 'Miss...',
 			vs: target[this.targetProp]
 		});
@@ -87,8 +93,7 @@ class HitCard extends BaseCard {
 				reason: 'for damage.',
 				card: this,
 				roll: damageRoll,
-				player,
-				target
+				who: player
 			});
 		}
 

--- a/cards/horn-gore.js
+++ b/cards/horn-gore.js
@@ -70,12 +70,18 @@ ${target.givenName} manages to take the opportunity of such close proximity to $
 	emitRoll (rolled, success, player, target, hornNumber) {
 		const commentary = this.getCommentary(rolled, player, target);
 
+		let reason;
+		if (player === target) {
+			reason = `vs ${target.pronouns.his} own ac (${target.ac})${hornNumber ? ` for ${this.flavors.spike} ${hornNumber}` : ''} in confusion.`;
+		} else {
+			reason = `vs ${target.givenName}'s ac (${target.ac})${hornNumber ? ` for ${this.flavors.spike} ${hornNumber}` : ''} to determine if gore was successful.`;
+		}
+
 		this.emit('rolled', {
-			reason: `vs ${target.givenName}'s ac (${target.ac})${hornNumber ? ` for horn ${hornNumber}` : ''} to determine if gore was successful.`,
+			reason,
 			card: this,
 			roll: rolled,
-			player,
-			target,
+			who: player,
 			outcome: commentary || (success ? 'Hit!' : 'Miss...'),
 			vs: target.ac
 		});
@@ -178,7 +184,8 @@ HornGore.flavors = {
 		['mercilessly juggles (on their mighty horns) the pitiful', 50],
 		['chases down gleefully, stomps on, and then wantonly drives their horns through', 5],
 		['teaches the true meaning of "horny" to', 5]
-	]
+	],
+	spike: 'horn'
 };
 
 module.exports = HornGore;

--- a/cards/immobilize.js
+++ b/cards/immobilize.js
@@ -169,11 +169,10 @@ class ImmobilizeCard extends HitCard {
 			const outcome = attackSuccess.success ? `${this.actions[0]} succeeded!` : failMessage;
 
 			this.emit('rolled', {
-				reason: `to see if ${player.pronouns.he} ${this.actions[1]} ${target.givenName}`,
+				reason: `to see if ${player.pronouns.he} ${this.actions[1]} ${target.givenName}.`,
 				card: this,
 				roll: attackRoll,
-				player,
-				target,
+				who: player,
 				outcome,
 				vs: this.getTargetPropValue(target)
 			});
@@ -206,8 +205,7 @@ class ImmobilizeCard extends HitCard {
 								reason: `and needs ${this.getFreedomThreshold(player, target) + 1} or higher to break free.`,
 								card: this,
 								roll: freedomRoll,
-								player: target,
-								target: player,
+								who: target,
 								outcome: success ? commentary || `Success! ${target.givenName} is freed.` : commentary || `${target.givenName} remains ${this.actions[2]} and will miss a turn.`,
 								vs: this.getFreedomThreshold(player, target)
 							});

--- a/cards/lucky-strike.js
+++ b/cards/lucky-strike.js
@@ -42,12 +42,19 @@ Roll twice for hit. Use the best roll.`;
 		} else if (tie) {
 			commentary = 'Miss... Tie goes to the defender.';
 		}
+
+		let reason;
+		if (player === target) {
+			reason = `vs ${target.pronouns.his} own ${this.targetProp.toLowerCase()} (${target[this.targetProp]}) in confusion.`;
+		} else {
+			reason = `vs ${target.givenName}'s ${this.targetProp.toLowerCase()} (${target[this.targetProp]}) to determine if the hit was a success.`;
+		}
+
 		this.emit('rolled', {
-			reason: `vs ${target.givenName}'s ${this.targetProp.toLowerCase()} (${target[this.targetProp]}) to determine if the hit was a success`,
+			reason,
 			card: this,
 			roll: betterRoll,
-			player,
-			target,
+			who: player,
 			outcome: success ? commentary || 'Hit!' : commentary || 'Miss...',
 			vs: target[this.targetProp]
 		});

--- a/cards/rehit.js
+++ b/cards/rehit.js
@@ -40,12 +40,18 @@ class Rehit extends HitCard {
 			commentary = 'Miss... Tie goes to the defender.';
 		}
 
+		let reason;
+		if (player === target) {
+			reason = `vs ${target.pronouns.his} own ac (${target.ac}) in confusion.`;
+		} else {
+			reason = `vs ${target.givenName}'s ac (${target.ac}) to determine if the hit was a success.`;
+		}
+
 		this.emit('rolled', {
-			reason: `vs ac (${target.ac}) to determine if the hit was a success.`,
+			reason,
 			card: this,
 			roll: attackRoll,
-			player,
-			target,
+			who: player,
 			outcome: success ? commentary || 'Hit!' : commentary || 'Miss...',
 			vs: target.ac
 		});


### PR DESCRIPTION
Improves readability of roll message a little bit, especially in cases where you accidentally target yourself. Another good improvement would be an _even worse_ critical fail when you are already confused and targeting yourself and you roll a 1.