### PR TITLE
docs(roadmap): plan leaderboard and fight stats features

### DIFF
--- a/docs/roadmap/13-leaderboard.md
+++ b/docs/roadmap/13-leaderboard.md
@@ -1,0 +1,206 @@
+# Leaderboard
+
+**Category**: Feature  
+**Priority**: Medium (post-launch)  
+**Status**: Not started
+
+## Background
+
+The engine already has rudimentary in-memory rankings: `lookAtCharacterRankings` and `lookAtMonsterRankings` sort the current room's characters and monsters by XP and return a top-5 text list. This works for a single room that's continuously running, but has two hard limits:
+
+1. **Stats are lost on restart.** Player XP and monster battle records survive (they're in the state snapshot), but the ranking *view* is computed on demand from live in-memory state. If you want historical stats — career win rates, all-time records — the data isn't there.
+2. **Rankings are room-scoped.** There's no concept of a global leaderboard across rooms.
+
+As multi-room play ramps up, players will want to know who the top Beastmasters are across the whole server, not just in their own room.
+
+## Design Goals
+
+- **Persisted stats**: win/loss/draw record and XP stored in the database, not just in the ephemeral game snapshot. Survives restarts, room resets, and monster dismissals.
+- **Two scopes**: per-room rankings (who's winning *here*) and global rankings (who's winning *anywhere*).
+- **Two surfaces**: a dedicated web UI leaderboard page and the existing text command interface.
+- **Sortable**: sort by XP, wins, win rate, or coins. Default is XP (matches current behavior).
+- **Two leaderboard types**: top players (Beastmasters) and top monsters (creatures). Both already exist as text commands; extend them with persistence and global scope.
+- **No breaking changes to text commands**: "look at character rankings" and "look at monster rankings" keep working as before, now backed by DB data.
+
+## Architecture
+
+### New Database Tables
+
+```typescript
+// room_player_stats — career stats per player per room
+room_player_stats: {
+  roomId: uuid references rooms(id) on delete cascade,
+  userId: uuid references profiles(id) on delete cascade,
+  xp: integer not null default 0,
+  wins: integer not null default 0,
+  losses: integer not null default 0,
+  draws: integer not null default 0,
+  coinsEarned: integer not null default 0,
+  updatedAt: timestamp default now(),
+  primary key (roomId, userId)
+}
+
+// room_monster_stats — career stats per monster per room
+// Monster identity uses the stable string ID embedded in the game state snapshot.
+room_monster_stats: {
+  roomId: uuid references rooms(id) on delete cascade,
+  monsterId: text not null,       // stable engine-generated creature ID
+  ownerUserId: uuid references profiles(id),
+  displayName: text not null,
+  monsterType: text not null,     // 'Basilisk' | 'Gladiator' etc.
+  xp: integer not null default 0,
+  level: integer not null default 1,
+  wins: integer not null default 0,
+  losses: integer not null default 0,
+  draws: integer not null default 0,
+  updatedAt: timestamp default now(),
+  primary key (roomId, monsterId)
+}
+```
+
+Global rankings are derived from these tables at query time using aggregate views or simple `GROUP BY userId` across all rooms, no separate global table needed.
+
+### Stat Update Flow
+
+Stats are updated by a server-side event subscriber that watches `ring.win`, `ring.loss`, `ring.draw`, and `ring.fled` events:
+
+```
+ring.win event emitted
+  ↓
+FightStatsSubscriber (packages/server/src/fight-stats.ts)
+  ↓
+upsert room_player_stats (winner +1 win, loser +1 loss)
+upsert room_monster_stats (winning monster +1 win, losing monster +1 loss)
+```
+
+The event payload for `ring.win` / `ring.loss` already carries contestant info (monster ID, owner user ID, XP delta). The subscriber reads these and writes to the DB. This is the same pattern used by `EventPersister` (`event-persister.ts`) for writing raw events — a second lightweight subscriber alongside it.
+
+XP changes from `ring.xp` events update both the player's and monster's `xp` column. Coin earnings from `ring.win` / `ring.cardDrop` events update `coinsEarned`.
+
+**On stat write failures**: log the error, don't crash the game. Stat writes are best-effort analytics — a missed write means a fight isn't counted, which is acceptable. Do not retry in a tight loop.
+
+### API: New tRPC Procedures
+
+Add a `leaderboard` router:
+
+```typescript
+leaderboard.roomPlayers({ roomId, limit?, sortBy? })
+// → { rank, displayName, xp, wins, losses, draws, winRate }[]
+// sortBy: 'xp' (default) | 'wins' | 'winRate' | 'coins'
+// limit: 10 default, max 50
+
+leaderboard.roomMonsters({ roomId, limit?, sortBy? })
+// → { rank, displayName, monsterType, ownerName, xp, level, wins, losses, winRate }[]
+
+leaderboard.globalPlayers({ limit?, sortBy? })
+// → { rank, displayName, xp, wins, losses, draws, winRate, roomCount }[]
+// Aggregates across all rooms for each userId
+
+leaderboard.globalMonsters({ limit?, sortBy? })
+// → { rank, displayName, monsterType, ownerName, xp, level, wins, losses, winRate }[]
+```
+
+All procedures are `protectedProcedure` (require auth). Global procedures don't require room membership — the data is public within the game.
+
+### Text Command Interface
+
+The engine's existing `look at character rankings` and `look at monster rankings` commands remain the entry point. Instead of reading from in-memory state, they call the new tRPC leaderboard procedures (or the underlying DB query directly via the server's `RoomManager`).
+
+New command aliases to consider:
+
+```
+leaderboard
+show leaderboard
+look at leaderboard
+top players
+top monsters
+```
+
+All route to the same room-scoped leaderboard. The text output format stays the same (the pre-rendered `text` field on the GameEvent), but now shows wins and win rate alongside XP:
+
+```
+Top 5 Players by XP:
+
+ Vlad        305 XP   12W  3L  80%
+ JaneSmith   198 XP    7W  5L  58%
+ ...
+```
+
+For a "global" leaderboard via text: `global leaderboard` or `look at global rankings` — a new command variant that queries across rooms and formats the same way.
+
+### Web UI: Leaderboard Page
+
+The leaderboard web page **breaks from the terminal aesthetic** — the same pattern established in `06a-web-app.md` for room management UIs. It's a normal web page with sortable tables, not a terminal pane.
+
+**Navigation**: accessible via a "Leaderboard" tab or link in the top header bar of the web app, visible from any room view. The header is already the designated place for nav that doesn't consume the pane's horizontal space.
+
+**Layout**:
+
+```
+┌───────────────────────────────────────────────────────┐
+│  DECK MONSTERS   [Room: Tavern Basement ▾]   [⚔ Ring] │
+│  [Leaderboard]   [Profile]   [Settings]               │
+├───────────────────────────────────────────────────────┤
+│                                                       │
+│  Leaderboard                                          │
+│                                                       │
+│  ○ This Room  ○ Global     Players | Monsters         │
+│                                                       │
+│  Sort by: [ XP ▾ ]                                    │
+│                                                       │
+│  #   Name          XP     W    L   Win Rate           │
+│  1   Vlad         305    12    3    80%               │
+│  2   JaneSmith    198     7    5    58%               │
+│  ...                                                  │
+└───────────────────────────────────────────────────────┘
+```
+
+Two toggle groups:
+- **Scope**: This Room / Global
+- **Type**: Players / Monsters
+
+One sort dropdown. No pagination for now — show top 25. "This Room" is the default when visiting from inside a room; "Global" is the default when visiting without a room context (e.g., from the home screen).
+
+The monster leaderboard adds an "Owner" column and a "Type" column (Basilisk, Gladiator, etc.).
+
+**Data freshness**: the leaderboard page polls or re-fetches on focus. No real-time subscription needed here — leaderboard data changing second-by-second is fine to show stale for a minute.
+
+## Migration: Backfilling Stats
+
+When this feature is deployed, existing rooms already have character XP and battle records in the game state snapshot. A one-time backfill job should read each room's state blob, deserialize it, and write the in-memory stats into the new DB tables. This ensures the leaderboard has data on day one rather than starting from zero.
+
+The backfill runs as a one-off script, not as part of the regular server startup. After the backfill, the event subscriber keeps stats current.
+
+## Non-Goals
+
+- **ELO or ladder ranking**: a simple win count and XP sort is enough for now. Skill-based matchmaking and structured seasons are post-launch concerns.
+- **Per-fight detailed stats on the leaderboard page**: that belongs to the fight stats document (`14-fight-stats.md`).
+- **Leaderboard on Discord**: Discord embeds work but this is extra connector work. The text command interface is sufficient for Discord users.
+
+## Tasks
+
+### Database
+- [ ] Add `room_player_stats` table to Drizzle schema + Supabase migration
+- [ ] Add `room_monster_stats` table to Drizzle schema + Supabase migration
+- [ ] Write one-time backfill script to seed tables from existing state blobs
+
+### Server
+- [ ] Implement `FightStatsSubscriber` — listens to `ring.win`, `ring.loss`, `ring.draw`, `ring.fled`, `ring.xp`, `ring.cardDrop` and upserts stats tables
+- [ ] Register `FightStatsSubscriber` alongside `EventPersister` in server startup
+- [ ] Add `leaderboard` tRPC router with `roomPlayers`, `roomMonsters`, `globalPlayers`, `globalMonsters` procedures
+- [ ] Update `lookAtCharacterRankings` and `lookAtMonsterRankings` in `Game` to read from DB (via `RoomManager`) instead of in-memory sort
+
+### Engine / Commands
+- [ ] Add "leaderboard", "global leaderboard", "top players", "top monsters" command aliases to `commands/look-at.ts`
+
+### Web UI
+- [ ] Add "Leaderboard" link/tab to top navigation header
+- [ ] Implement `LeaderboardPage` component (scope toggle, type toggle, sort dropdown, table)
+- [ ] Wire `LeaderboardPage` to tRPC `leaderboard.*` procedures
+- [ ] Pre-select "This Room" scope when navigating from a room context
+
+## Open Questions
+
+- **Global leaderboard privacy**: should players be able to opt out of appearing in the global leaderboard? Easy to add a `profileVisibility` flag on `profiles`. Probably not needed for a private game server, but worth noting.
+- **Win rate denominator**: should "win rate" exclude draws? Current thinking: W / (W + L), draws excluded from the denominator. Make it explicit in the UI.
+- **Monster identity across resets**: monster IDs are stable within a room's lifetime, but if a room is reset, old stats for those monster IDs become orphaned. Two options: soft-delete old stats on reset, or just let them accumulate (stale data is fine). Leaning toward clear on room reset.

