### PR TITLE
Tweak items allowed in encounters

### DIFF
--- a/creatures/base.js
+++ b/creatures/base.js
@@ -504,6 +504,13 @@ Battles won: ${this.battles.wins}`;
 		}
 
 		if (!foundItem) {
+			// Monsters in an encounter can only use items they are carrying
+			if (monster && monster.inEncounter) {
+				return Promise.reject(channel({
+					announce: `${monster.givenName} doesn't seem to be holding that item.`
+				}));
+			}
+
 			foundItem = character.items.find(potentialItem => isMatchingItem(potentialItem, item));
 		}
 

--- a/items/helpers/use.mocha.node.js
+++ b/items/helpers/use.mocha.node.js
@@ -34,7 +34,7 @@ describe('./items/helpers/use.js', () => {
 			.resolves('0');
 
 		channelStub.withArgs({
-			question: 'Is this correct? (yes/no)'
+			question: 'Are you sure? (yes/no)'
 		})
 			.resolves('yes');
 
@@ -68,7 +68,7 @@ describe('./items/helpers/use.js', () => {
 			.resolves('0');
 
 		channelStub.withArgs({
-			question: 'Is this correct? (yes/no)'
+			question: 'Are you sure? (yes/no)'
 		})
 			.resolves('yes');
 


### PR DESCRIPTION
Monsters in an encounter should only be able to use items that they are carrying