### PR TITLE
take XinWey's Doctrine into account

### DIFF
--- a/announcements/death.js
+++ b/announcements/death.js
@@ -2,9 +2,10 @@ const announceDeath = (publicChannel, channelManager, className, monster, { assa
 	let announce;
 
 	if (destroyed) {
-		announce = `${monster.identityWithHp} has been sent to the land of ${monster.pronouns.his} ancestors by ${assailant.identityWithHp}
-
-		☠️  R.I.P ${monster.identity}
+		announce = `In accordance with XinWey’s Doctrine: A person needs to experience real danger or they will never find joy in excelling. There has to be a risk of failure, the chance to die.
+As such, ${monster.identityWithHp} has been sent to the land of ${monster.pronouns.his} ancestors by ${assailant.identityWithHp}
+So it is written. So it is done.
+☠️  R.I.P ${monster.identity}
 `;
 	} else {
 		announce = `💀  ${monster.identityWithHp} is killed by ${assailant.identityWithHp}

--- a/cards/battle-focus.mocha.node.js
+++ b/cards/battle-focus.mocha.node.js
@@ -7,6 +7,12 @@ const pause = require('../helpers/pause');
 
 const { GLADIATOR } = require('../helpers/creature-types');
 
+const ultimateComboNarration = [];
+for (let i = 17; i < 101; i++) {
+	ultimateComboNarration.push(`HUMILIATION! ${i} hits`);
+}
+ultimateComboNarration.push('ULTIMATE COMBO! 100 HITS (99 total damage).');
+
 describe('./cards/battle-focus.js', () => {
 	let channelStub;
 	let pauseStub;
@@ -127,6 +133,89 @@ describe('./cards/battle-focus.js', () => {
 				expect(hitSpy.callCount).to.equal(2);
 
 				return expect(target.hp).to.equal(before - 6);
+			});
+	});
+
+	it('Permakills on big first hit and combos until humiliation.', () => {
+		const battleFocus = new BattleFocusCard();
+		const player = new Gladiator({ name: 'player' });
+		const target = new Minotaur({ name: 'target', hpVariance: 0 });
+		target.hp = 1;
+		const before = target.hp;
+
+		const battleFocusProto = Object.getPrototypeOf(battleFocus);
+		const berserkProto = Object.getPrototypeOf(battleFocusProto);
+		const hitProto = Object.getPrototypeOf(berserkProto);
+		const baseProto = Object.getPrototypeOf(hitProto);
+		const minotaurProto = Object.getPrototypeOf(target);
+		const creatureProto = Object.getPrototypeOf(minotaurProto);
+
+		// checkSuccess must return true in order for hit to be called from hitCheck
+		const checkSuccessStub = sinon.stub(baseProto, 'checkSuccess').callsFake(() =>// eslint-disable-line no-unused-vars
+			({ success: true, strokeOfLuck: false, curseOfLoki: false }));
+		const hitCheckStub = sinon.stub(hitProto, 'hitCheck');
+		const berserkEffectSpy = sinon.spy(berserkProto, 'effect');
+		const berserkEffectLoopSpy = sinon.spy(berserkProto, 'effectLoop');
+		const hitEffectSpy = sinon.spy(hitProto, 'effect');
+		const hitSpy = sinon.spy(creatureProto, 'hit');
+		const getDamageRollStub = sinon.stub(berserkProto, 'getDamageRoll');
+		getDamageRollStub.returns({
+			result: 10,
+			naturalRoll: { result: 10 },
+			strokeOfLuck: false,
+			curseOfLoki: false
+		});
+
+		const ring = {
+			contestants: [
+				{ monster: player },
+				{ monster: target }
+			],
+			channelManager: {
+				sendMessages: () => Promise.resolve()
+			}
+		};
+
+		const attackRoll = battleFocus.getAttackRoll(player);
+		hitCheckStub.returns({
+			attackRoll,
+			success: true,
+			strokeOfLuck: false,
+			curseOfLoki: false
+		});
+
+		hitCheckStub.onCall(100).returns({
+			attackRoll,
+			success: false,
+			strokeOfLuck: false,
+			curseOfLoki: false
+		});
+
+		const narrations = [];
+		battleFocus.on('narration', (className, monster, { narration }) => {
+			narrations.push(narration);
+		});
+
+		return battleFocus
+			.play(player, target, ring, ring.contestants)
+			.then(() => {
+				hitCheckStub.restore();
+				hitEffectSpy.restore();
+				checkSuccessStub.restore();
+				hitSpy.restore();
+				berserkEffectSpy.restore();
+				berserkEffectLoopSpy.restore();
+				getDamageRollStub.restore();
+
+				expect(berserkEffectSpy.callCount).to.equal(1);
+				expect(berserkEffectLoopSpy.callCount).to.equal(101);
+				expect(hitCheckStub.callCount).to.equal(101);
+				expect(hitEffectSpy.callCount).to.equal(0);
+				expect(hitSpy.callCount).to.equal(16);
+				expect(narrations).to.deep.equal(ultimateComboNarration);
+				expect(target.destroyed).to.be.true;
+
+				return expect(target.hp).to.be.below(-Math.floor(target.maxHp/2));
 			});
 	});
 });

--- a/cards/battle-focus.mocha.node.js
+++ b/cards/battle-focus.mocha.node.js
@@ -136,7 +136,7 @@ describe('./cards/battle-focus.js', () => {
 			});
 	});
 