--- a/docs/roadmap/14-fight-stats.md
+++ b/docs/roadmap/14-fight-stats.md
@@ -1,0 +1,251 @@
+# Fight Stats and Catch-Up Feed
+
+**Category**: Feature  
+**Priority**: Medium (post-launch)  
+**Status**: Not started
+
+## Background
+
+The ring runs continuously, fighting every 60 seconds. Players join rooms, get invested in their monsters, and then go to sleep, go to work, or simply close the tab. When they come back, they have no idea what happened. Did Stonefang win? Did my monster die? How many fights happened?
+
+The engine's `ring.battles = []` array was intentionally never persisted (noted in `CLAUDE.md` as known debt). The `room_events` table now provides the raw event log, but there's no higher-level view over it — no "these 17 events constitute Fight #42" abstraction, and no dedicated UI to browse recent fights.
+
+The web app already streams live events via the `ringFeed` WebSocket. The catch-up problem (reconnecting mid-session, last-seen event ID) is partially solved. But this feature is about a different kind of catch-up: arriving *hours later* and getting a readable summary of what you missed, not just a raw event replay.
+
+There's also an analytics angle: players want to know if their deck is working. "My monster fought 10 times and lost 8 — maybe I should equip different cards."
+
+## Design Goals
+
+- **Catch-up summary**: a concise human-readable account of what happened in a room since a given time, suitable for reading in 30 seconds.
+- **Per-fight breakdown**: detailed view of a specific fight — participants, rounds, card plays, outcome, XP changes.
+- **Text command access**: "what happened" or "show recent fights" as a text command in the console, because Discord users need it too.
+- **Web UI surface**: a "Recent Fights" section in the ring pane and/or a dedicated fight log page.
+- **Low overhead**: build on the existing `room_events` data; no new real-time infrastructure.
+
+## Architecture
+
+### Fight Summaries Table
+
+Raw `room_events` are granular — many events per fight. A fight summary is a derived, human-queryable record:
+
+```typescript
+// fight_summaries — one row per completed ring fight
+fight_summaries: {
+  id: bigserial primary key,
+  roomId: uuid references rooms(id) on delete cascade,
+  fightNumber: integer not null,         // sequential per room (1, 2, 3, ...)
+  startedAt: timestamp not null,
+  endedAt: timestamp not null,
+  outcome: text not null,                // 'win' | 'draw' | 'fled' | 'permaDeath'
+  winnerMonsterId: text,                 // null on draw
+  winnerMonsterName: text,
+  winnerOwnerUserId: uuid,
+  loserMonsterId: text,
+  loserMonsterName: text,
+  loserOwnerUserId: uuid,
+  roundCount: integer not null,
+  winnerXpGained: integer not null default 0,
+  loserXpGained: integer not null default 0,
+  cardDropName: text,                    // null if no card dropped
+  notableCards: text[],                  // card types played that caused significant effects
+  startEventId: bigint references room_events(id),
+  endEventId: bigint references room_events(id),
+}
+// index on (roomId, endedAt) — for "recent fights in room X" queries
+// index on (roomId, winnerMonsterId) — for per-monster history queries
+// index on (roomId, loserMonsterId)
+```
+
+`fightNumber` is a monotonically increasing counter per room, stored on the `rooms` table or derived from a `room_fight_counter` sequence. It gives fights a stable human-readable identity ("Fight #42").
+
+### Population: FightSummaryWriter
+
+A server-side event subscriber (`packages/server/src/fight-summary-writer.ts`) watches the event stream and assembles fight summaries:
+
+1. On `ring.fight` event: record fight start (timestamp, participants from payload).
+2. On each `card.played` event: accumulate notable cards (e.g., cards dealing ≥ 50% of a creature's HP in one hit).
+3. On `ring.win`, `ring.draw`, `ring.fled`, or `ring.permaDeath` event: write the completed `fight_summary` row.
+
+The subscriber is stateful per room — it holds an in-memory pending fight record while the fight is in progress. This state is reconstructed on server restart from recent `room_events` (any `ring.fight` event without a subsequent outcome event means a fight was interrupted; mark it as abandoned or simply skip it).
+
+**Why not derive summaries from `room_events` at query time?** For ad-hoc queries with low volume it would work, but it requires joining and scanning potentially many event rows per fight. Pre-computing summaries is cheaper at read time and allows indexes on fight attributes (outcome, winner, loser) without scanning the raw event log.
+
+### API: tRPC Procedures
+
+Add `fightStats` procedures to the `game` router:
+
+```typescript
+game.recentFights({ roomId, limit?, before? })
+// → FightSummary[]
+// limit: 10 default, max 50
+// before: timestamp — return fights that ended before this time (pagination cursor)
+// Accessible to any room member.
+// Sorted by endedAt DESC.
+
+game.fight({ roomId, fightNumber })
+// → FightSummary & { events: GameEvent[] }
+// Returns the summary plus the raw events for that fight,
+// so the client can replay/render a detailed breakdown.
+
+game.monsterFightHistory({ roomId, monsterId, limit? })
+// → FightSummary[]
+// All fights in this room involving a specific monster.
+
+game.catchUp({ roomId, since })
+// → { fightCount: number, summaries: FightSummary[], textSummary: string }
+// since: ISO timestamp (e.g., "2026-04-09T22:00:00Z")
+// textSummary is a pre-rendered multi-line string the text command can emit directly.
+```
+
+### Text Command: "What Happened"
+
+New command aliases wired in `commands/look-at.ts` (or a new `commands/history.ts` handler):
+
+```
+what happened
+catch me up
+show recent fights
+show fight history
+look at fight log
+```
+
+These call `game.catchUp({ roomId, since: lastSeenAt })` and emit the `textSummary` field as an announcement. If the player's `lastSeenAt` isn't tracked, default to the last hour.
+
+Example output:
+
+```
+Since you were last here (3 hours ago):
+
+Fight #38 — Stonefang defeated Whisperwind in 4 rounds
+Fight #39 — Mirebell fled from The Horned Terror
+Fight #40 — Draw between Copperclaw and The Horned Terror
+Fight #41 — Stonefang defeated Mirebell in 6 rounds  ☠ Mirebell perished
+Fight #42 — Stonefang defeated Copperclaw in 3 rounds (card drop: Brain Drain)
+
+Stonefang is on a 3-fight winning streak.
+```
+
+The summary highlights win streaks, perma-deaths, and card drops because those are the things players actually care about after a long absence.
+
+If nothing happened: "No fights since you were last here."
+
+### "Last Seen" Tracking
+
+To make "what happened since you were away" automatic, track each user's last active timestamp per room:
+
+```typescript
+// Add to room_members:
+lastSeenAt: timestamp  // updated on every command or ringFeed subscription
+```
+
+When the player issues the catch-up command, `lastSeenAt` is the implicit `since` parameter. After the summary is delivered, `lastSeenAt` is updated.
+
+Alternatively, the web client can pass an explicit `since` parameter (its local last-active timestamp), avoiding server-side state entirely. Both approaches work; the server-side tracking is more robust for cross-device scenarios.
+
+### Web UI: Two Surfaces
+
+**Surface 1: Live fight ticker in the Ring pane** (always visible)
+
+After the ring event feed, show the last completed fight as a brief one-liner below the scrolling text:
+
+```
+Last fight: Stonefang defeated Whisperwind (#38) — 2 min ago
+```
+
+Clicking it expands to the full fight breakdown.
+
+**Surface 2: Fight Log page/tab**
+
+A dedicated page (normal web UI, not terminal aesthetic) showing a paginated list of fight summaries:
+
+```
+┌───────────────────────────────────────────────────────┐
+│  DECK MONSTERS   [Room: Tavern Basement ▾]   [⚔ Ring] │
+│  [Fight Log]   [Leaderboard]   [Profile]              │
+├───────────────────────────────────────────────────────┤
+│                                                       │
+│  Fight Log — Tavern Basement                         │
+│                                                       │
+│  #42   Stonefang vs Copperclaw          3 min ago    │
+│        Stonefang won in 3 rounds                     │
+│        ✦ Card drop: Brain Drain                      │
+│                                                       │
+│  #41   Stonefang vs Mirebell           17 min ago    │
+│        Stonefang won in 6 rounds  ☠ Mirebell perished│
+│                                                       │
+│  #40   Copperclaw vs The Horned Terror  31 min ago   │
+│        Draw after 8 rounds                           │
+│        [Show card-by-card breakdown]                 │
+│                                                       │
+│  ... [Load 10 more]                                  │
+└───────────────────────────────────────────────────────┘
+```
+
+Clicking a fight row expands it to show round-by-round card plays from the raw event log. This is the "card-by-card breakdown" link.
+
+The Fight Log is accessible via a tab in the top navigation, same as Leaderboard. When a user arrives at the room after being away, the web app could automatically surface an inline catch-up banner:
+
+```
+╔══════════════════════════════════════╗
+║  You were away for 3h 12m            ║
+║  5 fights happened. [See what I missed] ║
+╚══════════════════════════════════════╝
+```
+
+## Fight Event Payload Requirements
+
+For `FightSummaryWriter` to populate summaries correctly, the `ring.win`, `ring.loss`, `ring.draw`, `ring.fled`, and `ring.permaDeath` event payloads need to carry structured participant data. Review current payloads in `packages/engine/src/announcements/` and ensure they include at minimum:
+
+- `winnerMonsterId`, `winnerMonsterName`, `winnerOwnerUserId`
+- `loserMonsterId`, `loserMonsterName`, `loserOwnerUserId`
+- `xpGained` for each participant
+- `cardDropName` if applicable
+
+If any of these are missing, they need to be added to the relevant announcement modules during implementation. The `text` field already has the human-readable version; this adds the machine-readable structure alongside it.
+
+## Relationship to Leaderboard (13-leaderboard.md)
+
+Fight stats and leaderboard are complementary:
+
+- The **leaderboard** answers "who's winning overall?" — aggregate career stats.
+- **Fight stats** answer "what just happened?" and "how did my monster do in that fight?" — per-fight detail.
+
+Both are populated from ring outcome events. The `FightStatsSubscriber` from `13-leaderboard.md` and the `FightSummaryWriter` here can share a single subscriber that handles all ring outcome events, or remain separate for clarity. Separate is probably cleaner — one writes to stats tables, one writes to `fight_summaries`.
+
+## Non-Goals
+
+- **Real-time fight animation**: replaying a fight card-by-card with delays and animations is a nice future feature (and ties into `09-graphics.md`) but out of scope here. The breakdown is static — all cards shown at once.
+- **Fight search/filtering**: no search by card type or date range for now. Pagination and per-monster filtering are sufficient.
+- **Fight replay on Discord**: Discord users get the text command catch-up. A rich embed showing round-by-round detail is post-launch.
+
+## Tasks
+
+### Database
+- [ ] Add `fight_summaries` table to Drizzle schema + Supabase migration
+- [ ] Add `lastSeenAt` column to `room_members` table
+- [ ] Add index on `fight_summaries(roomId, endedAt)` and per-monster indexes
+
+### Server
+- [ ] Implement `FightSummaryWriter` — stateful event subscriber that assembles and writes fight summaries
+- [ ] Register `FightSummaryWriter` in server startup alongside `EventPersister` and `FightStatsSubscriber`
+- [ ] Update `lastSeenAt` in `room_members` on each `game.command` mutation and `game.ringFeed` subscription
+- [ ] Add `fightStats` tRPC procedures: `recentFights`, `fight`, `monsterFightHistory`, `catchUp`
+- [ ] Ensure `ring.win` / `ring.loss` / `ring.draw` / `ring.fled` / `ring.permaDeath` payloads carry structured participant data; update announcement modules if needed
+
+### Engine / Commands
+- [ ] Add "what happened", "catch me up", "show recent fights", "show fight history" command aliases
+- [ ] Implement the catch-up text command handler — calls `catchUp` API, formats and emits the text summary
+
+### Web UI
+- [ ] Add "Fight Log" tab/link to top navigation header
+- [ ] Implement `FightLogPage` component — paginated list of fight summaries, expandable rows
+- [ ] Implement inline catch-up banner shown on room join after absence (threshold: > 30 min away, > 0 fights)
+- [ ] Add "last fight" one-liner ticker to the bottom of the Ring pane
+- [ ] Implement expandable fight detail view (card-by-card breakdown from raw events)
+
+## Open Questions
+
+- **How long to retain fight summaries?** The raw `room_events` table has an open question about retention policy (7 days suggested in `02-backend-hosting.md`). Fight summaries are smaller and more valuable to keep longer — 30 or 90 days seems right. Decide during implementation.
+- **Streak tracking**: "Stonefang is on a 3-fight winning streak" is compelling UX. Where does the current streak live — computed from recent `fight_summaries` at query time (simple, slightly expensive), or maintained as a counter on `room_monster_stats` (cheap to read, stateful)? Leaning toward computing it at query time for the first version.
+- **Interrupted fights**: if the server restarts mid-fight, the `FightSummaryWriter`'s in-memory pending fight state is lost. These fights should be marked as abandoned (not win/loss/draw) rather than silently omitted. Add an `'abandoned'` outcome variant.
+- **Multi-monster rings**: the current engine supports 2–12 monsters in the ring. Fight summaries assume 1v1 (winner + loser). Multi-monster fights need a richer participant array. Design the schema with this in mind even if the first implementation only handles 1v1 — use an array of participant objects rather than separate winner/loser columns.


### PR DESCRIPTION
Adds two new roadmap documents:

- 13-leaderboard.md: persisted player and monster rankings with room
  and global scopes, new tRPC leaderboard procedures, a sortable web UI
  page, and text command aliases layered over the existing rankings system.

- 14-fight-stats.md: fight summary persistence derived from room_events,
  a catch-up text command ("what happened"), a Fight Log web page with
  per-fight breakdowns, and an inline catch-up banner for returning players.

Both features build on the existing event bus and room_events table and
are designed to integrate with the FightStatsSubscriber from the leaderboard
plan.

https://claude.ai/code/session_019Sm9iBep7LdFHKiRVGyEe6