### PR TITLE
Adds ring summary

### DIFF
--- a/commands/look-at.js
+++ b/commands/look-at.js
@@ -11,8 +11,10 @@ function lookAtAction ({ channel, character, game, results }) {
 				case 'deck':
 				case 'cards':
 					return character.lookAtCards(channel, thing);
-				case 'ring':
-					return game.lookAtRing(channel, thing);
+				case 'ring': {
+					const summary = thing === 'summary';
+					return game.lookAtRing(channel, undefined, true, summary);
+				}
 				case 'monsters in': {
 					thing = thing.replace(/the /i, '');
 					const ringName = thing === 'ring' ? undefined : thing;

--- a/game.js
+++ b/game.js
@@ -347,8 +347,8 @@ class Game extends BaseClass {
 		return this.exploration;
 	}
 
-	lookAtRing (channel, ringName = 'main', showCharacters) {
-		return this.getRing(ringName).look(channel, showCharacters);
+	lookAtRing (channel, ringName = 'main', showCharacters, summary) {
+		return this.getRing(ringName).look(channel, showCharacters, summary);
 	}
 
 	lookAtRingCards (channel, ringName = 'main') {

--- a/ring/index.js
+++ b/ring/index.js
@@ -215,10 +215,9 @@ Sent the following monster into the ring:
 				});
 			}))
 			.then(() => {
-				const summary = this.contestants.map((contestant) => {
-					const { monster } = contestant;
-					return `${monster.identity} - ${monster.creatureType} (${monster.level})`;
-				});
+				const summary = this.contestants.map(({ monster }) => (
+					`${monster.identity} - ${monster.creatureType} (${monster.level})`
+				));
 
 				return channelManager.queueMessage({
 					announce:

--- a/ring/index.js
+++ b/ring/index.js
@@ -192,13 +192,12 @@ class Ring extends BaseClass {
 			return Promise.resolve()
 				.then(() => {
 					const monsters = this.contestants.map(({ monster }) => (
-						`${monster.identity} - ${monster.creatureType} (${monster.level})`
+						`${monster.identity} - ${monster.creatureType} (${monster.displayLevel.replace('level ', '')})`
 					));
 
 					return channelManager.queueMessage({
 						announce:
 `###########################################
-Ring summary:
 ${monsters.join('\n')}
 ###########################################`,
 						channel,
@@ -211,7 +210,7 @@ ${monsters.join('\n')}
 		return Promise.resolve()
 			.then(() => channelManager.queueMessage({
 				announce:
-`#####################NOOOOOOOOO######################
+`###########################################
 There ${length === 1 ? 'is one contestant' : `are ${length} contestants`} in the ring.
 ###########################################`,
 				channel,
@@ -235,20 +234,6 @@ Sent the following monster into the ring:
 					channelName
 				});
 			}))
-// 			.then(() => {
-// 				const summary = this.contestants.map(({ monster }) => (
-// 					`${monster.identity} - ${monster.creatureType} (${monster.level})`
-// 				));
-
-// 				return channelManager.queueMessage({
-// 					announce:
-// `Ring summary:
-// ${summary.join('\n')}
-// ###########################################`,
-// 					channel,
-// 					channelName
-// 				});
-// 			})
 			.then(() => channelManager.sendMessages());
 	}
 

--- a/ring/index.js
+++ b/ring/index.js
@@ -176,7 +176,7 @@ class Ring extends BaseClass {
 		return this.contestants.find(contestant => (contestant.character === character && contestant.monster === monster));
 	}
 
-	look (channel, showCharacters = true) {
+	look (channel, showCharacters = true, summary = false) {
 		const { length } = this.contestants;
 
 		if (length < 1) {
@@ -187,10 +187,31 @@ class Ring extends BaseClass {
 		}
 
 		const { channelManager, channelName } = channel;
+
+		if (summary) {
+			return Promise.resolve()
+				.then(() => {
+					const monsters = this.contestants.map(({ monster }) => (
+						`${monster.identity} - ${monster.creatureType} (${monster.level})`
+					));
+
+					return channelManager.queueMessage({
+						announce:
+`###########################################
+Ring summary:
+${monsters.join('\n')}
+###########################################`,
+						channel,
+						channelName
+					});
+				})
+				.then(() => channelManager.sendMessages());
+		}
+
 		return Promise.resolve()
 			.then(() => channelManager.queueMessage({
 				announce:
-`###########################################
+`#####################NOOOOOOOOO######################
 There ${length === 1 ? 'is one contestant' : `are ${length} contestants`} in the ring.
 ###########################################`,
 				channel,
@@ -214,20 +235,20 @@ Sent the following monster into the ring:
 					channelName
 				});
 			}))
-			.then(() => {
-				const summary = this.contestants.map(({ monster }) => (
-					`${monster.identity} - ${monster.creatureType} (${monster.level})`
-				));
+// 			.then(() => {
+// 				const summary = this.contestants.map(({ monster }) => (
+// 					`${monster.identity} - ${monster.creatureType} (${monster.level})`
+// 				));
 
-				return channelManager.queueMessage({
-					announce:
-`Ring summary:
-${summary.join('\n')}
-###########################################`,
-					channel,
-					channelName
-				});
-			})
+// 				return channelManager.queueMessage({
+// 					announce:
+// `Ring summary:
+// ${summary.join('\n')}
+// ###########################################`,
+// 					channel,
+// 					channelName
+// 				});
+// 			})
 			.then(() => channelManager.sendMessages());
 	}
 

--- a/ring/index.js
+++ b/ring/index.js
@@ -214,6 +214,21 @@ Sent the following monster into the ring:
 					channelName
 				});
 			}))
+			.then(() => {
+				const summary = this.contestants.map((contestant) => {
+					const { monster } = contestant;
+					return `${monster.identity} - ${monster.creatureType} (${monster.level})`;
+				});
+
+				return channelManager.queueMessage({
+					announce:
+`Ring summary:
+${summary.join('\n')}
+###########################################`,
+					channel,
+					channelName
+				});
+			})
 			.then(() => channelManager.sendMessages());
 	}
 


### PR DESCRIPTION
Shows a ring summary with `look at ring summary`

<img width="526" alt="screenshot 2018-02-21 10 22 34" src="https://user-images.githubusercontent.com/1715111/36492393-a75645ce-16f2-11e8-8f7c-ab8141d20574.png">

To test:
- Pull changes
- Copy over to local jane (manually or with `npm link`)
- Start jane
- Send monsters to the ring
- Run `dm look at ring summary`
