### PR TITLE
Don't double account for advantage in freedom roll

### DIFF
--- a/cards/horn-gore.mocha.node.js
+++ b/cards/horn-gore.mocha.node.js
@@ -197,11 +197,11 @@ Turns immobilized resets on curse of loki.
 		expect(hornGore.getImmobilizeRoll(player, jinn).modifier).to.equal(player.strModifier - 6);
 		expect(hornGore.getImmobilizeRoll(player, minotaur).modifier).to.equal(player.strModifier - 2);
 
-		expect(hornGore.getFreedomRoll(player, angel).modifier).to.equal(angel.strModifier + 6);
-		expect(hornGore.getFreedomRoll(player, basilisk).modifier).to.equal(basilisk.strModifier + 6);
-		expect(hornGore.getFreedomRoll(player, gladiator).modifier).to.equal(gladiator.strModifier + 2);
-		expect(hornGore.getFreedomRoll(player, jinn).modifier).to.equal(jinn.strModifier + 6);
-		expect(hornGore.getFreedomRoll(player, minotaur).modifier).to.equal(minotaur.strModifier + 2);
+		expect(hornGore.getFreedomRoll(player, angel).modifier).to.equal(angel.strModifier);
+		expect(hornGore.getFreedomRoll(player, basilisk).modifier).to.equal(basilisk.strModifier);
+		expect(hornGore.getFreedomRoll(player, gladiator).modifier).to.equal(gladiator.strModifier);
+		expect(hornGore.getFreedomRoll(player, jinn).modifier).to.equal(jinn.strModifier);
+		expect(hornGore.getFreedomRoll(player, minotaur).modifier).to.equal(minotaur.strModifier);
 	});
 
 	it('hits twice and immobilizes', () => {

--- a/cards/immobilize.js
+++ b/cards/immobilize.js
@@ -151,7 +151,7 @@ ${ongoingDamageText}`;
 
 	getFreedomRoll (immobilizer, immobilized) {
 		const statsBonus = this.freedomSavingThrowTargetAttr === 'ac' ? immobilized.dexModifier : immobilized[`${this.freedomSavingThrowTargetAttr}Modifier`];
-		return roll({ primaryDice: this.attackDice, modifier: statsBonus - this.getAttackModifier(immobilized), bonusDice: immobilized.bonusAttackDice, crit: true });
+		return roll({ primaryDice: this.attackDice, modifier: statsBonus, bonusDice: immobilized.bonusAttackDice, crit: true });
 	}
 
 	// Most of the time this should be an auto-success since they get a chance to break free on their next turn

--- a/cards/mesmerize.mocha.node.js
+++ b/cards/mesmerize.mocha.node.js
@@ -167,12 +167,12 @@ Turns immobilized resets on curse of loki.
 		expect(mesmerize.getImmobilizeRoll(player, jinn).modifier).to.equal(player.intModifier);
 		expect(mesmerize.getImmobilizeRoll(player, minotaur).modifier).to.equal(player.intModifier - 2);
 
-		expect(mesmerize.getFreedomRoll(player, player).modifier).to.equal(player.intModifier + 2);
-		expect(mesmerize.getFreedomRoll(player, angel).modifier).to.equal(angel.intModifier + 2);
-		expect(mesmerize.getFreedomRoll(player, basilisk).modifier).to.equal(basilisk.intModifier - 2);
-		expect(mesmerize.getFreedomRoll(player, gladiator).modifier).to.equal(gladiator.intModifier - 2);
+		expect(mesmerize.getFreedomRoll(player, player).modifier).to.equal(player.intModifier);
+		expect(mesmerize.getFreedomRoll(player, angel).modifier).to.equal(angel.intModifier);
+		expect(mesmerize.getFreedomRoll(player, basilisk).modifier).to.equal(basilisk.intModifier);
+		expect(mesmerize.getFreedomRoll(player, gladiator).modifier).to.equal(gladiator.intModifier);
 		expect(mesmerize.getFreedomRoll(player, jinn).modifier).to.equal(jinn.intModifier);
-		expect(mesmerize.getFreedomRoll(player, minotaur).modifier).to.equal(minotaur.intModifier + 2);
+		expect(mesmerize.getFreedomRoll(player, minotaur).modifier).to.equal(minotaur.intModifier);
 	});
 
 	it('immobilizes everyone on play', () => mesmerize


### PR DESCRIPTION
We were accounting for an immobilizer's advantage in both the roll _and_ the target number for freedom rolls on immobilize.

This makes it only take advantage into account for the target number, _not_ the roll to get free.

Advantage is taken into consideration for:

- Hit
- Initial Immobilization
- Immobilization freedom threshold (target number).

The reason we are taking it into consideration for `getFreedomThreshold` but not `getFreedomRoll` is because in `getFreedomRoll` we would have to invert the number, which is slightly more confusion. I'd be open to moving the calculation of it out of `getFreedomThreshold` into `getFreedomRoll` instead (for consistency).