### PR TITLE
Changes how psychic cards are handled

### DIFF
--- a/announcements/hit.mocha.node.js
+++ b/announcements/hit.mocha.node.js
@@ -24,7 +24,7 @@ describe('./announcements/hit.js', () => {
 		it('can announce normal hit to public channel', () => {
 			const announcement = `💪 🤜 💪  Assailant hits Monster for 2 damage.
 
-💪 *Monster has 30HP.*
+💪 *Monster has 31HP.*
 `;
 			const publicChannel = ({ announce }) => {
 				expect(announce).to.equal(announcement);
@@ -105,7 +105,7 @@ describe('./announcements/hit.js', () => {
 		it('can announce weak hit to public channel', () => {
 			const announcement = `💪 🏓 💪  Assailant hits Monster for 1 damage.
 
-💪 *Monster has 30HP.*
+💪 *Monster has 31HP.*
 `;
 			const publicChannel = ({ announce }) => {
 				expect(announce).to.equal(announcement);
@@ -128,7 +128,7 @@ describe('./announcements/hit.js', () => {
 		it('can announce strong damage to public channel', () => {
 			const announcement = `💪 🔪 💪  Assailant hits Monster for 5 damage.
 
-💪 *Monster has 30HP.*
+💪 *Monster has 31HP.*
 `;
 			const publicChannel = ({ announce }) => {
 				expect(announce).to.equal(announcement);
@@ -151,7 +151,7 @@ describe('./announcements/hit.js', () => {
 		it('can announce top damage to public channel', () => {
 			const announcement = `💪 🔥 💪  Assailant hits Monster for 10 damage.
 
-💪 *Monster has 30HP.*
+💪 *Monster has 31HP.*
 `;
 			const publicChannel = ({ announce }) => {
 				expect(announce).to.equal(announcement);

--- a/cards/battle-focus.mocha.node.js
+++ b/cards/battle-focus.mocha.node.js
@@ -7,7 +7,7 @@ const Minotaur = require('../monsters/minotaur');
 const { GLADIATOR } = require('../constants/creature-types');
 
 const ultimateComboNarration = [];
-for (let i = 17; i < 101; i++) {
+for (let i = 18; i < 101; i++) {
 	ultimateComboNarration.push(`HUMILIATION! ${i} hits`);
 }
 ultimateComboNarration.push('ULTIMATE COMBO! 100 HITS (109 total damage).');
@@ -187,7 +187,7 @@ describe('./cards/battle-focus.js', () => {
 				expect(berserkEffectLoopSpy.callCount).to.equal(101);
 				expect(hitCheckStub.callCount).to.equal(101);
 				expect(hitEffectSpy.callCount).to.equal(0);
-				expect(hitSpy.callCount).to.equal(16);
+				expect(hitSpy.callCount).to.equal(17);
 				expect(narrations).to.deep.equal(ultimateComboNarration);
 				expect(target.destroyed).to.be.true;
 

--- a/cards/boost.js
+++ b/cards/boost.js
@@ -74,7 +74,7 @@ class BoostCard extends BaseCard {
 	}
 
 	getBoostOverflowNarrative (player, target) {
-		return `${target.givenName}'s ${this.cursedProp} boosts have been maxed out. Boost will be granted to hp instead.`;
+		return `${target.givenName}'s ${this.boostedProp} boosts have been maxed out. Boost will be granted to hp instead.`;
 	}
 
 	effect (player, target) {

--- a/cards/brain-drain.js
+++ b/cards/brain-drain.js
@@ -3,10 +3,11 @@
 const CurseCard = require('./curse');
 const HitCard = require('./hit');
 
+const { CLERIC } = require('../constants/creature-classes');
+const { JINN } = require('../constants/creature-types');
 const { max } = require('../helpers/chance');
 const { PSYCHIC } = require('../constants/card-classes');
 const { REASONABLE } = require('../helpers/costs');
-
 const STATS = require('../constants/stats');
 
 class BrainDrainCard extends CurseCard {
@@ -34,6 +35,7 @@ ${stats}`;
 
 BrainDrainCard.cardClass = [PSYCHIC];
 BrainDrainCard.cardType = 'Brain Drain';
+BrainDrainCard.permittedClassesAndTypes = [CLERIC, JINN];
 BrainDrainCard.description = 'And we shall bury our enemies in their own confusion.';
 BrainDrainCard.cost = REASONABLE.cost;
 

--- a/cards/brain-drain.js
+++ b/cards/brain-drain.js
@@ -20,9 +20,9 @@ class BrainDrainCard extends CurseCard {
 	}
 
 	get stats () {
-		const hit = new HitCard({ damageDice: this.damageDice });
+		const hit = new HitCard(this.options);
 		let stats = `Curse: ${this.cursedProp} ${this.curseAmount}
-can reduce ${this.cursedProp} down to ${STATS.MAX_PROP_MODIFICATIONS[this.cursedProp]}, then takes ${max(this.damageDice)} from hp instead.`;
+Can reduce ${this.cursedProp} down to ${STATS.MAX_PROP_MODIFICATIONS[this.cursedProp]}, then takes ${max(this.damageDice)} from hp instead.`;
 
 		if (this.hasChanceToHit) {
 			stats = `${hit.stats}
@@ -42,7 +42,8 @@ BrainDrainCard.cost = REASONABLE.cost;
 BrainDrainCard.defaults = {
 	...CurseCard.defaults,
 	curseAmount: -20,
-	cursedProp: 'xp'
+	cursedProp: 'xp',
+	targetProp: 'int'
 };
 
 module.exports = BrainDrainCard;

--- a/cards/brain-drain.mocha.node.js
+++ b/cards/brain-drain.mocha.node.js
@@ -7,11 +7,11 @@ const HitCard = require('./hit');
 describe('./cards/brain-drain.js', () => {
 	it('can be instantiated with defaults', () => {
 		const brainDrain = new BrainDrainCard();
-		const hit = new HitCard({ damageDice: '1d4' });
+		const hit = new HitCard({ damageDice: '1d4', targetProp: 'int' });
 
 		const stats = `${hit.stats}
 Curse: xp -20
-can reduce xp down to 40, then takes 4 from hp instead.`;
+Can reduce xp down to 40, then takes 4 from hp instead.`;
 
 		expect(brainDrain).to.be.an.instanceof(BrainDrainCard);
 		expect(brainDrain.icon).to.equal('🤡');

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -7,7 +7,7 @@ const { roll } = require('../helpers/chance');
 const { BARD, CLERIC, WIZARD } = require('../constants/creature-classes');
 const { ATTACK_PHASE, DEFENSE_PHASE } = require('../constants/phases');
 const { capitalize } = require('../helpers/capitalize');
-const { AOE, HIDE, PSYCHIC } = require('../constants/card-classes');
+const { AOE, HIDE, MUSICAL, PSYCHIC } = require('../constants/card-classes');
 const { RARE } = require('../helpers/probabilities');
 const { PRICEY } = require('../helpers/costs');
 
@@ -55,7 +55,8 @@ class CloakOfInvisibilityCard extends BaseCard {
 				card.effect = (player, target, ring, activeContestants) => {
 					if (phase === DEFENSE_PHASE &&
 						player !== invisibilityTarget && target === invisibilityTarget &&
-						!card.isCardClass(AOE)) {
+						!card.isCardClass(AOE) &&
+						!card.isCardClass(MUSICAL)) {
 						// If this isn't a psychic attack and your target is invisible, look for a new target
 						if (!card.isCardClass(PSYCHIC)) {
 							const potentialTargets = activeContestants.filter(({ monster }) => (monster !== player && !isInvisible(monster)));

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -7,7 +7,7 @@ const { roll } = require('../helpers/chance');
 const { BARD, CLERIC, WIZARD } = require('../constants/creature-classes');
 const { ATTACK_PHASE, DEFENSE_PHASE } = require('../constants/phases');
 const { capitalize } = require('../helpers/capitalize');
-const { AOE, HIDE, MUSICAL, PSYCHIC } = require('../constants/card-classes');
+const { AOE, HIDE, ACOUSTIC, PSYCHIC } = require('../constants/card-classes');
 const { RARE } = require('../helpers/probabilities');
 const { PRICEY } = require('../helpers/costs');
 
@@ -56,7 +56,7 @@ class CloakOfInvisibilityCard extends BaseCard {
 					if (phase === DEFENSE_PHASE &&
 						player !== invisibilityTarget && target === invisibilityTarget &&
 						!card.isCardClass(AOE) &&
-						!card.isCardClass(MUSICAL)) {
+						!card.isCardClass(ACOUSTIC)) {
 						// If this isn't a psychic attack and your target is invisible, look for a new target
 						if (!card.isCardClass(PSYCHIC)) {
 							const potentialTargets = activeContestants.filter(({ monster }) => (monster !== player && !isInvisible(monster)));

--- a/cards/cloak-of-invisibility.js
+++ b/cards/cloak-of-invisibility.js
@@ -55,18 +55,20 @@ class CloakOfInvisibilityCard extends BaseCard {
 				card.effect = (player, target, ring, activeContestants) => {
 					if (phase === DEFENSE_PHASE &&
 						player !== invisibilityTarget && target === invisibilityTarget &&
-						!card.isCardClass(AOE) &&
-						!card.isCardClass(PSYCHIC)) {
-						const potentialTargets = activeContestants.filter(({ monster }) => (monster !== player && !isInvisible(monster)));
+						!card.isCardClass(AOE)) {
+						// If this isn't a psychic attack and your target is invisible, look for a new target
+						if (!card.isCardClass(PSYCHIC)) {
+							const potentialTargets = activeContestants.filter(({ monster }) => (monster !== player && !isInvisible(monster)));
 
-						if (potentialTargets.length > 0) {
-							const newTarget = sample(potentialTargets).monster;
+							if (potentialTargets.length > 0) {
+								const newTarget = sample(potentialTargets).monster;
 
-							this.emit('narration', {
-								narration: `${player.givenName} doesn't see ${invisibilityTarget.givenName} anywhere and turns ${player.pronouns.his} attention to ${newTarget.givenName} instead.`
-							});
+								this.emit('narration', {
+									narration: `${player.givenName} doesn't see ${invisibilityTarget.givenName} anywhere and turns ${player.pronouns.his} attention to ${newTarget.givenName} instead.`
+								});
 
-							return effect.call(card, player, newTarget, ring, activeContestants);
+								return effect.call(card, player, newTarget, ring, activeContestants);
+							}
 						}
 
 						this.emit('effect', {

--- a/cards/concussion.js
+++ b/cards/concussion.js
@@ -1,0 +1,23 @@
+/* eslint-disable max-len */
+
+const BrainDrainCard = require('./brain-drain');
+
+const { BARBARIAN, FIGHTER } = require('../constants/creature-classes');
+const { MELEE } = require('../constants/card-classes');
+
+class ConcussionCard extends BrainDrainCard {
+	// Set defaults for these values that can be overridden by the options passed in
+	constructor ({
+		icon = '🥊',
+		...rest
+	} = {}) {
+		super({ icon, ...rest });
+	}
+}
+
+ConcussionCard.cardClass = [MELEE];
+ConcussionCard.cardType = 'Concussion';
+ConcussionCard.permittedClassesAndTypes = [BARBARIAN, FIGHTER];
+ConcussionCard.description = 'A hard blow to the head should do the trick.';
+
+module.exports = ConcussionCard;

--- a/cards/concussion.js
+++ b/cards/concussion.js
@@ -1,11 +1,13 @@
 /* eslint-disable max-len */
+const random = require('lodash.random');
 
-const BrainDrainCard = require('./brain-drain');
+const CurseCard = require('./curse');
 
 const { BARBARIAN, FIGHTER } = require('../constants/creature-classes');
 const { MELEE } = require('../constants/card-classes');
+const { REASONABLE } = require('../helpers/costs');
 
-class ConcussionCard extends BrainDrainCard {
+class ConcussionCard extends CurseCard {
 	// Set defaults for these values that can be overridden by the options passed in
 	constructor ({
 		icon = '🥊',
@@ -13,11 +15,26 @@ class ConcussionCard extends BrainDrainCard {
 	} = {}) {
 		super({ icon, ...rest });
 	}
+
+	get curseAmount () {
+		return random(-1, this.options.curseAmount);
+	}
+
+	get curseDescription () {
+		return `Curse: ${this.cursedProp} -1${this.options.curseAmount} depending on how hard the hit is`;
+	}
 }
 
 ConcussionCard.cardClass = [MELEE];
 ConcussionCard.cardType = 'Concussion';
 ConcussionCard.permittedClassesAndTypes = [BARBARIAN, FIGHTER];
 ConcussionCard.description = 'A hard blow to the head should do the trick.';
+ConcussionCard.cost = REASONABLE.cost;
+
+ConcussionCard.defaults = {
+	...CurseCard.defaults,
+	curseAmount: -2,
+	cursedProp: 'int'
+};
 
 module.exports = ConcussionCard;

--- a/cards/concussion.mocha.node.js
+++ b/cards/concussion.mocha.node.js
@@ -1,0 +1,81 @@
+const { expect } = require('../shared/test-setup');
+
+const ConcussionCard = require('./concussion');
+const Gladiator = require('../monsters/gladiator');
+const HitCard = require('./hit');
+
+describe('./cards/brain-drain.js', () => {
+	it('can be instantiated with defaults', () => {
+		const concussion = new ConcussionCard();
+		const hit = new HitCard({ damageDice: '1d4' });
+
+		const stats = `${hit.stats}
+Curse: xp -20
+can reduce xp down to 40, then takes 4 from hp instead.`;
+
+		expect(concussion).to.be.an.instanceof(ConcussionCard);
+		expect(concussion.icon).to.equal('🥊');
+		expect(concussion.curseAmount).to.equal(-20);
+		expect(concussion.cursedProp).to.equal('xp');
+		expect(concussion.stats).to.equal(stats);
+	});
+
+	it('decreases xp', () => {
+		const concussion = new ConcussionCard();
+
+		const player = new Gladiator({ name: 'player' });
+		const target = new Gladiator({ name: 'target' });
+		target.xp = 300;
+
+		expect(target.xp).to.equal(300);
+
+		const ring = {
+			contestants: [
+				{ monster: player },
+				{ monster: target }
+			],
+			channelManager: {
+				sendMessages: () => Promise.resolve()
+			}
+		};
+
+		return concussion.play(player, target, ring)
+			.then((result) => {
+				expect(result).to.equal(true);
+				return expect(target.xp).to.equal(280);
+			});
+	});
+
+	it('makes a difference for their modifiers', () => {
+		const concussion = new ConcussionCard();
+
+		const player = new Gladiator({ name: 'player' });
+		const target = new Gladiator({ name: 'target' });
+		target.xp = 100;
+
+		expect(target.xp).to.equal(100);
+
+		const startingStrMod = target.strModifier;
+		const startingIntMod = target.intModifier;
+		const startingDexMod = target.dexModifier;
+
+		const ring = {
+			contestants: [
+				{ monster: player },
+				{ monster: target }
+			],
+			channelManager: {
+				sendMessages: () => Promise.resolve()
+			}
+		};
+
+		return concussion.play(player, target, ring)
+			.then((result) => {
+				expect(result).to.equal(true);
+				expect(startingStrMod).to.be.above(target.strModifier);
+				expect(startingIntMod).to.be.above(target.intModifier);
+				expect(startingDexMod).to.be.above(target.dexModifier);
+				return expect(target.xp).to.equal(80);
+			});
+	});
+});

--- a/cards/concussion.mocha.node.js
+++ b/cards/concussion.mocha.node.js
@@ -4,30 +4,28 @@ const ConcussionCard = require('./concussion');
 const Gladiator = require('../monsters/gladiator');
 const HitCard = require('./hit');
 
-describe('./cards/brain-drain.js', () => {
+describe('./cards/concussion.js', () => {
 	it('can be instantiated with defaults', () => {
 		const concussion = new ConcussionCard();
 		const hit = new HitCard({ damageDice: '1d4' });
 
 		const stats = `${hit.stats}
-Curse: xp -20
-can reduce xp down to 40, then takes 4 from hp instead.`;
+Curse: int -1-2 depending on how hard the hit is, with a maximum total curse of -3 per level. Afterwards penalties come out of hp instead.`;
 
 		expect(concussion).to.be.an.instanceof(ConcussionCard);
 		expect(concussion.icon).to.equal('🥊');
-		expect(concussion.curseAmount).to.equal(-20);
-		expect(concussion.cursedProp).to.equal('xp');
+		expect(concussion.curseAmount).to.be.above(-3);
+		expect(concussion.curseAmount).to.be.below(0);
+		expect(concussion.cursedProp).to.equal('int');
 		expect(concussion.stats).to.equal(stats);
 	});
 
-	it('decreases xp', () => {
+	it('decreases int', () => {
 		const concussion = new ConcussionCard();
 
 		const player = new Gladiator({ name: 'player' });
 		const target = new Gladiator({ name: 'target' });
-		target.xp = 300;
-
-		expect(target.xp).to.equal(300);
+		const previousInt = target.int;
 
 		const ring = {
 			contestants: [
@@ -42,40 +40,7 @@ can reduce xp down to 40, then takes 4 from hp instead.`;
 		return concussion.play(player, target, ring)
 			.then((result) => {
 				expect(result).to.equal(true);
-				return expect(target.xp).to.equal(280);
-			});
-	});
-
-	it('makes a difference for their modifiers', () => {
-		const concussion = new ConcussionCard();
-
-		const player = new Gladiator({ name: 'player' });
-		const target = new Gladiator({ name: 'target' });
-		target.xp = 100;
-
-		expect(target.xp).to.equal(100);
-
-		const startingStrMod = target.strModifier;
-		const startingIntMod = target.intModifier;
-		const startingDexMod = target.dexModifier;
-
-		const ring = {
-			contestants: [
-				{ monster: player },
-				{ monster: target }
-			],
-			channelManager: {
-				sendMessages: () => Promise.resolve()
-			}
-		};
-
-		return concussion.play(player, target, ring)
-			.then((result) => {
-				expect(result).to.equal(true);
-				expect(startingStrMod).to.be.above(target.strModifier);
-				expect(startingIntMod).to.be.above(target.intModifier);
-				expect(startingDexMod).to.be.above(target.dexModifier);
-				return expect(target.xp).to.equal(80);
+				return expect(target.int).to.be.below(previousInt);
 			});
 	});
 });

--- a/cards/curse.js
+++ b/cards/curse.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 const HitCard = require('./hit');
 
 const { difference } = require('../helpers/difference');
@@ -43,9 +44,12 @@ class CurseCard extends HitCard {
 		return this.options.cursedProp;
 	}
 
+	get curseDescription () {
+		return `Curse: ${this.cursedProp} ${this.curseAmount}`;
+	}
+
 	get stats () {
-		let stats = `Curse: ${this.cursedProp} ${this.curseAmount}
-maximum total curse of -${STATS.MAX_PROP_MODIFICATIONS[this.cursedProp] * 3} per level, afterwards penalties come out of hp instead.`;
+		let stats = `${this.curseDescription}, with a maximum total curse of -${STATS.MAX_PROP_MODIFICATIONS[this.cursedProp] * 3} per level. Afterwards penalties come out of hp instead.`;
 
 		if (this.hasChanceToHit) {
 			stats = `${super.stats}

--- a/cards/curse.mocha.node.js
+++ b/cards/curse.mocha.node.js
@@ -11,8 +11,7 @@ describe('./cards/curse.js', () => {
 		const hit = new Hit({ damageDice: '1d4' });
 
 		const stats = `${hit.stats}
-Curse: ac -1
-maximum total curse of -3 per level, afterwards penalties come out of hp instead.`;
+Curse: ac -1, with a maximum total curse of -3 per level. Afterwards penalties come out of hp instead.`;
 
 		expect(curse).to.be.an.instanceof(Curse);
 		expect(curse.stats).to.equal(stats);

--- a/cards/enthrall.js
+++ b/cards/enthrall.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+const Promise = require('bluebird');
 
 const ImmobilizeCard = require('./immobilize');
 
@@ -36,12 +37,29 @@ class EnthrallCard extends ImmobilizeCard {
 ${super.stats}`;
 	}
 
-	getTargets (player, proposedTarget, ring, activeContestants) { // eslint-disable-line class-methods-use-this
-		return getTarget({
+	getTargets (player) { // eslint-disable-line class-methods-use-this
+		return [player];
+	}
+
+	effect (player, target, ring, activeContestants) {
+		if (player === target) {
+			this.emit('narration', {
+				narration: `${player.givenName} prepares ${player.pronouns.him}self to ${this.actions.IMMOBILIZE} ${player.pronouns.his} targets.`
+			});
+		} else {
+			this.emit('narration', {
+				narration: `${player.givenName} is confused and uses ${player.pronouns.his} power to help ${target.givenName} ${this.actions.IMMOBILIZE} ${target.pronouns.his} targets.`
+			});
+		}
+
+		const targets = getTarget({
 			contestants: activeContestants,
-			playerMonster: player,
+			playerMonster: target,
 			strategy: TARGET_ALL_CONTESTANTS
 		}).map(({ monster }) => monster);
+
+		return Promise.mapSeries(targets, newTarget => super.effect(target, newTarget, ring, activeContestants))
+			.then(results => results.reduce((result, val) => result && val, true));
 	}
 }
 

--- a/cards/helpers/all.js
+++ b/cards/helpers/all.js
@@ -12,6 +12,7 @@ const CalisthenicsCard = require('../calisthenics');
 const CamouflageVestCard = require('../camouflage-vest');
 const CloakOfInvisibilityCard = require('../cloak-of-invisibility');
 const CoilCard = require('../coil');
+const ConcussionCard = require('../concussion');
 const ConstrictCard = require('../constrict');
 const CurseCard = require('../curse');
 const DelayedHit = require('../delayed-hit');
@@ -65,6 +66,7 @@ module.exports = [
 	CamouflageVestCard,
 	CloakOfInvisibilityCard,
 	CoilCard,
+	ConcussionCard,
 	ConstrictCard,
 	CurseCard,
 	DelayedHit,

--- a/cards/immobilize.js
+++ b/cards/immobilize.js
@@ -141,16 +141,20 @@ ${ongoingDamageText}`;
 
 	getAttackRoll (player, target) {
 		const statsBonus = this.targetProp === 'ac' ? player.dexModifier : player[`${this.targetProp}Modifier`];
+
 		return roll({ primaryDice: this.attackDice, modifier: statsBonus + this.getAttackModifier(target), bonusDice: player.bonusAttackDice, crit: true });
 	}
 
 	getImmobilizeRoll (immobilizer, immobilized) {
 		const statsBonus = this.freedomSavingThrowTargetAttr === 'ac' ? immobilizer.dexModifier : immobilizer[`${this.freedomSavingThrowTargetAttr}Modifier`];
-		return roll({ primaryDice: this.attackDice, modifier: statsBonus + this.getAttackModifier(immobilized), bonusDice: immobilizer.bonusAttackDice, crit: true });
+		const attackModifier = immobilized ? this.getAttackModifier(immobilized) : 0;
+
+		return roll({ primaryDice: this.attackDice, modifier: statsBonus + attackModifier, bonusDice: immobilizer.bonusAttackDice, crit: true });
 	}
 
 	getFreedomRoll (immobilizer, immobilized) {
 		const statsBonus = this.freedomSavingThrowTargetAttr === 'ac' ? immobilized.dexModifier : immobilized[`${this.freedomSavingThrowTargetAttr}Modifier`];
+
 		return roll({ primaryDice: this.attackDice, modifier: statsBonus, bonusDice: immobilized.bonusAttackDice, crit: true });
 	}
 

--- a/cards/kalevala.js
+++ b/cards/kalevala.js
@@ -1,6 +1,6 @@
 const HitCard = require('./hit');
 
-const { MUSICAL, PSYCHIC } = require('../constants/card-classes');
+const { ACOUSTIC, PSYCHIC } = require('../constants/card-classes');
 
 const { VERY_RARE } = require('../helpers/probabilities');
 const { PRICEY } = require('../helpers/costs');
@@ -66,7 +66,7 @@ It will now do ${this.damageDice} damage.`
 	}
 }
 
-KalevalaCard.cardClass = [MUSICAL, PSYCHIC];
+KalevalaCard.cardClass = [ACOUSTIC, PSYCHIC];
 KalevalaCard.cardType = 'The Kalevala';
 KalevalaCard.probability = VERY_RARE.probability;
 KalevalaCard.description = 'Steadfast old Väinämöinen himself fashioned this instrument of eternal joy. Tune its pikebone pegs and it may lead you on to victory.'; // eslint-disable-line max-len

--- a/cards/kalevala.js
+++ b/cards/kalevala.js
@@ -1,6 +1,6 @@
 const HitCard = require('./hit');
 
-const { PSYCHIC } = require('../constants/card-classes');
+const { MUSICAL, PSYCHIC } = require('../constants/card-classes');
 
 const { VERY_RARE } = require('../helpers/probabilities');
 const { PRICEY } = require('../helpers/costs');
@@ -58,7 +58,7 @@ It will now do ${this.damageDice} damage.`
 	}
 }
 
-KalevalaCard.cardClass = [PSYCHIC];
+KalevalaCard.cardClass = [MUSICAL, PSYCHIC];
 KalevalaCard.cardType = 'The Kalevala';
 KalevalaCard.probability = VERY_RARE.probability;
 KalevalaCard.description = 'Steadfast old Väinämöinen himself fashioned this instrument of eternal joy. Tune its pikebone pegs and it may lead you on to victory.'; // eslint-disable-line max-len

--- a/cards/kalevala.js
+++ b/cards/kalevala.js
@@ -28,11 +28,11 @@ class KalevalaCard extends HitCard {
 		return `${this.constructor.cardType} (${this.damageDice})`;
 	}
 
-	hitCheck (player, target) {
-		const result = super.hitCheck(player, target);
+	levelUp (amount) {
+		if (this.damageDice !== damageLevels[damageLevels.length - 1]) {
+			let index = damageLevels.indexOf(this.damageDice) + amount;
+			if (index >= damageLevels.length) index = damageLevels.length - 1;
 
-		if (result.strokeOfLuck && this.damageDice !== damageLevels[damageLevels.length - 1]) {
-			const index = damageLevels.indexOf(this.damageDice) + 1;
 			const damageDice = damageLevels[index];
 
 			if (damageDice) {
@@ -53,6 +53,14 @@ It will now do ${this.damageDice} damage.`
 				});
 			}
 		}
+	}
+
+	hitCheck (player, target) {
+		const result = super.hitCheck(player, target);
+
+		if (result.strokeOfLuck) {
+			this.levelUp(1);
+		}
 
 		return result;
 	}
@@ -70,7 +78,8 @@ KalevalaCard.neverForSale = true;
 
 KalevalaCard.defaults = {
 	...HitCard.defaults,
-	damageDice: damageLevels[0] // What begins weak may one day be strong
+	damageDice: damageLevels[0], // What begins weak may one day be strong
+	targetProp: 'int'
 };
 
 KalevalaCard.flavors = {

--- a/cards/kalevala.mocha.node.js
+++ b/cards/kalevala.mocha.node.js
@@ -8,7 +8,7 @@ describe('./cards/kalevala.js', () => {
 		const kalevala = new KalevalaCard();
 
 		expect(kalevala).to.be.an.instanceof(KalevalaCard);
-		expect(kalevala.stats).to.equal('Hit: 1d20 vs ac / Damage: 1d4');
+		expect(kalevala.stats).to.equal('Hit: 1d20 vs int / Damage: 1d4');
 		expect(kalevala.cardType).to.equal('The Kalevala (1d4)');
 		expect(kalevala.icon).to.equal('🎻');
 	});
@@ -17,7 +17,7 @@ describe('./cards/kalevala.js', () => {
 		const kalevala = new KalevalaCard(JSON.parse('{"damageDice":"1d6","icon":"🎻"}'));
 
 		expect(kalevala).to.be.an.instanceof(KalevalaCard);
-		expect(kalevala.stats).to.equal('Hit: 1d20 vs ac / Damage: 1d6');
+		expect(kalevala.stats).to.equal('Hit: 1d20 vs int / Damage: 1d6');
 		expect(kalevala.cardType).to.equal('The Kalevala (1d6)');
 	});
 

--- a/cards/vengeful-rampage.mocha.node.js
+++ b/cards/vengeful-rampage.mocha.node.js
@@ -20,13 +20,13 @@ describe('./cards/vengeful-rampage.js', () => {
 
 		const roll = venegefulRampage.getDamageRoll(player, target);
 
-		expect(roll.modifier).to.equal(2);
+		expect(roll.modifier).to.equal(4);
 	});
 
 	it('does max damage equal to double player damage modifier', () => {
 		const venegefulRampage = new VenegefulRampageCard();
 
-		const player = new Basilisk({ name: 'player', hp: 2, hpVariance: 0, strModifier: 6 });
+		const player = new Basilisk({ name: 'player', hp: 4, hpVariance: 0, strModifier: 6 });
 		const target = new Basilisk({ name: 'target' });
 
 		const roll = venegefulRampage.getDamageRoll(player, target);

--- a/characters/helpers/random.js
+++ b/characters/helpers/random.js
@@ -57,7 +57,7 @@ module.exports = ({
 
 	let cleanBossDeck;
 	if (isBoss) {
-		const weakTypes = ['Flee', 'Harden', 'Heal', 'Hit', 'WhiskeyShot'];
+		const weakTypes = ['Flee', 'Harden', 'Heal', 'Hit', 'Whiskey Shot'];
 		cleanBossDeck = deck => deck.filter(card => !weakTypes.includes(card.cardType));
 	} else {
 		cleanBossDeck = deck => deck;
@@ -68,6 +68,13 @@ module.exports = ({
 		let deck = cleanBossDeck(getMinimumDeck());
 		deck = cleanBossDeck(fillDeck(deck, {}, character));
 		character.deck = fillDeck(deck, {}, character);
+
+		// Also level up some Kalevalas
+		character.deck.forEach((card) => {
+			if (typeof card.levelUp === 'function') {
+				card.levelUp(random(0, 6));
+			}
+		});
 	}
 
 	// Equip the monster

--- a/constants/card-classes.js
+++ b/constants/card-classes.js
@@ -4,6 +4,7 @@ module.exports = {
 	HEAL: 'Heal',
 	HIDE: 'Hide',
 	MELEE: 'Melee',
+	MUSICAL: 'Musical',
 	POISON: 'Poison',
 	PSYCHIC: 'Psychic'
 };

--- a/monsters/basilisk.js
+++ b/monsters/basilisk.js
@@ -57,6 +57,7 @@ class Basilisk extends BaseMonster {
 Basilisk.creatureType = BASILISK;
 Basilisk.class = BARBARIAN;
 Basilisk.acVariance = 2;
+Basilisk.hpVariance = 2;
 Basilisk.description =
 `
 The basilisk, often called the “King of Serpents,” is in fact not a serpent at all, but rather an eight-legged reptile with a nasty disposition and the ability to turn creatures to stone with its gaze. Folklore holds that, much like the cockatrice, the first basilisks hatched from eggs laid by snakes and incubated by roosters, but little in the basilisk’s physiology lends any credence to this claim.

--- a/monsters/gladiator.js
+++ b/monsters/gladiator.js
@@ -56,7 +56,7 @@ class Gladiator extends BaseMonster {
 
 Gladiator.creatureType = GLADIATOR;
 Gladiator.class = FIGHTER;
-Gladiator.hpVariance = 2;
+Gladiator.hpVariance = 3;
 Gladiator.description =
 `
 The gladiator is a professional duelist. Many are born slaves and reared in gladiatorial schools, until such time as they earn their freedom in battle, escape, or rebel. Some join dueling academies voluntarily, seeking fame or fortune in prize fights and honor matches. Some gladiators began as warriors from faroff lands, captured in battle and forced to fight to the death, while others are condemned criminals, paying their debt to society by participating in ritual combat for the public. Whatever their station or background, the gladiator has been hardened by combat and has learned to anticipate a wily foe. While gladiatorial matches often follow a prescribed, even ritual format, the gladiator must always be ready for the possibility that they will be thrown into a situation with unusual weapons, conditions, or opponents. Some arena fighters specialize in fighting exotic animals and monsters.

--- a/monsters/minotaur.js
+++ b/monsters/minotaur.js
@@ -56,7 +56,7 @@ class Minotaur extends BaseMonster {
 Minotaur.creatureType = MINOTAUR;
 Minotaur.class = BARBARIAN;
 Minotaur.acVariance = -1;
-Minotaur.hpVariance = 3;
+Minotaur.hpVariance = 4;
 Minotaur.description =
 `
 The bull-folk have many of the same characteristics as the bulls they resemble. Both genders have horned heads covered with shaggy hair. Warriors braid their hair with teeth or other tokens of fallen enemies. The thick hair covering their large bodies varies widely in color, from bright white to medium red-browns to dark brown and black. Many minotaurs shave or dye their fur in patterns signifying their allegiances and beliefs. Other methods of decoration include brands, ritual scars, and gilding or carving their horns.


### PR DESCRIPTION
Adds a concussion card to go with brain drain. Also changes the targeting of enthrall & entrance (which will impact how it's affected by Sandstorm, etc). Finally, changes the way that cloaks / camo handle psychic cards - the caster will have to roll to see through the invisibility but _won't_ look elsewhere for a target.