-	it('Permakills on big first hit and combos until humiliation.', () => {
+	it('Permakills if target HP < bigFirstHit damage amount and then combos until humiliation.', () => {
 		const battleFocus = new BattleFocusCard();
 		const player = new Gladiator({ name: 'player' });
 		const target = new Minotaur({ name: 'target', hpVariance: 0 });

--- a/cards/berserk.js
+++ b/cards/berserk.js
@@ -119,11 +119,11 @@ Stroke of luck increases damage per hit by 1.`;
 			// Do not consider the first hit part of the cumulative combo damage.
 			// For cards with a bigFirstHit, this will make perma-death possible (although unlikely)
 			if (iteration !== 1) {
-				this.cumulativeComboDamage++;
+				this.cumulativeComboDamage += damage;
 			}
 
 			// If we hit then do some damage
-			if (!target.dead && this.cumulativeComboDamage <= Math.floor(target.maxHp / 2)) {
+			if (this.cumulativeComboDamage <= Math.floor(target.maxHp / 2)) {
 				target.hit(damage, player, this);
 			} else {
 				this.emit('narration', {

--- a/cards/berserk.mocha.node.js
+++ b/cards/berserk.mocha.node.js
@@ -8,10 +8,10 @@ const pause = require('../helpers/pause');
 const { BARBARIAN } = require('../helpers/classes');
 
 const ultimateComboNarration = [];
-for (let i = 17; i < 101; i++) {
+for (let i = 5; i < 101; i++) {
 	ultimateComboNarration.push(`HUMILIATION! ${i} hits`);
 }
-ultimateComboNarration.push('ULTIMATE COMBO! 100 HITS (99 total damage).');
+ultimateComboNarration.push('ULTIMATE COMBO! 100 HITS (5148 total damage).');
 
 describe('./cards/berserk.js', () => {
 	let channelStub;
@@ -318,7 +318,7 @@ describe('./cards/berserk.js', () => {
 			});
 	});
 
-	it('Continues hitting after opponent is dead, but does not do combo damage after reaching maxHp/2, and does not permakill player', () => {
+	it('Continues hitting after opponent is dead, but does not do combo damage after exceeding maxHp/2, and does not permakill player even if every hit is a crit', () => {
 		const berserk = new BerserkCard();
 		const player = new Gladiator({ name: 'player' });
 		const target = new Minotaur({ name: 'target', hpVariance: 0 });
@@ -354,7 +354,7 @@ describe('./cards/berserk.js', () => {
 		hitCheckStub.returns({
 			attackRoll,
 			success: true,
-			strokeOfLuck: false,
+			strokeOfLuck: true,
 			curseOfLoki: false
 		});
 
@@ -384,11 +384,11 @@ describe('./cards/berserk.js', () => {
 				expect(berserkEffectLoopSpy.callCount).to.equal(101);
 				expect(hitCheckStub.callCount).to.equal(101);
 				expect(hitEffectSpy.callCount).to.equal(0);
-				expect(hitSpy.callCount).to.equal(16);
+				expect(hitSpy.callCount).to.equal(4);
 				expect(narrations).to.deep.equal(ultimateComboNarration);
 				expect(target.destroyed).to.be.false;
 
-				return expect(target.hp).to.equal(before - (Math.floor(target.maxHp/2) + 1));
+				return expect(target.hp).to.equal(-13);
 			});
 	});
 

--- a/cards/berserk.mocha.node.js
+++ b/cards/berserk.mocha.node.js
@@ -7,12 +7,11 @@ const pause = require('../helpers/pause');
 
 const { BARBARIAN } = require('../helpers/classes');
 
-const ultraComboNarration = [];
+const ultimateComboNarration = [];
 for (let i = 17; i < 101; i++) {
-	ultraComboNarration.push(`HUMILIATION! ${i} hits`);
+	ultimateComboNarration.push(`HUMILIATION! ${i} hits`);
 }
-ultraComboNarration.push('ULTRA COMBO! 100 HITS (99 total damage).');
-
+ultimateComboNarration.push('ULTIMATE COMBO! 100 HITS (99 total damage).');
 
 describe('./cards/berserk.js', () => {
 	let channelStub;
@@ -319,10 +318,11 @@ describe('./cards/berserk.js', () => {
 			});
 	});
 
-	it('Continues hitting after opponent is dead, but does not do combo damage after reaching maxHp/2', () => {
+	it('Continues hitting after opponent is dead, but does not do combo damage after reaching maxHp/2, and does not permakill player', () => {
 		const berserk = new BerserkCard();
 		const player = new Gladiator({ name: 'player' });
 		const target = new Minotaur({ name: 'target', hpVariance: 0 });
+		target.hp = 1;
 		const before = target.hp;
 
 		const berserkProto = Object.getPrototypeOf(berserk);
@@ -385,9 +385,10 @@ describe('./cards/berserk.js', () => {
 				expect(hitCheckStub.callCount).to.equal(101);
 				expect(hitEffectSpy.callCount).to.equal(0);
 				expect(hitSpy.callCount).to.equal(16);
-				expect(narrations).to.deep.equal(ultraComboNarration);
+				expect(narrations).to.deep.equal(ultimateComboNarration);
+				expect(target.destroyed).to.be.false;
 
-				return expect(target.hp).to.equal(before - 16);
+				return expect(target.hp).to.equal(before - (Math.floor(target.maxHp/2) + 1));
 			});
 	});
 

--- a/creatures/base.js
+++ b/creatures/base.js
@@ -518,7 +518,7 @@ Battles won: ${this.battles.wins}`;
 			prevHp: originalHP
 		});
 
-		if (!this.dead && hp <= 0) {
+		if (originalHP > 0 && hp <= 0) {
 			return this.die(assailant);
 		}
 

--- a/creatures/base.js
+++ b/creatures/base.js
@@ -505,9 +505,6 @@ Battles won: ${this.battles.wins}`;
 		});
 		this.encounterModifiers.hitLog = hitLog;
 
-		// don't do damage if already dead
-		if (this.hp < 1) return false;
-
 		const hp = this.hp - damage;
 		const originalHP = this.hp;
 
@@ -521,11 +518,11 @@ Battles won: ${this.battles.wins}`;
 			prevHp: originalHP
 		});
 
-		if (hp <= 0) {
+		if (!this.dead && hp <= 0) {
 			return this.die(assailant);
 		}
 
-		return true;
+		return !this.dead;
 	}
 
 	heal (amount = 0) {

--- a/monsters/basilisk.mocha.node.js
+++ b/monsters/basilisk.mocha.node.js
@@ -103,7 +103,7 @@ describe('./monsters/basilisk.js', () => {
 		expect(basilisk.dead).to.be.true;
 	});
 
-	it('can not be hit while dead', () => {
+	it('does not re-die if already dead', () => {
 		const basilisk = new Basilisk();
 
 		const basiliskProto = Object.getPrototypeOf(basilisk);
@@ -123,6 +123,6 @@ describe('./monsters/basilisk.js', () => {
 		expect(dieSpy.calledOnce).to.be.true;
 
 		dieSpy.restore();
-		expect(basilisk.hp).to.equal(0);
+		expect(basilisk.hp).to.equal(-1);
 	});
 });

--- a/monsters/basilisk.mocha.node.js
+++ b/monsters/basilisk.mocha.node.js
@@ -94,13 +94,20 @@ describe('./monsters/basilisk.js', () => {
 	it('can die from being hit', () => {
 		const basilisk = new Basilisk();
 
+		const basiliskProto = Object.getPrototypeOf(basilisk);
+		const creatureProto = Object.getPrototypeOf(basiliskProto);
+		const dieSpy = sinon.spy(creatureProto, 'die');
+
 		basilisk.hp = 1;
 
 		expect(basilisk.dead).to.be.false;
 
 		basilisk.hit(1, basilisk);
 
+		expect(dieSpy.calledOnce).to.be.true;
 		expect(basilisk.dead).to.be.true;
+
+		dieSpy.restore();
 	});
 
 	it('does not re-die if already dead', () => {


### PR DESCRIPTION
This pr:

- Fixes cumulativeDamage tracker in berserk
- Allows BattleFocus to permakill player _if_ the target has only ~1HP and the player successfully damages them for _max damage_.
- Allows players to be hit after they are dead (they still are not target-able after they are dead, so the attack hitting them after they are dead _has to be_ a combination attack which is begun when they are alive, eg Forked Metal Rod, Horn Gore, BattleFocus, Berserk)
- Updates permadeath announcement to include XinWey's Doctrine (which is from a Brandon Sanderson sci-fi/fantasy novella)