### PR TITLE
Implement leaderboard and fight stats from roadmap plans 13–14

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,8 @@ import LoginView from './views/LoginView.js';
 import RoomLobbyView from './views/RoomLobbyView.js';
 import RoomSettingsView from './views/RoomSettingsView.js';
 import AccountView from './views/AccountView.js';
+import LeaderboardView from './views/LeaderboardView.js';
+import FightLogView from './views/FightLogView.js';
 import { trpc } from './lib/trpc.js';
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
@@ -174,6 +176,33 @@ export default function App() {
         element={
           <RequireAuth>
             <AccountWrapper />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/leaderboard"
+        element={
+          <RequireAuth>
+            <LeaderboardView />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/room/:roomId/leaderboard"
+        element={
+          <RequireAuth>
+            <LeaderboardView />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/room/:roomId/fights"
+        element={
+          <RequireAuth>
+            <FightLogView />
           </RequireAuth>
         }
       />

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -97,6 +97,18 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
           <Link to="/rooms" className="btn" style={{ fontSize: '0.8rem' }}>
             Rooms
           </Link>
+          <Link
+            to={roomId ? `/room/${roomId}/leaderboard` : '/leaderboard'}
+            className="btn"
+            style={{ fontSize: '0.8rem' }}
+          >
+            Leaderboard
+          </Link>
+          {roomId && (
+            <Link to={`/room/${roomId}/fights`} className="btn" style={{ fontSize: '0.8rem' }}>
+              Fight log
+            </Link>
+          )}
           <Link to="/account" className="btn" style={{ fontSize: '0.8rem' }}>
             Account
           </Link>
@@ -160,6 +172,18 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
             onClick={(e) => e.stopPropagation()}
           >
             <Link to="/rooms" className="btn" onClick={() => setMenuOpen(false)}>Rooms</Link>
+            <Link
+              to={roomId ? `/room/${roomId}/leaderboard` : '/leaderboard'}
+              className="btn"
+              onClick={() => setMenuOpen(false)}
+            >
+              Leaderboard
+            </Link>
+            {roomId && (
+              <Link to={`/room/${roomId}/fights`} className="btn" onClick={() => setMenuOpen(false)}>
+                Fight log
+              </Link>
+            )}
             <Link to="/account" className="btn" onClick={() => setMenuOpen(false)}>Account</Link>
             <button
               className="btn"

--- a/apps/web/src/components/CatchUpBanner.tsx
+++ b/apps/web/src/components/CatchUpBanner.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+import { trpc } from '../lib/trpc.js';
+
+const THIRTY_MIN_MS = 30 * 60 * 1000;
+
+export default function CatchUpBanner({ roomId }: { roomId: string }) {
+  const { data: room } = trpc.room.info.useQuery({ roomId });
+  const lastSeen = room?.lastSeenAt ? new Date(room.lastSeenAt as string) : null;
+  const since = lastSeen ? lastSeen.toISOString() : undefined;
+
+  const catchUp = trpc.game.catchUp.useQuery(
+    { roomId, since, touchLastSeen: false },
+    {
+      enabled: !!room && !!lastSeen && Date.now() - lastSeen.getTime() > THIRTY_MIN_MS,
+    }
+  );
+
+  if (!lastSeen) return null;
+  const awayMs = Date.now() - lastSeen.getTime();
+  if (awayMs <= THIRTY_MIN_MS) return null;
+  if (!catchUp.data || catchUp.data.fightCount <= 0) return null;
+
+  const hours = Math.floor(awayMs / 3600000);
+  const mins = Math.floor((awayMs % 3600000) / 60000);
+  const label = hours > 0 ? `${hours}h ${mins}m` : `${mins} min`;
+
+  return (
+    <div
+      style={{
+        margin: '0 1rem 0.75rem',
+        padding: '0.75rem 1rem',
+        border: '1px solid var(--color-accent)',
+        borderRadius: 6,
+        background: 'var(--color-bg-elevated, var(--color-bg))',
+        fontSize: '0.9rem',
+      }}
+    >
+      You were away for {label}. {catchUp.data.fightCount} fight{catchUp.data.fightCount === 1 ? '' : 's'} happened.{' '}
+      <Link to={`/room/${roomId}/fights`} style={{ color: 'var(--color-accent)' }}>
+        See what you missed
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/RingPane.tsx
+++ b/apps/web/src/components/RingPane.tsx
@@ -32,6 +32,15 @@ function eventClass(type: string): string {
 }
 
 /** Returns a human-readable countdown string from an epoch-ms timestamp. */
+function relAgo(d: Date): string {
+  const s = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (s < 120) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 120) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
 function formatCountdown(epochMs: number): string {
   const deltaMs = epochMs - Date.now();
   if (deltaMs <= 0) return 'now';
@@ -66,6 +75,8 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
 
   // Fetch persistent ring history from DB on mount
   const { data: history } = trpc.game.ringHistory.useQuery({ roomId });
+
+  const { data: lastFight } = trpc.game.recentFights.useQuery({ roomId, limit: 1 });
 
   // Tick every second while a fight or boss timer is active, to keep the badge live
   const [, setTick] = useState(0);
@@ -246,8 +257,22 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
             </time>
             <div className="event-text">{formatEventText(event.text ?? '')}</div>
           </li>
-        ))}
+        )        )}
       </ol>
+
+      {lastFight?.[0] && (
+        <div
+          style={{
+            padding: '0.35rem 0.75rem',
+            fontSize: '0.8rem',
+            borderTop: '1px solid var(--color-border)',
+            color: 'var(--color-fg-dim)',
+          }}
+        >
+          Last fight: {lastFight[0].winnerMonsterName ?? '?'} vs {lastFight[0].loserMonsterName ?? '?'} (#{lastFight[0].fightNumber}) —{' '}
+          {relAgo(new Date(lastFight[0].endedAt))}
+        </div>
+      )}
 
       {!isAtBottom && (
         <button

--- a/apps/web/src/components/RingPane.tsx
+++ b/apps/web/src/components/RingPane.tsx
@@ -5,6 +5,7 @@ type TrackedEvent = { id: string; data: GameEvent };
 import { trpc } from '../lib/trpc.js';
 import { useHandshake } from '../hooks/useHandshake.js';
 import { formatEventText } from '../utils/format-event-text.js';
+import { fightTitleOneLine, type FightSummaryLike } from '../utils/fight-display.js';
 
 interface RingPaneProps {
   roomId: string;
@@ -257,7 +258,7 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
             </time>
             <div className="event-text">{formatEventText(event.text ?? '')}</div>
           </li>
-        )        )}
+        ))}
       </ol>
 
       {lastFight?.[0] && (
@@ -269,7 +270,7 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
             color: 'var(--color-fg-dim)',
           }}
         >
-          Last fight: {lastFight[0].winnerMonsterName ?? '?'} vs {lastFight[0].loserMonsterName ?? '?'} (#{lastFight[0].fightNumber}) —{' '}
+          Last fight: {fightTitleOneLine(lastFight[0] as FightSummaryLike)} (#{lastFight[0].fightNumber}) —{' '}
           {relAgo(new Date(lastFight[0].endedAt))}
         </div>
       )}

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import RingPane from './RingPane.js';
 import ConsolePane from './ConsolePane.js';
 import PaneDivider from './PaneDivider.js';
+import CatchUpBanner from './CatchUpBanner.js';
 
 type TabId = 'ring' | 'console';
 
@@ -71,6 +72,8 @@ export default function Terminal({ roomId }: TerminalProps) {
       data-layout={isSideBySide ? 'side-by-side' : 'tabbed'}
     >
       {/* Tab bar — only visible on narrow screens */}
+      <CatchUpBanner roomId={roomId} />
+
       {!isSideBySide && (
         <div className="terminal-tabs" role="tablist" aria-label="Switch panes">
           <button

--- a/apps/web/src/utils/fight-display.ts
+++ b/apps/web/src/utils/fight-display.ts
@@ -1,0 +1,69 @@
+/** Shared labels for fight log / ring ticker (multi-monster aware). */
+
+export type FightParticipantLike = {
+  monsterId: string;
+  monsterName: string;
+  outcome: 'win' | 'loss' | 'draw' | 'fled' | 'permaDeath';
+};
+
+export type FightSummaryLike = {
+  outcome: string;
+  roundCount: number;
+  winnerMonsterName: string | null;
+  loserMonsterName: string | null;
+  cardDropName: string | null;
+  participants: FightParticipantLike[];
+};
+
+function nameList(names: string[]): string {
+  if (names.length === 0) return '?';
+  if (names.length === 1) return names[0]!;
+  if (names.length === 2) return `${names[0]} vs ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, vs ${names[names.length - 1]}`;
+}
+
+/** One-line title: e.g. "A vs B" or "A, B vs C, D" for multi-monster. */
+export function fightTitleOneLine(f: FightSummaryLike): string {
+  const ps = f.participants ?? [];
+  if (ps.length <= 2 && f.winnerMonsterName && f.loserMonsterName) {
+    return `${f.winnerMonsterName} vs ${f.loserMonsterName}`;
+  }
+  if (ps.length >= 3) {
+    return nameList(ps.map((p) => p.monsterName));
+  }
+  return `${f.winnerMonsterName ?? '?'} vs ${f.loserMonsterName ?? '?'}`;
+}
+
+export function fightSubtitle(f: FightSummaryLike): string {
+  const ps = f.participants ?? [];
+  if (f.outcome === 'draw') {
+    const names = ps.length > 0 ? ps.map((p) => p.monsterName) : [];
+    return names.length ? `Draw — ${nameList(names)}` : 'Draw';
+  }
+  if (f.outcome === 'fled') {
+    const fled = ps.filter((p) => p.outcome === 'fled').map((p) => p.monsterName);
+    const survived = ps.filter((p) => p.outcome === 'win').map((p) => p.monsterName);
+    if (fled.length && survived.length) return `${nameList(fled)} fled from ${nameList(survived)}`;
+    if (fled.length) return `${nameList(fled)} fled`;
+    return `${f.winnerMonsterName ?? '?'} fled`;
+  }
+  if (f.outcome === 'permaDeath') {
+    const winners = ps.filter((p) => p.outcome === 'win').map((p) => p.monsterName);
+    const dead = ps.filter((p) => p.outcome === 'permaDeath').map((p) => p.monsterName);
+    const w = winners.length ? nameList(winners) : f.winnerMonsterName ?? '?';
+    const d = dead.length ? nameList(dead) : f.loserMonsterName ?? '?';
+    return `${w} won in ${f.roundCount} rounds — ☠ ${d} perished`;
+  }
+  if (f.outcome === 'win') {
+    const winners = ps.filter((p) => p.outcome === 'win').map((p) => p.monsterName);
+    const losers = ps.filter((p) => p.outcome === 'loss').map((p) => p.monsterName);
+    const w = winners.length ? nameList(winners) : f.winnerMonsterName ?? '?';
+    const l = losers.length ? nameList(losers) : f.loserMonsterName ?? '?';
+    let s = `${w} won vs ${l} in ${f.roundCount} rounds`;
+    if (f.cardDropName) s += ` · Card: ${f.cardDropName}`;
+    return s;
+  }
+  let s = `Outcome: ${f.outcome}`;
+  if (f.cardDropName) s += ` · Card: ${f.cardDropName}`;
+  return s;
+}

--- a/apps/web/src/views/FightLogView.tsx
+++ b/apps/web/src/views/FightLogView.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { trpc } from '../lib/trpc.js';
 import AppShell from '../components/AppShell.js';
+import { fightSubtitle, fightTitleOneLine, type FightSummaryLike } from '../utils/fight-display.js';
 
 function relTime(d: Date): string {
   const s = Math.floor((Date.now() - d.getTime()) / 1000);
@@ -22,9 +23,31 @@ export default function FightLogView() {
   );
 
   const fights = trpc.game.recentFights.useQuery(
-    { roomId: roomId ?? '', limit: 20 },
+    { roomId: roomId ?? '', limit: 80 },
     { enabled: !!roomId }
   );
+
+  const streakByMonsterId = useMemo(() => {
+    const list = fights.data ?? [];
+    const ids = new Set<string>();
+    for (const f of list) {
+      for (const p of (f as FightSummaryLike).participants ?? []) {
+        if (p.monsterId) ids.add(p.monsterId);
+      }
+    }
+    const map = new Map<string, number>();
+    for (const id of ids) {
+      let n = 0;
+      for (const f of list) {
+        const p = (f as FightSummaryLike).participants?.find((x) => x.monsterId === id);
+        if (!p) continue;
+        if (p.outcome === 'win') n += 1;
+        else break;
+      }
+      map.set(id, n);
+    }
+    return map;
+  }, [fights.data]);
 
   const detail = trpc.game.fight.useQuery(
     { roomId: roomId ?? '', fightNumber: expanded ?? 0 },
@@ -49,7 +72,16 @@ export default function FightLogView() {
         {fights.isLoading && <p style={{ color: 'var(--color-fg-dim)' }}>Loading…</p>}
 
         <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {(fights.data ?? []).map((f) => (
+          {(fights.data ?? []).map((f) => {
+            const fs = f as FightSummaryLike;
+            const winners = (fs.participants ?? []).filter((p) => p.outcome === 'win');
+            const streakNotes = winners
+              .map((w) => {
+                const s = streakByMonsterId.get(w.monsterId) ?? 0;
+                return s >= 3 ? `${w.monsterName}: ${s}-fight streak` : null;
+              })
+              .filter(Boolean) as string[];
+            return (
             <li
               key={f.id}
               style={{
@@ -72,18 +104,19 @@ export default function FightLogView() {
               >
                 <div style={{ fontWeight: 600 }}>
                   #{f.fightNumber}{' '}
-                  {f.winnerMonsterName ?? '?'} vs {f.loserMonsterName ?? '?'}{' '}
+                  {fightTitleOneLine(fs)}{' '}
                   <span style={{ color: 'var(--color-fg-dim)', fontWeight: 400, fontSize: '0.85rem' }}>
                     {relTime(new Date(f.endedAt))}
                   </span>
                 </div>
                 <div style={{ fontSize: '0.9rem', marginTop: '0.25rem' }}>
-                  {f.outcome === 'draw' && 'Draw'}
-                  {f.outcome === 'fled' && `${f.winnerMonsterName} fled`}
-                  {f.outcome === 'permaDeath' && `${f.winnerMonsterName} won — permadeath`}
-                  {f.outcome === 'win' && `${f.winnerMonsterName} won in ${f.roundCount} rounds`}
-                  {f.cardDropName && ` · Card: ${f.cardDropName}`}
+                  {fightSubtitle(fs)}
                 </div>
+                {streakNotes.length > 0 && (
+                  <div style={{ fontSize: '0.8rem', marginTop: '0.25rem', color: 'var(--color-accent)' }}>
+                    {streakNotes.join(' · ')}
+                  </div>
+                )}
               </button>
               {expanded === f.fightNumber && detail.data && (
                 <div style={{ marginTop: '0.75rem', fontSize: '0.85rem', fontFamily: 'var(--font-mono, monospace)' }}>
@@ -99,7 +132,8 @@ export default function FightLogView() {
                 </div>
               )}
             </li>
-          ))}
+            );
+          })}
         </ul>
       </div>
     </AppShell>

--- a/apps/web/src/views/FightLogView.tsx
+++ b/apps/web/src/views/FightLogView.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { trpc } from '../lib/trpc.js';
+import AppShell from '../components/AppShell.js';
+
+function relTime(d: Date): string {
+  const s = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (s < 120) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 120) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+export default function FightLogView() {
+  const { roomId } = useParams<{ roomId: string }>();
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const { data: room } = trpc.room.info.useQuery(
+    { roomId: roomId ?? '' },
+    { enabled: !!roomId }
+  );
+
+  const fights = trpc.game.recentFights.useQuery(
+    { roomId: roomId ?? '', limit: 20 },
+    { enabled: !!roomId }
+  );
+
+  const detail = trpc.game.fight.useQuery(
+    { roomId: roomId ?? '', fightNumber: expanded ?? 0 },
+    { enabled: !!roomId && expanded !== null }
+  );
+
+  if (!roomId) {
+    return (
+      <AppShell>
+        <p style={{ padding: '1rem' }}>No room selected.</p>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell roomName={room?.name} roomId={roomId}>
+      <div style={{ padding: '1.5rem', maxWidth: 800, margin: '0 auto', overflowY: 'auto', flex: 1 }}>
+        <h1 style={{ fontSize: '1.25rem', marginBottom: '1rem', color: 'var(--color-fg-bright)' }}>
+          Fight log — {room?.name ?? '…'}
+        </h1>
+
+        {fights.isLoading && <p style={{ color: 'var(--color-fg-dim)' }}>Loading…</p>}
+
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {(fights.data ?? []).map((f) => (
+            <li
+              key={f.id}
+              style={{
+                border: '1px solid var(--color-border)',
+                borderRadius: 6,
+                padding: '0.75rem',
+                marginBottom: '0.5rem',
+                background: 'var(--color-bg-elevated, var(--color-bg))',
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => setExpanded(expanded === f.fightNumber ? null : f.fightNumber)}
+                style={{
+                  all: 'unset',
+                  cursor: 'pointer',
+                  width: '100%',
+                  display: 'block',
+                }}
+              >
+                <div style={{ fontWeight: 600 }}>
+                  #{f.fightNumber}{' '}
+                  {f.winnerMonsterName ?? '?'} vs {f.loserMonsterName ?? '?'}{' '}
+                  <span style={{ color: 'var(--color-fg-dim)', fontWeight: 400, fontSize: '0.85rem' }}>
+                    {relTime(new Date(f.endedAt))}
+                  </span>
+                </div>
+                <div style={{ fontSize: '0.9rem', marginTop: '0.25rem' }}>
+                  {f.outcome === 'draw' && 'Draw'}
+                  {f.outcome === 'fled' && `${f.winnerMonsterName} fled`}
+                  {f.outcome === 'permaDeath' && `${f.winnerMonsterName} won — permadeath`}
+                  {f.outcome === 'win' && `${f.winnerMonsterName} won in ${f.roundCount} rounds`}
+                  {f.cardDropName && ` · Card: ${f.cardDropName}`}
+                </div>
+              </button>
+              {expanded === f.fightNumber && detail.data && (
+                <div style={{ marginTop: '0.75rem', fontSize: '0.85rem', fontFamily: 'var(--font-mono, monospace)' }}>
+                  <p style={{ marginBottom: '0.35rem', color: 'var(--color-fg-dim)' }}>Event trace (same window)</p>
+                  <ol style={{ maxHeight: 240, overflow: 'auto', paddingLeft: '1rem' }}>
+                    {detail.data.events.map((ev) => (
+                      <li key={ev.id} style={{ marginBottom: '0.25rem' }}>
+                        <span style={{ color: 'var(--color-fg-dim)' }}>{ev.type}</span> — {ev.text.slice(0, 200)}
+                        {ev.text.length > 200 ? '…' : ''}
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/views/LeaderboardView.tsx
+++ b/apps/web/src/views/LeaderboardView.tsx
@@ -124,7 +124,12 @@ export default function LeaderboardView() {
                 <th style={{ padding: '0.35rem' }}>W</th>
                 <th style={{ padding: '0.35rem' }}>L</th>
                 <th style={{ padding: '0.35rem' }}>D</th>
-                <th style={{ padding: '0.35rem' }}>Win %</th>
+                <th
+                  style={{ padding: '0.35rem' }}
+                  title="Wins ÷ (wins + losses). Draws excluded."
+                >
+                  Win %
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -153,19 +158,45 @@ export default function LeaderboardView() {
                 <th style={{ padding: '0.35rem' }}>Owner</th>
                 <th style={{ padding: '0.35rem' }}>XP</th>
                 <th style={{ padding: '0.35rem' }}>Lv</th>
-                <th style={{ padding: '0.35rem' }}>Win %</th>
+                <th
+                  style={{ padding: '0.35rem' }}
+                  title="Wins ÷ (wins + losses). Draws excluded."
+                >
+                  Win %
+                </th>
+                <th style={{ padding: '0.35rem' }} title="Consecutive wins in recent fights (this room)">
+                  Streak
+                </th>
               </tr>
             </thead>
             <tbody>
               {(roomMonsters.data ?? []).map((r) => (
                 <tr key={r.rank} style={{ borderBottom: '1px solid var(--color-border)' }}>
                   <td style={{ padding: '0.35rem' }}>{r.rank}</td>
-                  <td style={{ padding: '0.35rem' }}>{r.displayName}</td>
+                  <td style={{ padding: '0.35rem' }}>
+                    {r.displayName}
+                    {r.winStreak >= 3 && (
+                      <span
+                        style={{
+                          marginLeft: '0.35rem',
+                          fontSize: '0.75rem',
+                          padding: '0.1rem 0.35rem',
+                          borderRadius: 4,
+                          background: 'var(--color-accent-muted, rgba(255,200,0,0.15))',
+                          color: 'var(--color-accent)',
+                        }}
+                        title="Active win streak"
+                      >
+                        {r.winStreak}W
+                      </span>
+                    )}
+                  </td>
                   <td style={{ padding: '0.35rem' }}>{r.monsterType}</td>
                   <td style={{ padding: '0.35rem' }}>{r.ownerName ?? '—'}</td>
                   <td style={{ padding: '0.35rem' }}>{r.xp}</td>
                   <td style={{ padding: '0.35rem' }}>{r.level}</td>
                   <td style={{ padding: '0.35rem' }}>{pct(r.winRate)}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.winStreak > 0 ? r.winStreak : '—'}</td>
                 </tr>
               ))}
             </tbody>
@@ -180,7 +211,12 @@ export default function LeaderboardView() {
                 <th style={{ padding: '0.35rem' }}>Name</th>
                 <th style={{ padding: '0.35rem' }}>XP</th>
                 <th style={{ padding: '0.35rem' }}>Rooms</th>
-                <th style={{ padding: '0.35rem' }}>Win %</th>
+                <th
+                  style={{ padding: '0.35rem' }}
+                  title="Wins ÷ (wins + losses), aggregated across rooms. Draws excluded."
+                >
+                  Win %
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -206,7 +242,12 @@ export default function LeaderboardView() {
                 <th style={{ padding: '0.35rem' }}>Type</th>
                 <th style={{ padding: '0.35rem' }}>Owner</th>
                 <th style={{ padding: '0.35rem' }}>XP</th>
-                <th style={{ padding: '0.35rem' }}>Win %</th>
+                <th
+                  style={{ padding: '0.35rem' }}
+                  title="Wins ÷ (wins + losses), aggregated across rooms. Draws excluded."
+                >
+                  Win %
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/apps/web/src/views/LeaderboardView.tsx
+++ b/apps/web/src/views/LeaderboardView.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { trpc } from '../lib/trpc.js';
+import AppShell from '../components/AppShell.js';
+
+type Scope = 'room' | 'global';
+type Kind = 'players' | 'monsters';
+type Sort = 'xp' | 'wins' | 'winRate' | 'coins';
+
+function pct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}
+
+export default function LeaderboardView() {
+  const { roomId } = useParams<{ roomId?: string }>();
+  const [scope, setScope] = useState<Scope>(roomId ? 'room' : 'global');
+  const [kind, setKind] = useState<Kind>('players');
+  const [sortBy, setSortBy] = useState<Sort>('xp');
+
+  const { data: room } = trpc.room.info.useQuery(
+    { roomId: roomId ?? '' },
+    { enabled: !!roomId }
+  );
+
+  const roomPlayers = trpc.leaderboard.roomPlayers.useQuery(
+    { roomId: roomId ?? '', limit: 25, sortBy },
+    { enabled: !!roomId && scope === 'room' && kind === 'players' }
+  );
+  const roomMonsters = trpc.leaderboard.roomMonsters.useQuery(
+    { roomId: roomId ?? '', limit: 25, sortBy },
+    { enabled: !!roomId && scope === 'room' && kind === 'monsters' }
+  );
+  const globalPlayers = trpc.leaderboard.globalPlayers.useQuery(
+    { limit: 25, sortBy },
+    { enabled: scope === 'global' && kind === 'players' }
+  );
+  const globalMonsters = trpc.leaderboard.globalMonsters.useQuery(
+    { limit: 25, sortBy },
+    { enabled: scope === 'global' && kind === 'monsters' }
+  );
+
+  const loading =
+    roomPlayers.isLoading ||
+    roomMonsters.isLoading ||
+    globalPlayers.isLoading ||
+    globalMonsters.isLoading;
+
+  return (
+    <AppShell roomName={room?.name} roomId={roomId}>
+      <div style={{ padding: '1.5rem', maxWidth: 960, margin: '0 auto', overflowY: 'auto', flex: 1 }}>
+        <h1 style={{ fontSize: '1.25rem', marginBottom: '1rem', color: 'var(--color-fg-bright)' }}>
+          Leaderboard
+        </h1>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', marginBottom: '1rem', alignItems: 'center' }}>
+          <label style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', fontSize: '0.85rem' }}>
+            <input
+              type="radio"
+              name="scope"
+              checked={scope === 'room'}
+              onChange={() => setScope('room')}
+              disabled={!roomId}
+            />
+            This room
+          </label>
+          <label style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', fontSize: '0.85rem' }}>
+            <input
+              type="radio"
+              name="scope"
+              checked={scope === 'global'}
+              onChange={() => setScope('global')}
+            />
+            Global
+          </label>
+          <span style={{ color: 'var(--color-border)' }}>|</span>
+          <label style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', fontSize: '0.85rem' }}>
+            <input
+              type="radio"
+              name="kind"
+              checked={kind === 'players'}
+              onChange={() => setKind('players')}
+            />
+            Players
+          </label>
+          <label style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', fontSize: '0.85rem' }}>
+            <input
+              type="radio"
+              name="kind"
+              checked={kind === 'monsters'}
+              onChange={() => setKind('monsters')}
+            />
+            Monsters
+          </label>
+          <span style={{ flex: 1 }} />
+          <label style={{ fontSize: '0.85rem', display: 'flex', gap: '0.35rem', alignItems: 'center' }}>
+            Sort by
+            <select
+              className="btn"
+              style={{ fontSize: '0.8rem' }}
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as Sort)}
+            >
+              <option value="xp">XP</option>
+              <option value="wins">Wins</option>
+              <option value="winRate">Win rate</option>
+              <option value="coins">Coins</option>
+            </select>
+          </label>
+        </div>
+
+        {!roomId && scope === 'room' && (
+          <p style={{ color: 'var(--color-fg-dim)' }}>Join a room to see room-scoped rankings, or switch to Global.</p>
+        )}
+
+        {loading && <p style={{ color: 'var(--color-fg-dim)' }}>Loading…</p>}
+
+        {kind === 'players' && scope === 'room' && roomId && (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--color-border)', textAlign: 'left' }}>
+                <th style={{ padding: '0.35rem' }}>#</th>
+                <th style={{ padding: '0.35rem' }}>Name</th>
+                <th style={{ padding: '0.35rem' }}>XP</th>
+                <th style={{ padding: '0.35rem' }}>W</th>
+                <th style={{ padding: '0.35rem' }}>L</th>
+                <th style={{ padding: '0.35rem' }}>D</th>
+                <th style={{ padding: '0.35rem' }}>Win %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(roomPlayers.data ?? []).map((r) => (
+                <tr key={r.rank} style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  <td style={{ padding: '0.35rem' }}>{r.rank}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.displayName}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.xp}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.wins}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.losses}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.draws}</td>
+                  <td style={{ padding: '0.35rem' }}>{pct(r.winRate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {kind === 'monsters' && scope === 'room' && roomId && (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--color-border)', textAlign: 'left' }}>
+                <th style={{ padding: '0.35rem' }}>#</th>
+                <th style={{ padding: '0.35rem' }}>Name</th>
+                <th style={{ padding: '0.35rem' }}>Type</th>
+                <th style={{ padding: '0.35rem' }}>Owner</th>
+                <th style={{ padding: '0.35rem' }}>XP</th>
+                <th style={{ padding: '0.35rem' }}>Lv</th>
+                <th style={{ padding: '0.35rem' }}>Win %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(roomMonsters.data ?? []).map((r) => (
+                <tr key={r.rank} style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  <td style={{ padding: '0.35rem' }}>{r.rank}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.displayName}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.monsterType}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.ownerName ?? '—'}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.xp}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.level}</td>
+                  <td style={{ padding: '0.35rem' }}>{pct(r.winRate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {kind === 'players' && scope === 'global' && (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--color-border)', textAlign: 'left' }}>
+                <th style={{ padding: '0.35rem' }}>#</th>
+                <th style={{ padding: '0.35rem' }}>Name</th>
+                <th style={{ padding: '0.35rem' }}>XP</th>
+                <th style={{ padding: '0.35rem' }}>Rooms</th>
+                <th style={{ padding: '0.35rem' }}>Win %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(globalPlayers.data ?? []).map((r) => (
+                <tr key={r.rank} style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  <td style={{ padding: '0.35rem' }}>{r.rank}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.displayName}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.xp}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.roomCount}</td>
+                  <td style={{ padding: '0.35rem' }}>{pct(r.winRate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {kind === 'monsters' && scope === 'global' && (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--color-border)', textAlign: 'left' }}>
+                <th style={{ padding: '0.35rem' }}>#</th>
+                <th style={{ padding: '0.35rem' }}>Name</th>
+                <th style={{ padding: '0.35rem' }}>Type</th>
+                <th style={{ padding: '0.35rem' }}>Owner</th>
+                <th style={{ padding: '0.35rem' }}>XP</th>
+                <th style={{ padding: '0.35rem' }}>Win %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(globalMonsters.data ?? []).map((r) => (
+                <tr key={r.rank} style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  <td style={{ padding: '0.35rem' }}>{r.rank}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.displayName}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.monsterType}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.ownerName ?? '—'}</td>
+                  <td style={{ padding: '0.35rem' }}>{r.xp}</td>
+                  <td style={{ padding: '0.35rem' }}>{pct(r.winRate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,12 +29,16 @@ This guide covers setting up both from scratch and connecting them.
 
 ### Configure Auth URLs
 
+Supabase redirects users back to your app after OAuth sign-in. You need to tell it which URLs are allowed.
+
+If you have **custom domains set up** (see section 2e), use those. If you're deploying for the first time and only have Railway-generated URLs, use those for now — you can update these later.
+
 In **Authentication → URL Configuration**, set:
 
 | Setting | Value |
 |---|---|
-| **Site URL** | `https://<your-web-service>.up.railway.app` (your Railway web domain) |
-| **Redirect URLs** | Add `https://<your-web-service>.up.railway.app/**` and `http://localhost:5173/**` |
+| **Site URL** | `https://deck-monsters.com` (or your Railway web URL if no custom domain yet) |
+| **Redirect URLs** | Add each allowed origin, e.g.:<br>`https://deck-monsters.com/**`<br>`https://www.deck-monsters.com/**`<br>`https://<web>.up.railway.app/**`<br>`http://localhost:5173/**` |
 
 The Site URL is where Supabase redirects users after OAuth. If left as `localhost`, production OAuth flows will send users to your local machine.
 
@@ -145,7 +149,7 @@ Then go to **Variables** and add:
 |---|---|
 | `VITE_SUPABASE_URL` | Your Supabase project URL (e.g., `https://xxxx.supabase.co`) |
 | `VITE_SUPABASE_PUBLISHABLE_KEY` | Your Supabase Publishable key (`sb_publishable_...`) |
-| `VITE_SERVER_URL` | _(leave blank for now — fill in after deploying the Server service)_ |
+| `VITE_SERVER_URL` | `https://server.deck-monsters.com` once custom domains are set up (see 2e); otherwise the Server service's Railway URL |
 
 ### 2c. Service: Server (API)
 
@@ -169,7 +173,7 @@ Then go to **Variables** and add:
 | `SUPABASE_PUBLISHABLE_KEY` | Your Supabase Publishable key (`sb_publishable_...`) |
 | `SUPABASE_SECRET_KEY` | Your Supabase Secret key (`sb_secret_...`) — bypasses RLS, keep secret |
 | `CONNECTOR_SERVICE_TOKEN` | A secret token shared with all connectors — generate with `openssl rand -hex 32` |
-| `CORS_ORIGINS` | Comma-separated allowed origins, e.g. `https://<web>.up.railway.app,http://localhost:5173` |
+| `CORS_ORIGINS` | Comma-separated allowed origins. Once custom domains are set up (see 2e): `https://deck-monsters.com,https://www.deck-monsters.com,http://localhost:5173`. Before custom domains, use your Railway web URL, e.g. `https://<web>.up.railway.app,http://localhost:5173` |
 
 Once the build completes, verify the server is running:
 
@@ -185,6 +189,66 @@ Now that both services are deployed and have public URLs:
 1. Go to the **Web** service → **Variables**
 2. Set `VITE_SERVER_URL` to the Server service's public Railway URL (e.g., `https://<server>.up.railway.app`)
 3. Redeploy the Web service (Railway will trigger this automatically when you save the variable)
+
+If you have custom domains (see 2e), set `VITE_SERVER_URL` to `https://server.deck-monsters.com` instead.
+
+### 2e. Custom Domains
+
+Railway assigns each service a `*.up.railway.app` subdomain by default. The production deployment uses custom domains:
+
+| Service | Custom domain |
+|---|---|
+| **Web** | `deck-monsters.com` |
+| **Server** | `server.deck-monsters.com` |
+
+Optional Web aliases (assign all to the same Web service): `www.deck-monsters.com`, `web.deck-monsters.com`. Railway serves all of them without further config — there is no automatic redirect between them, so if you care about canonical URLs, handle that at the DNS/CDN layer (e.g., a Cloudflare redirect rule from `www.` → apex).
+
+#### Assign custom domains in Railway
+
+For each domain you want to add:
+
+1. Go to the service in the Railway dashboard → **Settings → Networking**
+2. Click **Add Custom Domain** and type the domain (e.g., `server.deck-monsters.com`)
+3. Railway shows the **CNAME target** to set at your DNS provider (e.g., `<region>.railway.app`)
+4. Add that CNAME record at your DNS registrar/provider
+5. Railway will automatically provision a TLS certificate via Let's Encrypt once the DNS propagates (usually within a few minutes)
+
+Repeat for each domain: `deck-monsters.com`, and any aliases.
+
+> **Apex domain (`deck-monsters.com`) note:** Some DNS providers don't support CNAME records at the apex. If yours doesn't, use their proprietary equivalent — Cloudflare's CNAME-flattening, Route 53's ALIAS record, or similar. Railway's domain setup page will note if a different record type is needed.
+
+#### Update configuration after adding custom domains
+
+Once both custom domains are live, update these values across your services:
+
+**Web service → Variables:**
+
+| Variable | New value |
+|---|---|
+| `VITE_SERVER_URL` | `https://server.deck-monsters.com` |
+
+Redeploy the Web service after saving.
+
+**Server service → Variables:**
+
+| Variable | New value |
+|---|---|
+| `CORS_ORIGINS` | `https://deck-monsters.com,https://www.deck-monsters.com,http://localhost:5173` |
+
+Add `https://web.deck-monsters.com` to `CORS_ORIGINS` if you're using that alias too. The server picks up the new value on next deploy or restart — no code change needed.
+
+**Discord connector → Variables:**
+
+| Variable | New value |
+|---|---|
+| `SERVER_URL` | `https://server.deck-monsters.com` |
+
+**Supabase → Authentication → URL Configuration:**
+
+| Setting | New value |
+|---|---|
+| **Site URL** | `https://deck-monsters.com` |
+| **Redirect URLs** | Add `https://deck-monsters.com/**` and `https://www.deck-monsters.com/**` (keep the Railway URL and localhost entries too) |
 
 ---
 
@@ -239,7 +303,7 @@ Go to **Variables** and add:
 | `DISCORD_TOKEN` | Your bot token from the Discord developer portal |
 | `DISCORD_CLIENT_ID` | Your application's client ID |
 | `DATABASE_URL` | Same Supabase transaction pooler URL as the server |
-| `SERVER_URL` | The Server service's public Railway URL (e.g., `https://<server>.up.railway.app`) |
+| `SERVER_URL` | `https://server.deck-monsters.com` (or the Railway-generated URL before custom domains are set up) |
 | `CONNECTOR_SERVICE_TOKEN` | Same token set on the Server service |
 
 ---
@@ -317,12 +381,14 @@ The local Supabase Studio is at `http://localhost:54323` — use it to inspect t
 | `SUPABASE_PUBLISHABLE_KEY` | Yes | Supabase Publishable key (`sb_publishable_...`) — safe for client-side use with RLS enabled |
 | `SUPABASE_SECRET_KEY` | Yes | Supabase Secret key (`sb_secret_...`) — used by `ensureConnectorUser` to create auth users; bypasses RLS, never expose publicly |
 | `CONNECTOR_SERVICE_TOKEN` | Yes | Shared secret for authenticating connector-to-server service calls (set in both the server and each connector's env) |
+| `CORS_ORIGINS` | No | Comma-separated list of allowed CORS origins for the server. Defaults to `http://localhost:5173`. Production example: `https://deck-monsters.com,https://www.deck-monsters.com,http://localhost:5173` |
 | `PORT` | No | HTTP port, defaults to `3000` (server only) |
 | `HOST` | No | Bind address, defaults to `0.0.0.0` (server only) |
 | `NODE_ENV` | No | `production` or `development` |
 | `DISCORD_TOKEN` | Connector | Discord bot token (Discord connector only) |
 | `DISCORD_CLIENT_ID` | Connector | Discord application client ID (Discord connector only) |
-| `SERVER_URL` | Connector | Base URL of the API server, used by the Discord connector for service calls |
+| `SERVER_URL` | Connector | Base URL of the API server, used by the Discord connector for service calls. Production: `https://server.deck-monsters.com` |
+| `VITE_SERVER_URL` | Web | Base URL of the API server, baked in at build time by Vite. Production: `https://server.deck-monsters.com`. Leave empty in dev (Vite proxy handles `/trpc` locally) |
 
 ---
 

--- a/docs/roadmap/13-leaderboard.md
+++ b/docs/roadmap/13-leaderboard.md
@@ -185,13 +185,14 @@ The backfill runs as a one-off script, not as part of the regular server startup
 - [x] Write one-time backfill script to seed tables from existing state blobs
 
 ### Server
-- [x] Implement `FightStatsSubscriber` — listens to `ring.win`, `ring.loss`, `ring.draw`, `ring.fled`, `ring.xp`, `ring.cardDrop` and upserts stats tables
+- [x] Implement `FightStatsSubscriber` — listens to `ring.fightResolved` (W/L/draw/XP for all participants) and `ring.xp` (coins only, to avoid double-counting XP) and upserts stats tables
 - [x] Register `FightStatsSubscriber` alongside `EventPersister` in server startup
 - [x] Add `leaderboard` tRPC router with `roomPlayers`, `roomMonsters`, `globalPlayers`, `globalMonsters` procedures
 - [x] Update `lookAtCharacterRankings` and `lookAtMonsterRankings` in `Game` to read from DB (via `RoomManager`) instead of in-memory sort
 
 ### Engine / Commands
 - [x] Add "leaderboard", "global leaderboard", "top players", "top monsters" command aliases in `commands/history.ts`
+- [x] Add "global monster leaderboard" / "look at global monster rankings" command aliases
 
 ### Web UI
 - [x] Add "Leaderboard" link/tab to top navigation header
@@ -199,8 +200,12 @@ The backfill runs as a one-off script, not as part of the regular server startup
 - [x] Wire `LeaderboardPage` to tRPC `leaderboard.*` procedures
 - [x] Pre-select "This Room" scope when navigating from a room context
 
+## Pending
+
+- [ ] **Win streak in leaderboard**: surface current winning streak per monster (see 14-fight-stats.md for streak tracking design). Once streaks are computed, add a streak column to the monster leaderboard.
+- [ ] **Win rate denominator in UI**: currently W / (W + L), draws excluded. Make this explicit in the leaderboard table header or a tooltip so players aren't surprised.
+
 ## Open Questions
 
 - **Global leaderboard privacy**: should players be able to opt out of appearing in the global leaderboard? Easy to add a `profileVisibility` flag on `profiles`. Probably not needed for a private game server, but worth noting.
-- **Win rate denominator**: should "win rate" exclude draws? Current thinking: W / (W + L), draws excluded from the denominator. Make it explicit in the UI.
-- **Monster identity across resets**: monster IDs are stable within a room's lifetime, but if a room is reset, old stats for those monster IDs become orphaned. Two options: soft-delete old stats on reset, or just let them accumulate (stale data is fine). Leaning toward clear on room reset.
+- **Monster identity across resets**: monster IDs are stable within a room's lifetime, but if a room is reset, old stats for those monster IDs become orphaned. Currently cleared on reset (`resetRoomState` in `RoomManager`). Verify this is working and document it.

--- a/docs/roadmap/13-leaderboard.md
+++ b/docs/roadmap/13-leaderboard.md
@@ -202,8 +202,8 @@ The backfill runs as a one-off script, not as part of the regular server startup
 
 ## Pending
 
-- [ ] **Win streak in leaderboard**: surface current winning streak per monster (see 14-fight-stats.md for streak tracking design). Once streaks are computed, add a streak column to the monster leaderboard.
-- [ ] **Win rate denominator in UI**: currently W / (W + L), draws excluded. Make this explicit in the leaderboard table header or a tooltip so players aren't surprised.
+- [x] **Win streak in leaderboard**: room monster leaderboard shows consecutive wins from the last 80 fights (`winStreak` column + badge when ≥3); text leaderboard includes `streak N` when > 0.
+- [x] **Win rate denominator in UI**: table headers use tooltips explaining W÷(W+L), draws excluded.
 
 ## Open Questions
 

--- a/docs/roadmap/13-leaderboard.md
+++ b/docs/roadmap/13-leaderboard.md
@@ -2,7 +2,7 @@
 
 **Category**: Feature  
 **Priority**: Medium (post-launch)  
-**Status**: Not started
+**Status**: In progress (core implementation landed)
 
 ## Background
 
@@ -180,24 +180,24 @@ The backfill runs as a one-off script, not as part of the regular server startup
 ## Tasks
 
 ### Database
-- [ ] Add `room_player_stats` table to Drizzle schema + Supabase migration
-- [ ] Add `room_monster_stats` table to Drizzle schema + Supabase migration
-- [ ] Write one-time backfill script to seed tables from existing state blobs
+- [x] Add `room_player_stats` table to Drizzle schema + Supabase migration
+- [x] Add `room_monster_stats` table to Drizzle schema + Supabase migration
+- [x] Write one-time backfill script to seed tables from existing state blobs
 
 ### Server
-- [ ] Implement `FightStatsSubscriber` — listens to `ring.win`, `ring.loss`, `ring.draw`, `ring.fled`, `ring.xp`, `ring.cardDrop` and upserts stats tables
-- [ ] Register `FightStatsSubscriber` alongside `EventPersister` in server startup
-- [ ] Add `leaderboard` tRPC router with `roomPlayers`, `roomMonsters`, `globalPlayers`, `globalMonsters` procedures
-- [ ] Update `lookAtCharacterRankings` and `lookAtMonsterRankings` in `Game` to read from DB (via `RoomManager`) instead of in-memory sort
+- [x] Implement `FightStatsSubscriber` — listens to `ring.win`, `ring.loss`, `ring.draw`, `ring.fled`, `ring.xp`, `ring.cardDrop` and upserts stats tables
+- [x] Register `FightStatsSubscriber` alongside `EventPersister` in server startup
+- [x] Add `leaderboard` tRPC router with `roomPlayers`, `roomMonsters`, `globalPlayers`, `globalMonsters` procedures
+- [x] Update `lookAtCharacterRankings` and `lookAtMonsterRankings` in `Game` to read from DB (via `RoomManager`) instead of in-memory sort
 
 ### Engine / Commands
-- [ ] Add "leaderboard", "global leaderboard", "top players", "top monsters" command aliases to `commands/look-at.ts`
+- [x] Add "leaderboard", "global leaderboard", "top players", "top monsters" command aliases in `commands/history.ts`
 
 ### Web UI
-- [ ] Add "Leaderboard" link/tab to top navigation header
-- [ ] Implement `LeaderboardPage` component (scope toggle, type toggle, sort dropdown, table)
-- [ ] Wire `LeaderboardPage` to tRPC `leaderboard.*` procedures
-- [ ] Pre-select "This Room" scope when navigating from a room context
+- [x] Add "Leaderboard" link/tab to top navigation header
+- [x] Implement `LeaderboardPage` component (scope toggle, type toggle, sort dropdown, table)
+- [x] Wire `LeaderboardPage` to tRPC `leaderboard.*` procedures
+- [x] Pre-select "This Room" scope when navigating from a room context
 
 ## Open Questions
 

--- a/docs/roadmap/14-fight-stats.md
+++ b/docs/roadmap/14-fight-stats.md
@@ -2,7 +2,7 @@
 
 **Category**: Feature  
 **Priority**: Medium (post-launch)  
-**Status**: Not started
+**Status**: In progress (core implementation landed)
 
 ## Background
 
@@ -221,27 +221,27 @@ Both are populated from ring outcome events. The `FightStatsSubscriber` from `13
 ## Tasks
 
 ### Database
-- [ ] Add `fight_summaries` table to Drizzle schema + Supabase migration
-- [ ] Add `lastSeenAt` column to `room_members` table
-- [ ] Add index on `fight_summaries(roomId, endedAt)` and per-monster indexes
+- [x] Add `fight_summaries` table to Drizzle schema + Supabase migration
+- [x] Add `lastSeenAt` column to `room_members` table
+- [x] Add index on `fight_summaries(roomId, endedAt)` and per-monster indexes
 
 ### Server
-- [ ] Implement `FightSummaryWriter` — stateful event subscriber that assembles and writes fight summaries
-- [ ] Register `FightSummaryWriter` in server startup alongside `EventPersister` and `FightStatsSubscriber`
-- [ ] Update `lastSeenAt` in `room_members` on each `game.command` mutation and `game.ringFeed` subscription
-- [ ] Add `fightStats` tRPC procedures: `recentFights`, `fight`, `monsterFightHistory`, `catchUp`
-- [ ] Ensure `ring.win` / `ring.loss` / `ring.draw` / `ring.fled` / `ring.permaDeath` payloads carry structured participant data; update announcement modules if needed
+- [x] Implement `FightSummaryWriter` — stateful event subscriber that assembles and writes fight summaries
+- [x] Register `FightSummaryWriter` in server startup alongside `EventPersister` and `FightStatsSubscriber`
+- [x] Update `lastSeenAt` in `room_members` on each `game.command` mutation and `game.ringFeed` subscription
+- [x] Add `fightStats` tRPC procedures: `recentFights`, `fight`, `monsterFightHistory`, `catchUp`
+- [x] Ensure `ring.win` / `ring.loss` / `ring.draw` / `ring.fled` / `ring.permaDeath` payloads carry structured participant data; update announcement modules if needed
 
 ### Engine / Commands
-- [ ] Add "what happened", "catch me up", "show recent fights", "show fight history" command aliases
-- [ ] Implement the catch-up text command handler — calls `catchUp` API, formats and emits the text summary
+- [x] Add "what happened", "catch me up", "show recent fights", "show fight history" command aliases
+- [x] Implement the catch-up text command handler — calls `catchUp` API, formats and emits the text summary
 
 ### Web UI
-- [ ] Add "Fight Log" tab/link to top navigation header
-- [ ] Implement `FightLogPage` component — paginated list of fight summaries, expandable rows
-- [ ] Implement inline catch-up banner shown on room join after absence (threshold: > 30 min away, > 0 fights)
-- [ ] Add "last fight" one-liner ticker to the bottom of the Ring pane
-- [ ] Implement expandable fight detail view (card-by-card breakdown from raw events)
+- [x] Add "Fight Log" tab/link to top navigation header
+- [x] Implement `FightLogPage` component — paginated list of fight summaries, expandable rows
+- [x] Implement inline catch-up banner shown on room join after absence (threshold: > 30 min away, > 0 fights)
+- [x] Add "last fight" one-liner ticker to the bottom of the Ring pane
+- [x] Implement expandable fight detail view (card-by-card breakdown from raw events)
 
 ## Open Questions
 

--- a/docs/roadmap/14-fight-stats.md
+++ b/docs/roadmap/14-fight-stats.md
@@ -252,8 +252,9 @@ Both are populated from ring outcome events. The `FightStatsSubscriber` from `13
 
 ## Pending
 
-- [ ] **Win streak in catch-up text**: the design doc example shows "Stonefang is on a 3-fight winning streak." at the end of a catch-up summary. Not yet implemented. Strategy: query the last N `fight_summaries` for each monster that appeared in the catch-up window, check for a consecutive-win run, append a streak line for any monster with 3+ consecutive wins. Compute at query time from `fight_summaries` — no new counter needed.
-- [ ] **Streak on the Fight Log UI**: once streak logic exists, surface it in the fight log (e.g., badge on a monster's name when it has an active streak).
+- [x] **Win streak in catch-up text**: appended after the fight list for monsters with ≥3 consecutive wins (computed from recent `fight_summaries` for monsters in the catch-up window).
+- [x] **Streak on the Fight Log UI**: winners with an active streak ≥3 show a note under the row; recent fights query uses limit 80 for streak computation client-side.
+- [x] **Multi-monster fight display in web UI**: `FightLogView` and ring “last fight” line use `participants` via `fight-display.ts` helpers when 3+ contestants.
 
 ## Open Questions
 

--- a/docs/roadmap/14-fight-stats.md
+++ b/docs/roadmap/14-fight-stats.md
@@ -44,31 +44,34 @@ fight_summaries: {
   loserMonsterName: text,
   loserOwnerUserId: uuid,
   roundCount: integer not null,
-  winnerXpGained: integer not null default 0,
-  loserXpGained: integer not null default 0,
+  winnerXpGained: integer not null default 0,  // 0 for multi-monster fights (see participants)
+  loserXpGained: integer not null default 0,   // 0 for multi-monster fights (see participants)
   cardDropName: text,                    // null if no card dropped
-  notableCards: text[],                  // card types played that caused significant effects
-  startEventId: bigint references room_events(id),
-  endEventId: bigint references room_events(id),
+  notableCards: text[],                  // reserved; not yet populated
+  participants: jsonb not null default '[]',  // always populated; all N contestants with outcome+xp
 }
-// index on (roomId, endedAt) — for "recent fights in room X" queries
-// index on (roomId, winnerMonsterId) — for per-monster history queries
-// index on (roomId, loserMonsterId)
+// B-tree index on (roomId, endedAt) — "recent fights in room X"
+// B-tree index on (roomId, winnerMonsterId), (roomId, loserMonsterId) — 1v1 fast path
+// GIN index on participants — JSONB containment queries for monster fight history
 ```
 
-`fightNumber` is a monotonically increasing counter per room, stored on the `rooms` table or derived from a `room_fight_counter` sequence. It gives fights a stable human-readable identity ("Fight #42").
+**1v1 vs multi-monster**: `winnerMonsterId`/`loserMonsterId` are convenience columns populated only when `contestants.length === 2` and there is a clear winner/loser. For fights with 3+ contestants (or draws in any size fight), they are null. The `participants` array is always fully populated and is the authoritative source for all fight queries. `queryMonsterFightHistory` uses a JSONB containment query (`participants @> '[{"monsterId":"..."}]'`) so it correctly finds multi-monster fights.
+
+`fightNumber` is a monotonically increasing counter per room stored on `rooms.fight_counter`, atomically incremented in a transaction when writing each summary. It gives fights a stable human-readable identity ("Fight #42").
 
 ### Population: FightSummaryWriter
 
-A server-side event subscriber (`packages/server/src/fight-summary-writer.ts`) watches the event stream and assembles fight summaries:
+`packages/server/src/fight-summary-writer.ts` watches the event stream:
 
-1. On `ring.fight` event: record fight start (timestamp, participants from payload).
-2. On each `card.played` event: accumulate notable cards (e.g., cards dealing ≥ 50% of a creature's HP in one hit).
-3. On `ring.win`, `ring.draw`, `ring.fled`, or `ring.permaDeath` event: write the completed `fight_summary` row.
+1. On `ring.fight` (start event — `eventName !== 'fightConcludes'`): record `startedAt` in an in-memory `pendingByRoom` map.
+2. On `ring.cardDrop` (public): stash the card drop name on the pending record.
+3. On `ring.fightResolved`: atomically increment `rooms.fight_counter`, write the `fight_summaries` row.
 
-The subscriber is stateful per room — it holds an in-memory pending fight record while the fight is in progress. This state is reconstructed on server restart from recent `room_events` (any `ring.fight` event without a subsequent outcome event means a fight was interrupted; mark it as abandoned or simply skip it).
+The subscriber is stateful per process — `pendingByRoom` is not persisted. A server restart during a fight means `startedAt` falls back to `endedAt` (the fight is still recorded; only its duration is lost). See the Pending section for the interrupted-fight edge case.
 
-**Why not derive summaries from `room_events` at query time?** For ad-hoc queries with low volume it would work, but it requires joining and scanning potentially many event rows per fight. Pre-computing summaries is cheaper at read time and allows indexes on fight attributes (outcome, winner, loser) without scanning the raw event log.
+**Why not derive summaries from `room_events` at query time?** For ad-hoc queries with low volume it would work, but it requires joining and scanning many event rows per fight. Pre-computing summaries is cheaper at read time and allows efficient indexes on fight outcome and participants.
+
+**`notableCards` not yet populated**: the current `FightSummaryWriter` doesn't track `card.played` events. This field is reserved for a future pass that identifies "turning point" cards (e.g., cards dealing ≥ 50% of a creature's max HP in one hit).
 
 ### API: tRPC Procedures
 
@@ -116,16 +119,19 @@ Example output:
 ```
 Since you were last here (3 hours ago):
 
-Fight #38 — Stonefang defeated Whisperwind in 4 rounds
+Fight #38 — Stonefang defeated Whisperwind in 4 round(s)
 Fight #39 — Mirebell fled from The Horned Terror
 Fight #40 — Draw between Copperclaw and The Horned Terror
-Fight #41 — Stonefang defeated Mirebell in 6 rounds  ☠ Mirebell perished
-Fight #42 — Stonefang defeated Copperclaw in 3 rounds (card drop: Brain Drain)
-
-Stonefang is on a 3-fight winning streak.
+Fight #41 — Stonefang defeated Mirebell in 6 round(s)  ☠ Mirebell perished
+Fight #42 — Stonefang defeated Copperclaw in 3 round(s) (card drop: Brain Drain)
 ```
 
-The summary highlights win streaks, perma-deaths, and card drops because those are the things players actually care about after a long absence.
+For a 3-monster fight the winner line lists all parties:
+```
+Fight #43 — Stonefang defeated Mirebell and Copperclaw in 5 round(s)
+```
+
+The summary highlights perma-deaths and card drops. Win streaks are a planned addition (see Pending).
 
 If nothing happened: "No fights since you were last here."
 
@@ -223,7 +229,8 @@ Both are populated from ring outcome events. The `FightStatsSubscriber` from `13
 ### Database
 - [x] Add `fight_summaries` table to Drizzle schema + Supabase migration
 - [x] Add `lastSeenAt` column to `room_members` table
-- [x] Add index on `fight_summaries(roomId, endedAt)` and per-monster indexes
+- [x] Add index on `fight_summaries(roomId, endedAt)` and per-monster B-tree indexes
+- [x] Add GIN index on `fight_summaries.participants` for JSONB containment queries (`queryMonsterFightHistory`)
 
 ### Server
 - [x] Implement `FightSummaryWriter` — stateful event subscriber that assembles and writes fight summaries
@@ -243,9 +250,13 @@ Both are populated from ring outcome events. The `FightStatsSubscriber` from `13
 - [x] Add "last fight" one-liner ticker to the bottom of the Ring pane
 - [x] Implement expandable fight detail view (card-by-card breakdown from raw events)
 
+## Pending
+
+- [ ] **Win streak in catch-up text**: the design doc example shows "Stonefang is on a 3-fight winning streak." at the end of a catch-up summary. Not yet implemented. Strategy: query the last N `fight_summaries` for each monster that appeared in the catch-up window, check for a consecutive-win run, append a streak line for any monster with 3+ consecutive wins. Compute at query time from `fight_summaries` — no new counter needed.
+- [ ] **Streak on the Fight Log UI**: once streak logic exists, surface it in the fight log (e.g., badge on a monster's name when it has an active streak).
+
 ## Open Questions
 
-- **How long to retain fight summaries?** The raw `room_events` table has an open question about retention policy (7 days suggested in `02-backend-hosting.md`). Fight summaries are smaller and more valuable to keep longer — 30 or 90 days seems right. Decide during implementation.
-- **Streak tracking**: "Stonefang is on a 3-fight winning streak" is compelling UX. Where does the current streak live — computed from recent `fight_summaries` at query time (simple, slightly expensive), or maintained as a counter on `room_monster_stats` (cheap to read, stateful)? Leaning toward computing it at query time for the first version.
-- **Interrupted fights**: if the server restarts mid-fight, the `FightSummaryWriter`'s in-memory pending fight state is lost. These fights should be marked as abandoned (not win/loss/draw) rather than silently omitted. Add an `'abandoned'` outcome variant.
-- **Multi-monster rings**: the current engine supports 2–12 monsters in the ring. Fight summaries assume 1v1 (winner + loser). Multi-monster fights need a richer participant array. Design the schema with this in mind even if the first implementation only handles 1v1 — use an array of participant objects rather than separate winner/loser columns.
+- **How long to retain fight summaries?** Fight summaries are smaller than raw events and more valuable for historical browsing. 30–90 days is a reasonable default; decide when setting up the retention job for `room_events`.
+- **Interrupted fights**: if the server restarts mid-fight, `FightSummaryWriter`'s in-memory `pendingByRoom` map is lost. Currently the summary is still written on `ring.fightResolved`, but `startedAt` falls back to `endedAt` (zero-duration fight). The fight IS recorded; only the "card-by-card breakdown" event query will be empty. An `'abandoned'` outcome variant isn't needed right now, but the zero-duration signal can be used in a future UI to flag such fights.
+- **Multi-monster fight display in web UI**: the `FightLogPage` currently shows "X vs Y" (1v1 framing). For 3+ contestant fights, the UI needs to render all participants from the `participants` array rather than just `winnerMonsterName`/`loserMonsterName`. The underlying data is there; this is a UI-only fix.

--- a/packages/engine/src/announcements/cardDrop.ts
+++ b/packages/engine/src/announcements/cardDrop.ts
@@ -13,10 +13,12 @@ export function announceCardDrop(
 	{ contestant, card }: CardDropOpts,
 ): void {
 	const cardDropped = actionCard(card, true);
+	const cardDropName = (card?.name ?? (card?.constructor as { name?: string })?.name ?? 'Card') as string;
 
 	const text = `${contestant.monster.identity} finds a card for ${contestant.character.identity} in the dust of the ring:\n\n${cardDropped}`;
 
 	// Send privately to the player and also broadcast publicly
-	eb.publish({ type: 'ring.cardDrop', scope: 'private', targetUserId: contestant.userId, text, payload: { contestant, card } });
-	eb.publish({ type: 'ring.cardDrop', scope: 'public', text, payload: { contestant, card } });
+	const payload = { contestant, card, cardDropName };
+	eb.publish({ type: 'ring.cardDrop', scope: 'private', targetUserId: contestant.userId, text, payload });
+	eb.publish({ type: 'ring.cardDrop', scope: 'public', text, payload });
 }

--- a/packages/engine/src/commands/history.ts
+++ b/packages/engine/src/commands/history.ts
@@ -8,6 +8,8 @@ const LEADERBOARD_MONSTERS = /^top monsters$/i;
 
 const GLOBAL_LEADERBOARD = /^(?:global leaderboard|look at global rankings)$/i;
 
+const GLOBAL_LEADERBOARD_MONSTERS = /^(?:global monster leaderboard|look at global monster rankings)$/i;
+
 const CATCH_UP =
 	/^(?:what happened|catch me up|show recent fights|show fight history|look at fight log)$/i;
 
@@ -25,6 +27,11 @@ export default function historyHandlers(): void {
 	registerPreCharacterHandler(GLOBAL_LEADERBOARD, (opts: ActionOptions) => {
 		const game = opts.game as Game;
 		return game.lookAtGlobalCharacterRankings(opts.channel);
+	});
+
+	registerPreCharacterHandler(GLOBAL_LEADERBOARD_MONSTERS, (opts: ActionOptions) => {
+		const game = opts.game as Game;
+		return game.lookAtGlobalMonsterRankings(opts.channel);
 	});
 
 	registerPreCharacterHandler(CATCH_UP, (opts: ActionOptions) => {

--- a/packages/engine/src/commands/history.ts
+++ b/packages/engine/src/commands/history.ts
@@ -1,0 +1,34 @@
+import type { Game } from '../game.js';
+import { registerPreCharacterHandler, type ActionOptions } from './index.js';
+
+const LEADERBOARD_PLAYERS =
+	/^(?:leaderboard|show leaderboard|look at leaderboard|top players)$/i;
+
+const LEADERBOARD_MONSTERS = /^top monsters$/i;
+
+const GLOBAL_LEADERBOARD = /^(?:global leaderboard|look at global rankings)$/i;
+
+const CATCH_UP =
+	/^(?:what happened|catch me up|show recent fights|show fight history|look at fight log)$/i;
+
+export default function historyHandlers(): void {
+	registerPreCharacterHandler(LEADERBOARD_PLAYERS, (opts: ActionOptions) => {
+		const game = opts.game as Game;
+		return game.lookAtCharacterRankings(opts.channel);
+	});
+
+	registerPreCharacterHandler(LEADERBOARD_MONSTERS, (opts: ActionOptions) => {
+		const game = opts.game as Game;
+		return game.lookAtMonsterRankings(opts.channel);
+	});
+
+	registerPreCharacterHandler(GLOBAL_LEADERBOARD, (opts: ActionOptions) => {
+		const game = opts.game as Game;
+		return game.lookAtGlobalCharacterRankings(opts.channel);
+	});
+
+	registerPreCharacterHandler(CATCH_UP, (opts: ActionOptions) => {
+		const game = opts.game as Game;
+		return game.catchUpCommand(opts.channel, opts.user.id);
+	});
+}

--- a/packages/engine/src/commands/index.ts
+++ b/packages/engine/src/commands/index.ts
@@ -1,4 +1,5 @@
 import lookAtHandlers from './look-at.js';
+import historyHandlers from './history.js';
 import monsterHandlers from './monster.js';
 import characterHandlers from './character.js';
 import storeHandlers from './store.js';
@@ -91,6 +92,13 @@ export function listen(options: { command?: string; game: any } | null): ((actio
 	return null;
 }
 
+export function registerPreCharacterHandler(
+	matcher: RegExp,
+	action: (options: ActionOptions) => Promise<unknown>
+): void {
+	preCharacterHandlers.push({ matcher, action });
+}
+
 export function registerHandler(
 	matcher: RegExp | ((command: string) => RegExpMatchArray | null),
 	action: (options: any) => Promise<unknown>
@@ -113,10 +121,11 @@ export function registerHandler(
 
 let handlersLoaded = false;
 
-export function loadHandlers(): void {
+export function 	loadHandlers(): void {
 	if (handlersLoaded) return;
 	handlersLoaded = true;
 	preCharacterHandlers.push(helpHandler);
+	historyHandlers();
 	lookAtHandlers(registerHandler);
 	monsterHandlers(registerHandler);
 	characterHandlers(registerHandler);

--- a/packages/engine/src/creatures/base.ts
+++ b/packages/engine/src/creatures/base.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { random, sample } from '../helpers/random.js';
 import { startCase } from '../helpers/start-case.js';
 import { BaseClass } from '../shared/baseClass.js';
@@ -113,6 +115,8 @@ export interface CreatureOptions {
 	bonusDamageDice?: string;
 	/** Reserved for future item/equipment effects that grant bonus INT dice. */
 	bonusIntDice?: string;
+	/** Stable id for analytics / leaderboards (persisted in game state). */
+	stableId?: string;
 	[key: string]: unknown;
 }
 
@@ -176,6 +180,15 @@ class BaseCreature extends BaseClass<CreatureOptions> {
 
 	get icon (): string | undefined {
 		return this.options.icon;
+	}
+
+	get stableId (): string {
+		let id = this.options.stableId as string | undefined;
+		if (!id) {
+			id = randomUUID();
+			this.setOptions({ stableId: id });
+		}
+		return id;
 	}
 
 	get givenName (): string {

--- a/packages/engine/src/events/types.ts
+++ b/packages/engine/src/events/types.ts
@@ -4,6 +4,7 @@ export type EventType =
 	| 'ring.clear'
 	| 'ring.countdown'
 	| 'ring.fight'
+	| 'ring.fightResolved'
 	| 'ring.win'
 	| 'ring.loss'
 	| 'ring.draw'

--- a/packages/engine/src/game.ts
+++ b/packages/engine/src/game.ts
@@ -24,6 +24,29 @@ import type { StateStore } from './types/state-store.js';
 // State save debounce: 30 seconds
 const SAVE_DEBOUNCE_MS = 30_000;
 
+export type LeaderboardSortKey = 'xp' | 'wins' | 'winRate' | 'coins';
+
+/** Optional server-injected analytics (web connector). */
+export interface GameAnalyticsCallbacks {
+	fetchRoomPlayerLeaderboard?: (
+		sortBy: LeaderboardSortKey,
+		limit: number
+	) => Promise<string | null>;
+	fetchRoomMonsterLeaderboard?: (
+		sortBy: LeaderboardSortKey,
+		limit: number
+	) => Promise<string | null>;
+	fetchGlobalPlayerLeaderboard?: (
+		sortBy: LeaderboardSortKey,
+		limit: number
+	) => Promise<string | null>;
+	fetchGlobalMonsterLeaderboard?: (
+		sortBy: LeaderboardSortKey,
+		limit: number
+	) => Promise<string | null>;
+	catchUp?: (userId: string, since: Date | null) => Promise<string | null>;
+}
+
 export class Game extends BaseClass {
 	static eventPrefix = 'game';
 
@@ -33,6 +56,8 @@ export class Game extends BaseClass {
 	roomId: string;
 	stateSaveFunc?: (state: string) => void;
 	stateStore?: StateStore;
+	/** Injected by the API server for DB-backed leaderboards / catch-up. */
+	analytics?: GameAnalyticsCallbacks;
 	private _eventBus: RoomEventBus;
 	private _saveDebounce?: ReturnType<typeof setTimeout>;
 	private _disposeListeners: Array<() => void> = [];
@@ -360,26 +385,68 @@ export class Game extends BaseClass {
 		});
 	}
 
-	lookAtCharacterRankings(channel: any): Promise<unknown> {
+	async lookAtCharacterRankings(channel: any): Promise<unknown> {
+		const text = await this.analytics?.fetchRoomPlayerLeaderboard?.('xp', 5);
+		if (text) {
+			return channel({ announce: text, delay: 'short' });
+		}
+
 		const results = this.getCreatureRankings(Object.values(this.characters));
 
-		return Promise.resolve(
-			channel({
-				announce: `*Top ${results.length} Players by XP:*\n\n\`\`\`\n${results.join('\n')}\n\`\`\`\n`,
-				delay: 'short',
-			})
-		);
+		return channel({
+			announce: `*Top ${results.length} Players by XP:*\n\n\`\`\`\n${results.join('\n')}\n\`\`\`\n`,
+			delay: 'short',
+		});
 	}
 
-	lookAtMonsterRankings(channel: any): Promise<unknown> {
+	async lookAtMonsterRankings(channel: any): Promise<unknown> {
+		const text = await this.analytics?.fetchRoomMonsterLeaderboard?.('xp', 5);
+		if (text) {
+			return channel({ announce: text, delay: 'short' });
+		}
+
 		const results = this.getCreatureRankings(Object.values(this.getAllMonstersLookup()));
 
-		return Promise.resolve(
-			channel({
-				announce: `*Top ${results.length} Monsters by XP:*\n\n\`\`\`\n${results.join('\n')}\n\`\`\`\n`,
-				delay: 'short',
-			})
-		);
+		return channel({
+			announce: `*Top ${results.length} Monsters by XP:*\n\n\`\`\`\n${results.join('\n')}\n\`\`\`\n`,
+			delay: 'short',
+		});
+	}
+
+	async lookAtGlobalCharacterRankings(channel: any): Promise<unknown> {
+		const text = await this.analytics?.fetchGlobalPlayerLeaderboard?.('xp', 5);
+		if (text) {
+			return channel({ announce: text, delay: 'short' });
+		}
+
+		return channel({
+			announce: 'Global rankings are not available in this environment.',
+			delay: 'short',
+		});
+	}
+
+	async lookAtGlobalMonsterRankings(channel: any): Promise<unknown> {
+		const text = await this.analytics?.fetchGlobalMonsterLeaderboard?.('xp', 5);
+		if (text) {
+			return channel({ announce: text, delay: 'short' });
+		}
+
+		return channel({
+			announce: 'Global rankings are not available in this environment.',
+			delay: 'short',
+		});
+	}
+
+	async catchUpCommand(channel: any, userId: string): Promise<unknown> {
+		const text = await this.analytics?.catchUp?.(userId, null);
+		if (text) {
+			return channel({ announce: text, delay: 'short' });
+		}
+
+		return channel({
+			announce: 'Catch-up summaries require the web server.',
+			delay: 'short',
+		});
 	}
 
 	editSelfCharacter(channel: any, character: any): Promise<unknown> {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -9,6 +9,7 @@ import { RoomEventBus } from './events/index.js';
 import type { GameEvent, EventType, EventScope, EventSubscriber } from './events/index.js';
 
 export { Game, ConnectorAdapter, RoomEventBus };
+export type { GameAnalyticsCallbacks, LeaderboardSortKey } from './game.js';
 export type { ChannelCallback, GameEvent, EventType, EventScope, EventSubscriber };
 export type { StateStore } from './types/state-store.js';
 export { engineReady, getHydratorStatus } from './helpers/engine-ready.js';

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -29,6 +29,14 @@ export interface Contestant {
 	round?: number;
 }
 
+function participantOutcome(contestant: Contestant, deaths: number): 'win' | 'loss' | 'draw' | 'fled' | 'permaDeath' {
+	if (deaths <= 0) return 'draw';
+	if (contestant.monster.destroyed) return 'permaDeath';
+	if (contestant.monster.dead) return 'loss';
+	if (contestant.fled) return 'fled';
+	return 'win';
+}
+
 export class Ring extends BaseClass {
 	static eventPrefix = 'ring';
 
@@ -679,10 +687,15 @@ export class Ring extends BaseClass {
 			},
 		});
 
+		const xpBefore = contestants.map(c => c.monster.xp as number);
 		contestants.forEach(contestant => {
-			const { userId } = contestant;
-
 			this.awardMonsterXP(contestant, contestants);
+		});
+		const xpGained = contestants.map((c, i) => (c.monster.xp as number) - (xpBefore[i] ?? 0));
+
+		contestants.forEach((contestant, i) => {
+			const { userId } = contestant;
+			const xpDelta = xpGained[i] ?? 0;
 
 			if (deaths > 0) {
 				if (contestant.monster.dead) {
@@ -694,7 +707,7 @@ export class Ring extends BaseClass {
 							scope: 'private',
 							targetUserId: userId,
 							text: `${contestant.monster.givenName} was too badly injured to be revived.`,
-							payload: { contestant },
+							payload: { contestant, xpGained: xpDelta },
 						});
 					} else {
 						this.eventBus.publish({
@@ -702,7 +715,7 @@ export class Ring extends BaseClass {
 							scope: 'private',
 							targetUserId: userId,
 							text: `${contestant.monster.givenName} has died in battle. You may now \`revive\` or \`dismiss\` ${contestant.monster.pronouns.him}.`,
-							payload: { contestant },
+							payload: { contestant, xpGained: xpDelta },
 						});
 					}
 				} else if (contestant.fled) {
@@ -711,7 +724,7 @@ export class Ring extends BaseClass {
 						scope: 'private',
 						targetUserId: userId,
 						text: `${contestant.monster.givenName} lived to fight another day!`,
-						payload: { contestant },
+						payload: { contestant, xpGained: xpDelta },
 					});
 				} else {
 					contestant.won = true;
@@ -721,7 +734,7 @@ export class Ring extends BaseClass {
 						scope: 'private',
 						targetUserId: userId,
 						text: `${contestant.monster.identity} is victorious!`,
-						payload: { contestant },
+						payload: { contestant, xpGained: xpDelta },
 					});
 				}
 			} else {
@@ -730,9 +743,70 @@ export class Ring extends BaseClass {
 					scope: 'private',
 					targetUserId: userId,
 					text: 'The fight ended in a draw.',
-					payload: { contestant },
+					payload: { contestant, xpGained: xpDelta },
 				});
 			}
+		});
+
+		let winnerMonsterId: string | undefined;
+		let winnerMonsterName: string | undefined;
+		let winnerOwnerUserId: string | undefined;
+		let loserMonsterId: string | undefined;
+		let loserMonsterName: string | undefined;
+		let loserOwnerUserId: string | undefined;
+		if (contestants.length === 2 && deaths > 0) {
+			const w = contestants.find(c => c.won);
+			const l = contestants.find(c => c.lost);
+			if (w && l) {
+				winnerMonsterId = w.monster.stableId;
+				winnerMonsterName = w.monster.givenName;
+				winnerOwnerUserId = w.userId;
+				loserMonsterId = l.monster.stableId;
+				loserMonsterName = l.monster.givenName;
+				loserOwnerUserId = l.userId;
+			}
+		}
+
+		const participants = contestants.map((c, i) => {
+			const m = c.monster;
+			const ch = c.character;
+			return {
+				monsterId: m.stableId as string,
+				monsterName: m.givenName as string,
+				monsterType: (m.constructor?.name ?? 'Monster') as string,
+				ownerUserId: c.userId as string,
+				ownerDisplayName: (ch.givenName ?? ch.name ?? '') as string,
+				outcome: participantOutcome(c, deaths),
+				xpGained: xpGained[i] ?? 0,
+				level: m.level as number,
+			};
+		});
+
+		const fightOutcome =
+			deaths <= 0
+				? 'draw'
+				: contestants.some(c => c.monster.destroyed)
+					? 'permaDeath'
+					: contestants.some(c => c.fled)
+						? 'fled'
+						: 'win';
+
+		this.eventBus.publish({
+			type: 'ring.fightResolved',
+			scope: 'public',
+			text: `Fight resolved (${fightOutcome})`,
+			payload: {
+				rounds,
+				deaths,
+				outcome: fightOutcome,
+				participants,
+				winnerMonsterId,
+				winnerMonsterName,
+				winnerOwnerUserId,
+				loserMonsterId,
+				loserMonsterName,
+				loserOwnerUserId,
+			},
 		});
 
 		this.emit('fightConcludes', {

--- a/packages/server/scripts/backfill-leaderboard-from-state.ts
+++ b/packages/server/scripts/backfill-leaderboard-from-state.ts
@@ -1,0 +1,86 @@
+/**
+ * One-off: seed room_player_stats / room_monster_stats from serialized room state blobs.
+ * Run with: DATABASE_URL=... pnpm exec tsx scripts/backfill-leaderboard-from-state.ts
+ *
+ * Does not infer win/loss history (starts at 0); updates XP/levels/names from current state.
+ */
+import { restoreGame } from '@deck-monsters/engine';
+
+import { db } from '../src/db/index.js';
+import { rooms, roomPlayerStats, roomMonsterStats } from '../src/db/schema.js';
+
+async function main(): Promise<void> {
+	const rows = await db.select({ id: rooms.id, stateBlob: rooms.stateBlob }).from(rooms);
+
+	for (const row of rows) {
+		if (!row.stateBlob) continue;
+		let game: ReturnType<typeof restoreGame>;
+		try {
+			game = restoreGame(row.stateBlob, () => {});
+		} catch {
+			console.warn(`skip room ${row.id}: bad state blob`);
+			continue;
+		}
+
+		const characters = (game as any).characters as Record<string, any> | undefined;
+		if (characters) {
+			for (const [userId, ch] of Object.entries(characters)) {
+				const xp = ch.xp ?? 0;
+				await db
+					.insert(roomPlayerStats)
+					.values({
+						roomId: row.id,
+						userId,
+						xp,
+						wins: 0,
+						losses: 0,
+						draws: 0,
+						coinsEarned: ch.coins ?? 0,
+					})
+					.onConflictDoUpdate({
+						target: [roomPlayerStats.roomId, roomPlayerStats.userId],
+						set: { xp, coinsEarned: ch.coins ?? 0 },
+					});
+
+				for (const m of ch.monsters ?? []) {
+					const mid = m?.stableId;
+					if (typeof mid !== 'string') continue;
+					await db
+						.insert(roomMonsterStats)
+						.values({
+							roomId: row.id,
+							monsterId: mid,
+							ownerUserId: userId,
+							displayName: m.givenName ?? 'Monster',
+							monsterType: m.constructor?.name ?? 'Monster',
+							xp: m.xp ?? 0,
+							level: m.level ?? 1,
+							wins: m.battles?.wins ?? 0,
+							losses: m.battles?.losses ?? 0,
+							draws: 0,
+						})
+						.onConflictDoUpdate({
+							target: [roomMonsterStats.roomId, roomMonsterStats.monsterId],
+							set: {
+								ownerUserId: userId,
+								displayName: m.givenName ?? 'Monster',
+								monsterType: m.constructor?.name ?? 'Monster',
+								xp: m.xp ?? 0,
+								level: m.level ?? 1,
+								wins: m.battles?.wins ?? 0,
+								losses: m.battles?.losses ?? 0,
+							},
+						});
+				}
+			}
+		}
+
+		game.dispose?.();
+		console.log(`backfilled room ${row.id}`);
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/packages/server/src/analytics-queries.streak.test.ts
+++ b/packages/server/src/analytics-queries.streak.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+
+import type { FightSummaryRow } from './analytics-queries.js';
+import { winStreakFromRecentFights } from './analytics-queries.js';
+
+function p(
+	monsterId: string,
+	outcome: 'win' | 'loss' | 'draw' | 'fled' | 'permaDeath'
+): FightSummaryRow['participants'][0] {
+	return {
+		monsterId,
+		monsterName: monsterId,
+		monsterType: 'T',
+		ownerUserId: 'u',
+		ownerDisplayName: 'U',
+		outcome,
+		xpGained: 0,
+		level: 1,
+	};
+}
+
+describe('winStreakFromRecentFights', () => {
+	it('counts consecutive wins from most recent', () => {
+		const fights: FightSummaryRow[] = [
+			{
+				id: 1,
+				roomId: 'r',
+				fightNumber: 5,
+				startedAt: new Date(),
+				endedAt: new Date(),
+				outcome: 'win',
+				winnerMonsterId: 'a',
+				winnerMonsterName: 'A',
+				winnerOwnerUserId: null,
+				loserMonsterId: 'b',
+				loserMonsterName: 'B',
+				loserOwnerUserId: null,
+				roundCount: 1,
+				winnerXpGained: 0,
+				loserXpGained: 0,
+				cardDropName: null,
+				participants: [p('a', 'win'), p('b', 'loss')],
+			},
+			{
+				id: 2,
+				roomId: 'r',
+				fightNumber: 4,
+				startedAt: new Date(),
+				endedAt: new Date(),
+				outcome: 'win',
+				winnerMonsterId: 'a',
+				winnerMonsterName: 'A',
+				winnerOwnerUserId: null,
+				loserMonsterId: 'b',
+				loserMonsterName: 'B',
+				loserOwnerUserId: null,
+				roundCount: 1,
+				winnerXpGained: 0,
+				loserXpGained: 0,
+				cardDropName: null,
+				participants: [p('a', 'win'), p('b', 'loss')],
+			},
+			{
+				id: 3,
+				roomId: 'r',
+				fightNumber: 3,
+				startedAt: new Date(),
+				endedAt: new Date(),
+				outcome: 'win',
+				winnerMonsterId: 'b',
+				winnerMonsterName: 'B',
+				winnerOwnerUserId: null,
+				loserMonsterId: 'a',
+				loserMonsterName: 'A',
+				loserOwnerUserId: null,
+				roundCount: 1,
+				winnerXpGained: 0,
+				loserXpGained: 0,
+				cardDropName: null,
+				participants: [p('b', 'win'), p('a', 'loss')],
+			},
+		];
+		expect(winStreakFromRecentFights(fights, 'a')).to.equal(2);
+		expect(winStreakFromRecentFights(fights, 'b')).to.equal(0);
+	});
+});

--- a/packages/server/src/analytics-queries.ts
+++ b/packages/server/src/analytics-queries.ts
@@ -350,6 +350,18 @@ export async function queryGlobalMonsters(
 	}));
 }
 
+/** Shape of each participant object inside fight_summaries.participants. */
+export type FightParticipant = {
+	monsterId: string;
+	monsterName: string;
+	monsterType: string;
+	ownerUserId: string;
+	ownerDisplayName: string;
+	outcome: 'win' | 'loss' | 'draw' | 'fled' | 'permaDeath';
+	xpGained: number;
+	level: number;
+};
+
 export type FightSummaryRow = {
 	id: number;
 	roomId: string;
@@ -357,6 +369,7 @@ export type FightSummaryRow = {
 	startedAt: Date;
 	endedAt: Date;
 	outcome: string;
+	// 1v1 convenience fields — null for fights with 3+ contestants.
 	winnerMonsterId: string | null;
 	winnerMonsterName: string | null;
 	winnerOwnerUserId: string | null;
@@ -367,7 +380,7 @@ export type FightSummaryRow = {
 	winnerXpGained: number;
 	loserXpGained: number;
 	cardDropName: string | null;
-	participants: unknown;
+	participants: FightParticipant[];
 };
 
 export async function queryRecentFights(
@@ -407,16 +420,17 @@ export async function queryMonsterFightHistory(
 	monsterId: string,
 	limit: number
 ): Promise<FightSummaryRow[]> {
+	// Use JSONB containment to find all fights where this monster appeared as a
+	// participant, regardless of how many contestants there were. This covers both
+	// 1v1 fights (where winnerMonsterId / loserMonsterId are set) and multi-monster
+	// fights (where those columns are null but participants[] always has everyone).
 	return db
 		.select()
 		.from(fightSummaries)
 		.where(
 			and(
 				eq(fightSummaries.roomId, roomId),
-				or(
-					eq(fightSummaries.winnerMonsterId, monsterId),
-					eq(fightSummaries.loserMonsterId, monsterId)
-				)
+				sql`${fightSummaries.participants} @> ${JSON.stringify([{ monsterId }])}::jsonb`
 			)
 		)
 		.orderBy(desc(fightSummaries.endedAt))
@@ -459,6 +473,47 @@ export function formatSinceLabel(d: Date): string {
 	return `${hrs} hour${hrs === 1 ? '' : 's'} ago`;
 }
 
+function nameList(names: string[]): string {
+	if (names.length === 0) return 'Unknown';
+	if (names.length === 1) return names[0]!;
+	if (names.length === 2) return `${names[0]} and ${names[1]}`;
+	return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+}
+
+function fightLine(s: FightSummaryRow): string {
+	const ps = s.participants;
+	let line = `Fight #${s.fightNumber} — `;
+
+	if (s.outcome === 'draw') {
+		// All participants drew — list everyone.
+		const names = ps.length > 0 ? ps.map(p => p.monsterName) : [s.winnerMonsterName ?? 'Unknown', s.loserMonsterName ?? 'Unknown'];
+		line += `Draw between ${nameList(names)}`;
+	} else if (s.outcome === 'fled') {
+		// Someone fled — show who survived vs who fled.
+		const fled = ps.filter(p => p.outcome === 'fled').map(p => p.monsterName);
+		const survived = ps.filter(p => p.outcome === 'win').map(p => p.monsterName);
+		if (fled.length > 0 && ps.length > 0) {
+			line += survived.length > 0
+				? `${nameList(fled)} fled from ${nameList(survived)}`
+				: `${nameList(fled)} fled`;
+		} else {
+			line += `${s.winnerMonsterName ?? 'Unknown'} fled from ${s.loserMonsterName ?? 'Unknown'}`;
+		}
+	} else {
+		// win or permaDeath — one or more winners, one or more losers.
+		const winners = ps.length > 0 ? ps.filter(p => p.outcome === 'win').map(p => p.monsterName) : [];
+		const losers = ps.length > 0 ? ps.filter(p => p.outcome === 'loss' || p.outcome === 'permaDeath').map(p => p.monsterName) : [];
+		const perished = ps.length > 0 ? ps.filter(p => p.outcome === 'permaDeath').map(p => p.monsterName) : [];
+		const w = winners.length > 0 ? nameList(winners) : s.winnerMonsterName ?? 'Unknown';
+		const l = losers.length > 0 ? nameList(losers) : s.loserMonsterName ?? 'Unknown';
+		line += `${w} defeated ${l} in ${s.roundCount} round(s)`;
+		if (perished.length > 0) line += `  ☠ ${nameList(perished)} perished`;
+	}
+
+	if (s.cardDropName) line += ` (card drop: ${s.cardDropName})`;
+	return line;
+}
+
 export function buildCatchUpText(
 	summaries: FightSummaryRow[],
 	sinceLabel: string
@@ -469,20 +524,7 @@ export function buildCatchUpText(
 
 	const lines: string[] = [`Since you were last here (${sinceLabel}):\n`];
 	for (const s of summaries) {
-		const w = s.winnerMonsterName ?? 'Unknown';
-		const l = s.loserMonsterName ?? 'Unknown';
-		let line = `Fight #${s.fightNumber} — `;
-		if (s.outcome === 'draw') {
-			line += `Draw between ${w} and ${l}`;
-		} else if (s.outcome === 'fled') {
-			line += `${w} fled from ${l}`;
-		} else if (s.outcome === 'permaDeath') {
-			line += `${w} defeated ${l} in ${s.roundCount} round(s)  ☠ ${l} perished`;
-		} else {
-			line += `${w} defeated ${l} in ${s.roundCount} round(s)`;
-		}
-		if (s.cardDropName) line += ` (card drop: ${s.cardDropName})`;
-		lines.push(line);
+		lines.push(fightLine(s));
 	}
 
 	return { fightCount: summaries.length, textSummary: lines.join('\n') };

--- a/packages/server/src/analytics-queries.ts
+++ b/packages/server/src/analytics-queries.ts
@@ -1,0 +1,509 @@
+import { and, asc, desc, eq, gte, inArray, lte, lt, or, sql } from 'drizzle-orm';
+
+import type { Db } from './db/index.js';
+import {
+	fightSummaries,
+	profiles,
+	roomEvents,
+	roomMonsterStats,
+	roomPlayerStats,
+	roomMembers,
+} from './db/schema.js';
+import type { GameEvent } from '@deck-monsters/engine';
+import { dbRowToGameEvent } from './db/game-event-map.js';
+
+export type LeaderboardSort = 'xp' | 'wins' | 'winRate' | 'coins';
+
+export function formatRoomPlayerLeaderboard(title: string, rows: Awaited<ReturnType<typeof queryRoomPlayers>>): string {
+	const lines = rows.map((r, i) => {
+		const wr = Math.round(r.winRate * 100);
+		return `${i + 1}. ${r.displayName}   ${r.xp} XP   ${r.wins}W ${r.losses}L ${wr}%`;
+	});
+	return `*${title}*\n\n\`\`\`\n${lines.join('\n') || '(no data yet)'}\n\`\`\`\n`;
+}
+
+export function formatRoomMonsterLeaderboard(title: string, rows: Awaited<ReturnType<typeof queryRoomMonsters>>): string {
+	const lines = rows.map((r, i) => {
+		const wr = Math.round(r.winRate * 100);
+		const owner = r.ownerName ? ` (${r.ownerName})` : '';
+		return `${i + 1}. ${r.displayName}${owner}   ${r.monsterType}   ${r.xp} XP L${r.level}   ${r.wins}W ${r.losses}L ${wr}%`;
+	});
+	return `*${title}*\n\n\`\`\`\n${lines.join('\n') || '(no data yet)'}\n\`\`\`\n`;
+}
+
+export function formatGlobalPlayerLeaderboard(title: string, rows: Awaited<ReturnType<typeof queryGlobalPlayers>>): string {
+	const lines = rows.map((r, i) => {
+		const wr = Math.round(r.winRate * 100);
+		return `${i + 1}. ${r.displayName}   ${r.xp} XP   ${r.wins}W ${r.losses}L ${wr}%   rooms: ${r.roomCount}`;
+	});
+	return `*${title}*\n\n\`\`\`\n${lines.join('\n') || '(no data yet)'}\n\`\`\`\n`;
+}
+
+export function formatGlobalMonsterLeaderboard(title: string, rows: Awaited<ReturnType<typeof queryGlobalMonsters>>): string {
+	const lines = rows.map((r, i) => {
+		const wr = Math.round(r.winRate * 100);
+		const owner = r.ownerName ? ` (${r.ownerName})` : '';
+		return `${i + 1}. ${r.displayName}${owner}   ${r.monsterType}   ${r.xp} XP L${r.level}   ${r.wins}W ${r.losses}L ${wr}%`;
+	});
+	return `*${title}*\n\n\`\`\`\n${lines.join('\n') || '(no data yet)'}\n\`\`\`\n`;
+}
+
+function winRateExpr() {
+	return sql<number>`case when (${roomPlayerStats.wins} + ${roomPlayerStats.losses}) > 0
+		then ${roomPlayerStats.wins}::float / (${roomPlayerStats.wins} + ${roomPlayerStats.losses})
+		else 0 end`;
+}
+
+function monsterWinRateExpr() {
+	return sql<number>`case when (${roomMonsterStats.wins} + ${roomMonsterStats.losses}) > 0
+		then ${roomMonsterStats.wins}::float / (${roomMonsterStats.wins} + ${roomMonsterStats.losses})
+		else 0 end`;
+}
+
+export async function queryRoomPlayers(
+	db: Db,
+	roomId: string,
+	sortBy: LeaderboardSort,
+	limit: number
+): Promise<
+	Array<{
+		displayName: string;
+		xp: number;
+		wins: number;
+		losses: number;
+		draws: number;
+		winRate: number;
+		coinsEarned: number;
+	}>
+> {
+	const orderBy =
+		sortBy === 'wins'
+			? desc(roomPlayerStats.wins)
+			: sortBy === 'coins'
+				? desc(roomPlayerStats.coinsEarned)
+				: sortBy === 'winRate'
+					? desc(winRateExpr())
+					: desc(roomPlayerStats.xp);
+
+	const rows = await db
+		.select({
+			displayName: profiles.displayName,
+			xp: roomPlayerStats.xp,
+			wins: roomPlayerStats.wins,
+			losses: roomPlayerStats.losses,
+			draws: roomPlayerStats.draws,
+			coinsEarned: roomPlayerStats.coinsEarned,
+			winRate: winRateExpr().as('wr'),
+		})
+		.from(roomPlayerStats)
+		.innerJoin(profiles, eq(roomPlayerStats.userId, profiles.id))
+		.where(eq(roomPlayerStats.roomId, roomId))
+		.orderBy(orderBy)
+		.limit(limit);
+
+	return rows.map((r) => ({
+		displayName: r.displayName,
+		xp: r.xp,
+		wins: r.wins,
+		losses: r.losses,
+		draws: r.draws,
+		coinsEarned: r.coinsEarned,
+		winRate: Number(r.winRate),
+	}));
+}
+
+export async function queryRoomMonsters(
+	db: Db,
+	roomId: string,
+	sortBy: LeaderboardSort,
+	limit: number
+): Promise<
+	Array<{
+		displayName: string;
+		monsterType: string;
+		ownerName: string | null;
+		xp: number;
+		level: number;
+		wins: number;
+		losses: number;
+		draws: number;
+		winRate: number;
+	}>
+> {
+	const orderBy =
+		sortBy === 'wins'
+			? desc(roomMonsterStats.wins)
+			: sortBy === 'coins'
+				? desc(roomMonsterStats.xp)
+				: sortBy === 'winRate'
+					? desc(monsterWinRateExpr())
+					: desc(roomMonsterStats.xp);
+
+	const rows = await db
+		.select({
+			displayName: roomMonsterStats.displayName,
+			monsterType: roomMonsterStats.monsterType,
+			ownerId: roomMonsterStats.ownerUserId,
+			xp: roomMonsterStats.xp,
+			level: roomMonsterStats.level,
+			wins: roomMonsterStats.wins,
+			losses: roomMonsterStats.losses,
+			draws: roomMonsterStats.draws,
+			winRate: monsterWinRateExpr().as('mwr'),
+		})
+		.from(roomMonsterStats)
+		.where(eq(roomMonsterStats.roomId, roomId))
+		.orderBy(orderBy)
+		.limit(limit);
+
+	const ownerIds = [...new Set(rows.map((r) => r.ownerId).filter(Boolean))] as string[];
+	const names = new Map<string, string>();
+	if (ownerIds.length > 0) {
+		const profs = await db
+			.select({ id: profiles.id, displayName: profiles.displayName })
+			.from(profiles)
+			.where(inArray(profiles.id, ownerIds));
+		for (const p of profs) names.set(p.id, p.displayName);
+	}
+
+	return rows.map((r) => ({
+		displayName: r.displayName,
+		monsterType: r.monsterType,
+		ownerName: r.ownerId ? (names.get(r.ownerId) ?? null) : null,
+		xp: r.xp,
+		level: r.level,
+		wins: r.wins,
+		losses: r.losses,
+		draws: r.draws,
+		winRate: Number(r.winRate),
+	}));
+}
+
+export async function queryGlobalPlayers(
+	db: Db,
+	sortBy: LeaderboardSort,
+	limit: number
+): Promise<
+	Array<{
+		displayName: string;
+		xp: number;
+		wins: number;
+		losses: number;
+		draws: number;
+		winRate: number;
+		coinsEarned: number;
+		roomCount: number;
+	}>
+> {
+	const orderBy =
+		sortBy === 'wins'
+			? 'tw desc'
+			: sortBy === 'coins'
+				? 'tc desc'
+				: sortBy === 'winRate'
+					? 'gwr desc'
+					: 'txp desc';
+
+	const rows = await db.execute(sql`
+		select
+			p.display_name as "displayName",
+			agg.txp::int as xp,
+			agg.tw::int as wins,
+			agg.tl::int as losses,
+			agg.td::int as draws,
+			agg.tc::int as "coinsEarned",
+			agg.rc::int as "roomCount",
+			agg.gwr::float8 as "winRate"
+		from (
+			select
+				user_id,
+				sum(xp)::bigint as txp,
+				sum(wins)::bigint as tw,
+				sum(losses)::bigint as tl,
+				sum(draws)::bigint as td,
+				sum(coins_earned)::bigint as tc,
+				count(distinct room_id)::bigint as rc,
+				case
+					when sum(wins + losses) > 0 then sum(wins)::float / sum(wins + losses)
+					else 0
+				end as gwr
+			from room_player_stats
+			group by user_id
+		) agg
+		inner join profiles p on p.id = agg.user_id
+		order by ${sql.raw(orderBy)}
+		limit ${limit}
+	`);
+
+	const out = rows.rows as Array<{
+		displayName: string;
+		xp: number;
+		wins: number;
+		losses: number;
+		draws: number;
+		coinsEarned: number;
+		roomCount: number;
+		winRate: number;
+	}>;
+
+	return out.map((r) => ({
+		displayName: r.displayName,
+		xp: Number(r.xp),
+		wins: Number(r.wins),
+		losses: Number(r.losses),
+		draws: Number(r.draws),
+		coinsEarned: Number(r.coinsEarned),
+		roomCount: Number(r.roomCount),
+		winRate: Number(r.winRate),
+	}));
+}
+
+export async function queryGlobalMonsters(
+	db: Db,
+	sortBy: LeaderboardSort,
+	limit: number
+): Promise<
+	Array<{
+		displayName: string;
+		monsterType: string;
+		ownerName: string | null;
+		xp: number;
+		level: number;
+		wins: number;
+		losses: number;
+		draws: number;
+		winRate: number;
+	}>
+> {
+	const orderBy =
+		sortBy === 'wins'
+			? 'tw desc'
+			: sortBy === 'winRate'
+				? 'gwr desc'
+				: 'txp desc';
+
+	const rows = await db.execute(sql`
+		select
+			gm.dn as "displayName",
+			gm.mt as "monsterType",
+			gm.oid as "ownerId",
+			gm.txp::int as xp,
+			gm.tlv::int as level,
+			gm.tw::int as wins,
+			gm.tl::int as losses,
+			gm.td::int as draws,
+			gm.gwr::float8 as "winRate"
+		from (
+			select
+				monster_id,
+				max(display_name) as dn,
+				max(monster_type) as mt,
+				max(owner_user_id) as oid,
+				sum(xp)::bigint as txp,
+				max(level)::bigint as tlv,
+				sum(wins)::bigint as tw,
+				sum(losses)::bigint as tl,
+				sum(draws)::bigint as td,
+				case
+					when sum(wins + losses) > 0 then sum(wins)::float / sum(wins + losses)
+					else 0
+				end as gwr
+			from room_monster_stats
+			group by monster_id
+		) gm
+		order by ${sql.raw(orderBy)}
+		limit ${limit}
+	`);
+
+	const raw = rows.rows as Array<{
+		displayName: string;
+		monsterType: string;
+		ownerId: string | null;
+		xp: number;
+		level: number;
+		wins: number;
+		losses: number;
+		draws: number;
+		winRate: number;
+	}>;
+
+	const ownerIds = [...new Set(raw.map((r) => r.ownerId).filter(Boolean))] as string[];
+	const names = new Map<string, string>();
+	if (ownerIds.length > 0) {
+		const profs = await db
+			.select({ id: profiles.id, displayName: profiles.displayName })
+			.from(profiles)
+			.where(inArray(profiles.id, ownerIds));
+		for (const p of profs) names.set(p.id, p.displayName);
+	}
+
+	return raw.map((r) => ({
+		displayName: r.displayName,
+		monsterType: r.monsterType,
+		ownerName: r.ownerId ? (names.get(r.ownerId) ?? null) : null,
+		xp: Number(r.xp),
+		level: Number(r.level),
+		wins: Number(r.wins),
+		losses: Number(r.losses),
+		draws: Number(r.draws),
+		winRate: Number(r.winRate),
+	}));
+}
+
+export type FightSummaryRow = {
+	id: number;
+	roomId: string;
+	fightNumber: number;
+	startedAt: Date;
+	endedAt: Date;
+	outcome: string;
+	winnerMonsterId: string | null;
+	winnerMonsterName: string | null;
+	winnerOwnerUserId: string | null;
+	loserMonsterId: string | null;
+	loserMonsterName: string | null;
+	loserOwnerUserId: string | null;
+	roundCount: number;
+	winnerXpGained: number;
+	loserXpGained: number;
+	cardDropName: string | null;
+	participants: unknown;
+};
+
+export async function queryRecentFights(
+	db: Db,
+	roomId: string,
+	limit: number,
+	before?: Date
+): Promise<FightSummaryRow[]> {
+	const cond = before
+		? and(eq(fightSummaries.roomId, roomId), lt(fightSummaries.endedAt, before))
+		: eq(fightSummaries.roomId, roomId);
+
+	return db
+		.select()
+		.from(fightSummaries)
+		.where(cond)
+		.orderBy(desc(fightSummaries.endedAt))
+		.limit(limit) as Promise<FightSummaryRow[]>;
+}
+
+export async function queryFightByNumber(
+	db: Db,
+	roomId: string,
+	fightNumber: number
+): Promise<(FightSummaryRow & { startedAt: Date; endedAt: Date }) | undefined> {
+	const rows = await db
+		.select()
+		.from(fightSummaries)
+		.where(and(eq(fightSummaries.roomId, roomId), eq(fightSummaries.fightNumber, fightNumber)))
+		.limit(1);
+	return rows[0] as (FightSummaryRow & { startedAt: Date; endedAt: Date }) | undefined;
+}
+
+export async function queryMonsterFightHistory(
+	db: Db,
+	roomId: string,
+	monsterId: string,
+	limit: number
+): Promise<FightSummaryRow[]> {
+	return db
+		.select()
+		.from(fightSummaries)
+		.where(
+			and(
+				eq(fightSummaries.roomId, roomId),
+				or(
+					eq(fightSummaries.winnerMonsterId, monsterId),
+					eq(fightSummaries.loserMonsterId, monsterId)
+				)
+			)
+		)
+		.orderBy(desc(fightSummaries.endedAt))
+		.limit(limit) as Promise<FightSummaryRow[]>;
+}
+
+export async function queryFightsSince(db: Db, roomId: string, since: Date): Promise<FightSummaryRow[]> {
+	return db
+		.select()
+		.from(fightSummaries)
+		.where(and(eq(fightSummaries.roomId, roomId), gte(fightSummaries.endedAt, since)))
+		.orderBy(fightSummaries.endedAt) as Promise<FightSummaryRow[]>;
+}
+
+export async function getMemberLastSeen(
+	db: Db,
+	roomId: string,
+	userId: string
+): Promise<Date | null> {
+	const rows = await db
+		.select({ lastSeenAt: roomMembers.lastSeenAt })
+		.from(roomMembers)
+		.where(and(eq(roomMembers.roomId, roomId), eq(roomMembers.userId, userId)))
+		.limit(1);
+	return rows[0]?.lastSeenAt ?? null;
+}
+
+export async function touchMemberLastSeen(db: Db, roomId: string, userId: string): Promise<void> {
+	await db
+		.update(roomMembers)
+		.set({ lastSeenAt: new Date() })
+		.where(and(eq(roomMembers.roomId, roomId), eq(roomMembers.userId, userId)));
+}
+
+export function formatSinceLabel(d: Date): string {
+	const ms = Date.now() - d.getTime();
+	const mins = Math.round(ms / 60000);
+	if (mins < 120) return `${mins} minutes ago`;
+	const hrs = Math.floor(mins / 60);
+	return `${hrs} hour${hrs === 1 ? '' : 's'} ago`;
+}
+
+export function buildCatchUpText(
+	summaries: FightSummaryRow[],
+	sinceLabel: string
+): { fightCount: number; textSummary: string } {
+	if (summaries.length === 0) {
+		return { fightCount: 0, textSummary: 'No fights since you were last here.' };
+	}
+
+	const lines: string[] = [`Since you were last here (${sinceLabel}):\n`];
+	for (const s of summaries) {
+		const w = s.winnerMonsterName ?? 'Unknown';
+		const l = s.loserMonsterName ?? 'Unknown';
+		let line = `Fight #${s.fightNumber} — `;
+		if (s.outcome === 'draw') {
+			line += `Draw between ${w} and ${l}`;
+		} else if (s.outcome === 'fled') {
+			line += `${w} fled from ${l}`;
+		} else if (s.outcome === 'permaDeath') {
+			line += `${w} defeated ${l} in ${s.roundCount} round(s)  ☠ ${l} perished`;
+		} else {
+			line += `${w} defeated ${l} in ${s.roundCount} round(s)`;
+		}
+		if (s.cardDropName) line += ` (card drop: ${s.cardDropName})`;
+		lines.push(line);
+	}
+
+	return { fightCount: summaries.length, textSummary: lines.join('\n') };
+}
+
+export async function loadFightEventsForSummary(
+	db: Db,
+	roomId: string,
+	startedAt: Date,
+	endedAt: Date
+): Promise<GameEvent[]> {
+	const rows = await db
+		.select()
+		.from(roomEvents)
+		.where(
+			and(
+				eq(roomEvents.roomId, roomId),
+				gte(roomEvents.createdAt, startedAt),
+				lte(roomEvents.createdAt, endedAt)
+			)
+		)
+		.orderBy(asc(roomEvents.id));
+	return rows.map(dbRowToGameEvent);
+}

--- a/packages/server/src/analytics-queries.ts
+++ b/packages/server/src/analytics-queries.ts
@@ -22,11 +22,17 @@ export function formatRoomPlayerLeaderboard(title: string, rows: Awaited<ReturnT
 	return `*${title}*\n\n\`\`\`\n${lines.join('\n') || '(no data yet)'}\n\`\`\`\n`;
 }
 
-export function formatRoomMonsterLeaderboard(title: string, rows: Awaited<ReturnType<typeof queryRoomMonsters>>): string {
+export function formatRoomMonsterLeaderboard(
+	title: string,
+	rows: Awaited<ReturnType<typeof queryRoomMonsters>>,
+	streakByMonsterId?: Map<string, number>
+): string {
 	const lines = rows.map((r, i) => {
 		const wr = Math.round(r.winRate * 100);
 		const owner = r.ownerName ? ` (${r.ownerName})` : '';
-		return `${i + 1}. ${r.displayName}${owner}   ${r.monsterType}   ${r.xp} XP L${r.level}   ${r.wins}W ${r.losses}L ${wr}%`;
+		const streak = streakByMonsterId?.get(r.monsterId);
+		const streakStr = streak !== undefined && streak > 0 ? `   streak ${streak}` : '';
+		return `${i + 1}. ${r.displayName}${owner}   ${r.monsterType}   ${r.xp} XP L${r.level}   ${r.wins}W ${r.losses}L ${wr}%${streakStr}`;
 	});
 	return `*${title}*\n\n\`\`\`\n${lines.join('\n') || '(no data yet)'}\n\`\`\`\n`;
 }
@@ -119,6 +125,7 @@ export async function queryRoomMonsters(
 	limit: number
 ): Promise<
 	Array<{
+		monsterId: string;
 		displayName: string;
 		monsterType: string;
 		ownerName: string | null;
@@ -141,6 +148,7 @@ export async function queryRoomMonsters(
 
 	const rows = await db
 		.select({
+			monsterId: roomMonsterStats.monsterId,
 			displayName: roomMonsterStats.displayName,
 			monsterType: roomMonsterStats.monsterType,
 			ownerId: roomMonsterStats.ownerUserId,
@@ -167,6 +175,7 @@ export async function queryRoomMonsters(
 	}
 
 	return rows.map((r) => ({
+		monsterId: r.monsterId,
 		displayName: r.displayName,
 		monsterType: r.monsterType,
 		ownerName: r.ownerId ? (names.get(r.ownerId) ?? null) : null,
@@ -516,7 +525,8 @@ function fightLine(s: FightSummaryRow): string {
 
 export function buildCatchUpText(
 	summaries: FightSummaryRow[],
-	sinceLabel: string
+	sinceLabel: string,
+	streakLines?: string[]
 ): { fightCount: number; textSummary: string } {
 	if (summaries.length === 0) {
 		return { fightCount: 0, textSummary: 'No fights since you were last here.' };
@@ -527,7 +537,94 @@ export function buildCatchUpText(
 		lines.push(fightLine(s));
 	}
 
+	if (streakLines && streakLines.length > 0) {
+		lines.push('');
+		for (const sl of streakLines) lines.push(sl);
+	}
+
 	return { fightCount: summaries.length, textSummary: lines.join('\n') };
+}
+
+const STREAK_MIN = 3;
+const STREAK_LOOKBACK = 80;
+
+/** Count consecutive wins for `monsterId` from most recent fights (fights ordered endedAt DESC). */
+export function winStreakFromRecentFights(fights: FightSummaryRow[], monsterId: string): number {
+	let n = 0;
+	for (const f of fights) {
+		const p = f.participants?.find((x) => x.monsterId === monsterId);
+		if (!p) continue;
+		if (p.outcome === 'win') n += 1;
+		else break;
+	}
+	return n;
+}
+
+/** Unique monster IDs that appear in these summaries (any outcome). */
+export function monsterIdsFromSummaries(summaries: FightSummaryRow[]): string[] {
+	const s = new Set<string>();
+	for (const row of summaries) {
+		for (const p of row.participants ?? []) {
+			if (p.monsterId) s.add(p.monsterId);
+		}
+	}
+	return [...s];
+}
+
+/**
+ * Current win streak for each monster (most recent fights first). Only monsters with streak >= minStreak are returned.
+ */
+export async function computeWinStreaksForMonsters(
+	db: Db,
+	roomId: string,
+	monsterIds: string[],
+	minStreak = STREAK_MIN
+): Promise<Map<string, number>> {
+	const out = new Map<string, number>();
+	if (monsterIds.length === 0) return out;
+
+	const recent = await queryRecentFights(db, roomId, STREAK_LOOKBACK);
+	for (const mid of monsterIds) {
+		const streak = winStreakFromRecentFights(recent, mid);
+		if (streak >= minStreak) out.set(mid, streak);
+	}
+	return out;
+}
+
+export function formatCatchUpStreakLines(
+	streaks: Map<string, number>,
+	summaries: FightSummaryRow[]
+): string[] {
+	if (streaks.size === 0) return [];
+	const nameById = new Map<string, string>();
+	for (const row of summaries) {
+		for (const p of row.participants ?? []) {
+			if (p.monsterId && !nameById.has(p.monsterId)) {
+				nameById.set(p.monsterId, p.monsterName);
+			}
+		}
+	}
+	const lines: string[] = [];
+	for (const [mid, n] of streaks) {
+		const name = nameById.get(mid) ?? 'A monster';
+		lines.push(`${name} is on a ${n}-fight winning streak.`);
+	}
+	return lines;
+}
+
+/** Win streak for leaderboard rows — uses recent fights once. */
+export async function computeMonsterWinStreaksForRoom(
+	db: Db,
+	roomId: string,
+	monsterIds: string[]
+): Promise<Map<string, number>> {
+	const out = new Map<string, number>();
+	if (monsterIds.length === 0) return out;
+	const recent = await queryRecentFights(db, roomId, STREAK_LOOKBACK);
+	for (const mid of monsterIds) {
+		out.set(mid, winStreakFromRecentFights(recent, mid));
+	}
+	return out;
 }
 
 export async function loadFightEventsForSummary(

--- a/packages/server/src/db/game-event-map.ts
+++ b/packages/server/src/db/game-event-map.ts
@@ -1,0 +1,26 @@
+import type { GameEvent } from '@deck-monsters/engine';
+
+type DbRoomEvent = {
+	id: number;
+	roomId: string;
+	type: string;
+	scope: string;
+	targetUserId: string | null;
+	payload: unknown;
+	text: string;
+	eventId: string | null;
+	createdAt: Date;
+};
+
+export function dbRowToGameEvent(row: DbRoomEvent): GameEvent {
+	return {
+		id: row.eventId ?? `hist:${row.id}`,
+		roomId: row.roomId,
+		timestamp: row.createdAt.getTime(),
+		type: row.type as GameEvent['type'],
+		scope: row.scope as GameEvent['scope'],
+		targetUserId: row.targetUserId ?? undefined,
+		payload: (row.payload ?? {}) as Record<string, unknown>,
+		text: row.text,
+	};
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -4,6 +4,7 @@ import {
 	text,
 	timestamp,
 	bigserial,
+	integer,
 	jsonb,
 	boolean,
 	primaryKey,
@@ -40,6 +41,7 @@ export const rooms = pgTable('rooms', {
 	inviteCode: text('invite_code').notNull().unique(),
 	stateBlob: text('state_blob'),
 	quarantinedBlob: text('quarantined_blob'),
+	fightCounter: integer('fight_counter').notNull().default(0),
 	createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 	updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
@@ -89,6 +91,79 @@ export const roomMembers = pgTable(
 			.references(() => profiles.id, { onDelete: 'cascade' }),
 		joinedAt: timestamp('joined_at', { withTimezone: true }).notNull().defaultNow(),
 		role: text('role').notNull().default('member'),
+		lastSeenAt: timestamp('last_seen_at', { withTimezone: true }),
 	},
 	(t) => [primaryKey({ columns: [t.roomId, t.userId] })]
+);
+
+export const roomPlayerStats = pgTable(
+	'room_player_stats',
+	{
+		roomId: uuid('room_id')
+			.notNull()
+			.references(() => rooms.id, { onDelete: 'cascade' }),
+		userId: uuid('user_id')
+			.notNull()
+			.references(() => profiles.id, { onDelete: 'cascade' }),
+		xp: integer('xp').notNull().default(0),
+		wins: integer('wins').notNull().default(0),
+		losses: integer('losses').notNull().default(0),
+		draws: integer('draws').notNull().default(0),
+		coinsEarned: integer('coins_earned').notNull().default(0),
+		updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.roomId, t.userId] })]
+);
+
+export const roomMonsterStats = pgTable(
+	'room_monster_stats',
+	{
+		roomId: uuid('room_id')
+			.notNull()
+			.references(() => rooms.id, { onDelete: 'cascade' }),
+		monsterId: text('monster_id').notNull(),
+		ownerUserId: uuid('owner_user_id').references(() => profiles.id, { onDelete: 'set null' }),
+		displayName: text('display_name').notNull(),
+		monsterType: text('monster_type').notNull(),
+		xp: integer('xp').notNull().default(0),
+		level: integer('level').notNull().default(1),
+		wins: integer('wins').notNull().default(0),
+		losses: integer('losses').notNull().default(0),
+		draws: integer('draws').notNull().default(0),
+		updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.roomId, t.monsterId] })]
+);
+
+export const fightSummaries = pgTable(
+	'fight_summaries',
+	{
+		id: bigserial('id', { mode: 'number' }).primaryKey(),
+		roomId: uuid('room_id')
+			.notNull()
+			.references(() => rooms.id, { onDelete: 'cascade' }),
+		fightNumber: integer('fight_number').notNull(),
+		startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+		endedAt: timestamp('ended_at', { withTimezone: true }).notNull(),
+		outcome: text('outcome').notNull(),
+		winnerMonsterId: text('winner_monster_id'),
+		winnerMonsterName: text('winner_monster_name'),
+		winnerOwnerUserId: uuid('winner_owner_user_id'),
+		loserMonsterId: text('loser_monster_id'),
+		loserMonsterName: text('loser_monster_name'),
+		loserOwnerUserId: uuid('loser_owner_user_id'),
+		roundCount: integer('round_count').notNull(),
+		winnerXpGained: integer('winner_xp_gained').notNull().default(0),
+		loserXpGained: integer('loser_xp_gained').notNull().default(0),
+		cardDropName: text('card_drop_name'),
+		notableCards: text('notable_cards').array(),
+		participants: jsonb('participants').$type<unknown[]>().notNull().default([]),
+		createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+	},
+	(t) => [
+		unique('fight_summaries_room_fight_number_key').on(t.roomId, t.fightNumber),
+		index('fight_summaries_room_ended_idx').on(t.roomId, t.endedAt),
+		index('fight_summaries_room_winner_monster_idx').on(t.roomId, t.winnerMonsterId),
+		index('fight_summaries_room_loser_monster_idx').on(t.roomId, t.loserMonsterId),
+	]
 );

--- a/packages/server/src/fight-stats-subscriber.ts
+++ b/packages/server/src/fight-stats-subscriber.ts
@@ -1,0 +1,159 @@
+/**
+ * Best-effort upserts for room_player_stats and room_monster_stats from
+ * ring.fightResolved, ring.xp, and ring.cardDrop events.
+ */
+import { sql } from 'drizzle-orm';
+
+import type { RoomEventBus, GameEvent } from '@deck-monsters/engine';
+import type { Db } from './db/index.js';
+import { roomMonsterStats, roomPlayerStats } from './db/schema.js';
+
+type Participant = {
+	monsterId: string;
+	monsterName: string;
+	monsterType: string;
+	ownerUserId: string;
+	ownerDisplayName: string;
+	outcome: 'win' | 'loss' | 'draw' | 'fled' | 'permaDeath';
+	xpGained: number;
+	level: number;
+};
+
+function outcomeToMonsterDelta(
+	outcome: Participant['outcome']
+): { wins: number; losses: number; draws: number } {
+	switch (outcome) {
+		case 'win':
+			return { wins: 1, losses: 0, draws: 0 };
+		case 'loss':
+		case 'permaDeath':
+			return { wins: 0, losses: 1, draws: 0 };
+		case 'draw':
+		case 'fled':
+			return { wins: 0, losses: 0, draws: 1 };
+		default:
+			return { wins: 0, losses: 0, draws: 0 };
+	}
+}
+
+function outcomeToPlayerDelta(
+	outcome: Participant['outcome']
+): { wins: number; losses: number; draws: number } {
+	return outcomeToMonsterDelta(outcome);
+}
+
+export function attachFightStatsSubscriber(
+	eventBus: RoomEventBus,
+	db: Db,
+	log: (err: unknown) => void = () => {}
+): () => void {
+	const subscriberId = `fight-stats:${eventBus.roomId}`;
+
+	return eventBus.subscribe(subscriberId, {
+		deliver(event: GameEvent) {
+			if (event.type === 'ring.fightResolved') {
+				void handleFightResolved(db, event).catch(log);
+				return;
+			}
+			// Coins from XP announcements (ring.xp can include coinsGained).
+			if (event.type === 'ring.xp') {
+				void handleXpCoinsOnly(db, event).catch(log);
+			}
+		},
+	});
+}
+
+async function handleFightResolved(db: Db, event: GameEvent): Promise<void> {
+	const roomId = event.roomId;
+	const payload = event.payload as {
+		participants?: Participant[];
+	};
+	const participants = payload.participants;
+	if (!participants?.length) return;
+
+	for (const p of participants) {
+		const { wins, losses, draws } = outcomeToPlayerDelta(p.outcome);
+		const pd = outcomeToMonsterDelta(p.outcome);
+
+		await db
+			.insert(roomPlayerStats)
+			.values({
+				roomId,
+				userId: p.ownerUserId,
+				xp: p.xpGained,
+				wins,
+				losses,
+				draws,
+				coinsEarned: 0,
+			})
+			.onConflictDoUpdate({
+				target: [roomPlayerStats.roomId, roomPlayerStats.userId],
+				set: {
+					xp: sql`${roomPlayerStats.xp} + ${p.xpGained}`,
+					wins: sql`${roomPlayerStats.wins} + ${wins}`,
+					losses: sql`${roomPlayerStats.losses} + ${losses}`,
+					draws: sql`${roomPlayerStats.draws} + ${draws}`,
+					updatedAt: new Date(),
+				},
+			});
+
+		await db
+			.insert(roomMonsterStats)
+			.values({
+				roomId,
+				monsterId: p.monsterId,
+				ownerUserId: p.ownerUserId,
+				displayName: p.monsterName,
+				monsterType: p.monsterType,
+				xp: p.xpGained,
+				level: p.level,
+				wins: pd.wins,
+				losses: pd.losses,
+				draws: pd.draws,
+			})
+			.onConflictDoUpdate({
+				target: [roomMonsterStats.roomId, roomMonsterStats.monsterId],
+				set: {
+					ownerUserId: p.ownerUserId,
+					displayName: p.monsterName,
+					monsterType: p.monsterType,
+					xp: sql`${roomMonsterStats.xp} + ${p.xpGained}`,
+					level: p.level,
+					wins: sql`${roomMonsterStats.wins} + ${pd.wins}`,
+					losses: sql`${roomMonsterStats.losses} + ${pd.losses}`,
+					draws: sql`${roomMonsterStats.draws} + ${pd.draws}`,
+					updatedAt: new Date(),
+				},
+			});
+	}
+}
+
+/** XP and W/L are applied from ring.fightResolved only; this handles bonus coin lines on ring.xp. */
+async function handleXpCoinsOnly(db: Db, event: GameEvent): Promise<void> {
+	const payload = event.payload as {
+		coinsGained?: number;
+		contestant?: { userId?: string };
+	};
+	const coinsGained = payload.coinsGained ?? 0;
+	const userId = payload.contestant?.userId;
+	if (coinsGained <= 0 || !userId) return;
+
+	await db
+		.insert(roomPlayerStats)
+		.values({
+			roomId: event.roomId,
+			userId,
+			xp: 0,
+			wins: 0,
+			losses: 0,
+			draws: 0,
+			coinsEarned: coinsGained,
+		})
+		.onConflictDoUpdate({
+			target: [roomPlayerStats.roomId, roomPlayerStats.userId],
+			set: {
+				coinsEarned: sql`${roomPlayerStats.coinsEarned} + ${coinsGained}`,
+				updatedAt: new Date(),
+			},
+		});
+}

--- a/packages/server/src/fight-summary-writer.ts
+++ b/packages/server/src/fight-summary-writer.ts
@@ -1,0 +1,129 @@
+/**
+ * Assembles fight_summaries rows from ring.fight (start) + ring.fightResolved + ring.cardDrop.
+ * Best-effort: errors are logged, not propagated.
+ */
+import { eq, sql } from 'drizzle-orm';
+
+import type { RoomEventBus, GameEvent } from '@deck-monsters/engine';
+import type { Db } from './db/index.js';
+import { fightSummaries, rooms } from './db/schema.js';
+
+type Pending = {
+	startedAt: Date;
+	cardDropName?: string;
+};
+
+const pendingByRoom = new Map<string, Pending>();
+
+export function attachFightSummaryWriter(
+	eventBus: RoomEventBus,
+	db: Db,
+	log: (err: unknown) => void = () => {}
+): () => void {
+	const roomId = eventBus.roomId;
+	const subscriberId = `fight-summary:${roomId}`;
+
+	return eventBus.subscribe(subscriberId, {
+		deliver(event: GameEvent) {
+			if (event.type === 'ring.fight') {
+				try {
+					onRingFight(roomId, event);
+				} catch (err) {
+					log(err);
+				}
+				return;
+			}
+			if (event.type === 'ring.cardDrop' && event.scope === 'public') {
+				onCardDrop(roomId, event);
+				return;
+			}
+			if (event.type === 'ring.fightResolved') {
+				void onFightResolved(db, roomId, event).catch(log);
+			}
+		},
+	});
+}
+
+function onRingFight(roomId: string, event: GameEvent): void {
+	const payload = event.payload as { eventName?: string };
+	if (payload.eventName === 'fightConcludes') return;
+
+	pendingByRoom.set(roomId, {
+		startedAt: new Date(event.timestamp),
+	});
+}
+
+function onCardDrop(roomId: string, event: GameEvent): void {
+	const pending = pendingByRoom.get(roomId);
+	if (!pending) return;
+	const payload = event.payload as { cardDropName?: string };
+	const name = payload.cardDropName;
+	if (name) pending.cardDropName = name;
+}
+
+async function onFightResolved(db: Db, roomId: string, event: GameEvent): Promise<void> {
+	const pending = pendingByRoom.get(roomId);
+	pendingByRoom.delete(roomId);
+
+	const payload = event.payload as {
+		rounds: number;
+		deaths: number;
+		outcome: string;
+		participants?: unknown[];
+		winnerMonsterId?: string;
+		winnerMonsterName?: string;
+		winnerOwnerUserId?: string;
+		loserMonsterId?: string;
+		loserMonsterName?: string;
+		loserOwnerUserId?: string;
+	};
+
+	const participants = (payload.participants ?? []) as Array<{
+		monsterId: string;
+		outcome: string;
+		xpGained: number;
+	}>;
+
+	let winnerXp = 0;
+	let loserXp = 0;
+	for (const p of participants) {
+		if (p.outcome === 'win') winnerXp = p.xpGained;
+		if (p.outcome === 'loss' || p.outcome === 'permaDeath') loserXp = p.xpGained;
+	}
+
+	const endedAt = new Date(event.timestamp);
+	const startedAt = pending?.startedAt ?? endedAt;
+
+	await db.transaction(async (tx) => {
+		const rows = await tx
+			.update(rooms)
+			.set({
+				fightCounter: sql`${rooms.fightCounter} + 1`,
+				updatedAt: new Date(),
+			})
+			.where(eq(rooms.id, roomId))
+			.returning({ fightCounter: rooms.fightCounter });
+
+		const fightNumber = rows[0]?.fightCounter ?? 1;
+
+		await tx.insert(fightSummaries).values({
+			roomId,
+			fightNumber,
+			startedAt,
+			endedAt,
+			outcome: payload.outcome,
+			winnerMonsterId: payload.winnerMonsterId ?? null,
+			winnerMonsterName: payload.winnerMonsterName ?? null,
+			winnerOwnerUserId: payload.winnerOwnerUserId ?? null,
+			loserMonsterId: payload.loserMonsterId ?? null,
+			loserMonsterName: payload.loserMonsterName ?? null,
+			loserOwnerUserId: payload.loserOwnerUserId ?? null,
+			roundCount: payload.rounds,
+			winnerXpGained: winnerXp,
+			loserXpGained: loserXp,
+			cardDropName: pending?.cardDropName ?? null,
+			notableCards: null,
+			participants: payload.participants ?? [],
+		});
+	});
+}

--- a/packages/server/src/room-manager.test.ts
+++ b/packages/server/src/room-manager.test.ts
@@ -261,7 +261,15 @@ describe('RoomManager', () => {
 			});
 			const rm2 = new RoomManager(db2 as never, () => {}, deps);
 			// Prime cache
-			(rm2 as any).active.set(roomId, { game: mockGame, eventBus: mockGame.eventBus, lastActivityAt: Date.now(), unsubscribePersister: sinon.stub(), unsubscribeMetrics: sinon.stub() });
+			(rm2 as any).active.set(roomId, {
+				game: mockGame,
+				eventBus: mockGame.eventBus,
+				lastActivityAt: Date.now(),
+				unsubscribePersister: sinon.stub(),
+				unsubscribeMetrics: sinon.stub(),
+				unsubscribeFightStats: sinon.stub(),
+				unsubscribeFightSummary: sinon.stub(),
+			});
 
 			await rm2.deleteRoom(OWNER_ID, roomId);
 
@@ -293,7 +301,7 @@ describe('RoomManager', () => {
 				selectResults: [
 					[{ id: ROOM_ID, name: 'My Room', inviteCode: INVITE }],
 					[{ value: 3 }],     // count query (Promise.all[0])
-					[{ role: 'owner' }], // member role query (Promise.all[1])
+					[{ role: 'owner', lastSeenAt: null }], // member role query (Promise.all[1])
 				],
 			});
 			const { deps } = makeEngineDeps();
@@ -307,6 +315,7 @@ describe('RoomManager', () => {
 				inviteCode: INVITE,
 				memberCount: 3,
 				role: 'owner',
+				lastSeenAt: null,
 			});
 		});
 

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -21,12 +21,16 @@ import { attachFightStatsSubscriber } from './fight-stats-subscriber.js';
 import { attachFightSummaryWriter } from './fight-summary-writer.js';
 import {
 	buildCatchUpText,
+	computeMonsterWinStreaksForRoom,
+	computeWinStreaksForMonsters,
+	formatCatchUpStreakLines,
 	formatGlobalMonsterLeaderboard,
 	formatGlobalPlayerLeaderboard,
 	formatRoomMonsterLeaderboard,
 	formatRoomPlayerLeaderboard,
 	formatSinceLabel,
 	getMemberLastSeen,
+	monsterIdsFromSummaries,
 	queryFightsSince,
 	queryGlobalMonsters,
 	queryGlobalPlayers,
@@ -89,7 +93,12 @@ export class RoomManager {
 			},
 			fetchRoomMonsterLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
 				const rows = await queryRoomMonsters(this.db, roomId, sortBy as LeaderboardSort, limit);
-				return formatRoomMonsterLeaderboard(`Top ${limit} Monsters`, rows);
+				const streaks = await computeMonsterWinStreaksForRoom(
+					this.db,
+					roomId,
+					rows.map((r) => r.monsterId)
+				);
+				return formatRoomMonsterLeaderboard(`Top ${limit} Monsters`, rows, streaks);
 			},
 			fetchGlobalPlayerLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
 				const rows = await queryGlobalPlayers(this.db, sortBy as LeaderboardSort, limit);
@@ -107,7 +116,10 @@ export class RoomManager {
 				}
 				const summaries = await queryFightsSince(this.db, roomId, sinceDate);
 				const label = formatSinceLabel(sinceDate);
-				const { textSummary } = buildCatchUpText(summaries, label);
+				const ids = monsterIdsFromSummaries(summaries);
+				const streakMap = await computeWinStreaksForMonsters(this.db, roomId, ids);
+				const streakLines = formatCatchUpStreakLines(streakMap, summaries);
+				const { textSummary } = buildCatchUpText(summaries, label, streakLines);
 				await touchMemberLastSeen(this.db, roomId, userId);
 				return textSummary;
 			},

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -9,12 +9,32 @@ import {
 	engineReady,
 	getHydratorStatus,
 	createKeyedPromiseQueue,
+	type LeaderboardSortKey,
 } from '@deck-monsters/engine';
 import type { Db } from './db/index.js';
-import { rooms, roomMembers, profiles, roomEvents } from './db/schema.js';
+import { rooms, roomMembers, profiles, roomEvents, roomPlayerStats, roomMonsterStats, fightSummaries } from './db/schema.js';
+import { dbRowToGameEvent } from './db/game-event-map.js';
 import type { GameEvent } from '@deck-monsters/engine';
 import { PostgresStateStore } from './state-store.js';
 import { attachEventPersister } from './event-persister.js';
+import { attachFightStatsSubscriber } from './fight-stats-subscriber.js';
+import { attachFightSummaryWriter } from './fight-summary-writer.js';
+import {
+	buildCatchUpText,
+	formatGlobalMonsterLeaderboard,
+	formatGlobalPlayerLeaderboard,
+	formatRoomMonsterLeaderboard,
+	formatRoomPlayerLeaderboard,
+	formatSinceLabel,
+	getMemberLastSeen,
+	queryFightsSince,
+	queryGlobalMonsters,
+	queryGlobalPlayers,
+	queryRoomMonsters,
+	queryRoomPlayers,
+	touchMemberLastSeen,
+	type LeaderboardSort,
+} from './analytics-queries.js';
 import { attachMetricsCollector } from './metrics/collector.js';
 import {
 	roomsCreated,
@@ -32,6 +52,8 @@ interface ActiveRoom {
 	lastActivityAt: number;
 	unsubscribePersister: () => void;
 	unsubscribeMetrics: () => void;
+	unsubscribeFightStats: () => void;
+	unsubscribeFightSummary: () => void;
 }
 
 interface EngineDeps {
@@ -41,31 +63,6 @@ interface EngineDeps {
 
 function generateInviteCode(): string {
 	return randomUUID().replace(/-/g, '').slice(0, 8).toUpperCase();
-}
-
-type DbRoomEvent = {
-	id: number;
-	roomId: string;
-	type: string;
-	scope: string;
-	targetUserId: string | null;
-	payload: unknown;
-	text: string;
-	eventId: string | null;
-	createdAt: Date;
-};
-
-function dbRowToGameEvent(row: DbRoomEvent): GameEvent {
-	return {
-		id: row.eventId ?? `hist:${row.id}`,
-		roomId: row.roomId,
-		timestamp: row.createdAt.getTime(),
-		type: row.type as GameEvent['type'],
-		scope: row.scope as GameEvent['scope'],
-		targetUserId: row.targetUserId ?? undefined,
-		payload: (row.payload ?? {}) as Record<string, unknown>,
-		text: row.text,
-	};
 }
 
 export class RoomManager {
@@ -84,6 +81,39 @@ export class RoomManager {
 	 * Returns a log callback scoped to a room that increments the relevant
 	 * error counter before delegating to the base logger.
 	 */
+	private _attachGameAnalytics(roomId: string, game: Game): void {
+		game.analytics = {
+			fetchRoomPlayerLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
+				const rows = await queryRoomPlayers(this.db, roomId, sortBy as LeaderboardSort, limit);
+				return formatRoomPlayerLeaderboard(`Top ${limit} Players`, rows);
+			},
+			fetchRoomMonsterLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
+				const rows = await queryRoomMonsters(this.db, roomId, sortBy as LeaderboardSort, limit);
+				return formatRoomMonsterLeaderboard(`Top ${limit} Monsters`, rows);
+			},
+			fetchGlobalPlayerLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
+				const rows = await queryGlobalPlayers(this.db, sortBy as LeaderboardSort, limit);
+				return formatGlobalPlayerLeaderboard(`Top ${limit} Players (global)`, rows);
+			},
+			fetchGlobalMonsterLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
+				const rows = await queryGlobalMonsters(this.db, sortBy as LeaderboardSort, limit);
+				return formatGlobalMonsterLeaderboard(`Top ${limit} Monsters (global)`, rows);
+			},
+			catchUp: async (userId: string, since: Date | null) => {
+				let sinceDate = since;
+				if (!sinceDate) {
+					const ls = await getMemberLastSeen(this.db, roomId, userId);
+					sinceDate = ls ?? new Date(Date.now() - 60 * 60 * 1000);
+				}
+				const summaries = await queryFightsSince(this.db, roomId, sinceDate);
+				const label = formatSinceLabel(sinceDate);
+				const { textSummary } = buildCatchUpText(summaries, label);
+				await touchMemberLastSeen(this.db, roomId, userId);
+				return textSummary;
+			},
+		};
+	}
+
 	private _makeRoomLogger(roomId: string): (err: unknown) => void {
 		return (err: unknown) => {
 			const ctx = (err as Record<string, unknown> | null)?.context;
@@ -122,7 +152,18 @@ export class RoomManager {
 		const eventBus = game.eventBus;
 		const unsubscribePersister = attachEventPersister(eventBus, this.db, this.log);
 		const unsubscribeMetrics = attachMetricsCollector(eventBus, game.ring, roomId);
-		this.active.set(roomId, { game, eventBus, lastActivityAt: Date.now(), unsubscribePersister, unsubscribeMetrics });
+		const unsubscribeFightStats = attachFightStatsSubscriber(eventBus, this.db, this.log);
+		const unsubscribeFightSummary = attachFightSummaryWriter(eventBus, this.db, this.log);
+		this._attachGameAnalytics(roomId, game);
+		this.active.set(roomId, {
+			game,
+			eventBus,
+			lastActivityAt: Date.now(),
+			unsubscribePersister,
+			unsubscribeMetrics,
+			unsubscribeFightStats,
+			unsubscribeFightSummary,
+		});
 		roomsCreated.inc();
 		roomsActive.set(this.active.size);
 
@@ -193,6 +234,8 @@ export class RoomManager {
 		const activeEntry = this.active.get(roomId);
 		if (activeEntry) {
 			activeEntry.unsubscribeMetrics();
+			activeEntry.unsubscribeFightStats();
+			activeEntry.unsubscribeFightSummary();
 		}
 		this.active.delete(roomId);
 		roomsActive.set(this.active.size);
@@ -218,7 +261,14 @@ export class RoomManager {
 	async getRoomInfo(
 		userId: string,
 		roomId: string
-	): Promise<{ roomId: string; name: string; inviteCode: string; memberCount: number; role: 'owner' | 'member' } | null> {
+	): Promise<{
+		roomId: string;
+		name: string;
+		inviteCode: string;
+		memberCount: number;
+		role: 'owner' | 'member';
+		lastSeenAt: Date | null;
+	} | null> {
 		const rows = await this.db
 			.select({ id: rooms.id, name: rooms.name, inviteCode: rooms.inviteCode })
 			.from(rooms)
@@ -232,7 +282,7 @@ export class RoomManager {
 		const [countRows, memberRows] = await Promise.all([
 			this.db.select({ value: count() }).from(roomMembers).where(eq(roomMembers.roomId, roomId)),
 			this.db
-				.select({ role: roomMembers.role })
+				.select({ role: roomMembers.role, lastSeenAt: roomMembers.lastSeenAt })
 				.from(roomMembers)
 				.where(and(eq(roomMembers.roomId, roomId), eq(roomMembers.userId, userId)))
 				.limit(1),
@@ -250,6 +300,7 @@ export class RoomManager {
 			inviteCode: rows[0].inviteCode,
 			memberCount,
 			role,
+			lastSeenAt: memberRows[0].lastSeenAt ?? null,
 		};
 	}
 
@@ -330,6 +381,11 @@ export class RoomManager {
 	}
 
 	async resetRoomState(roomId: string): Promise<void> {
+		await this.db.delete(roomPlayerStats).where(eq(roomPlayerStats.roomId, roomId));
+		await this.db.delete(roomMonsterStats).where(eq(roomMonsterStats.roomId, roomId));
+		await this.db.delete(fightSummaries).where(eq(fightSummaries.roomId, roomId));
+		await this.db.update(rooms).set({ fightCounter: 0, updatedAt: new Date() }).where(eq(rooms.id, roomId));
+
 		// Quarantine current state, start fresh on next load.
 		const rows = await this.db
 			.select({ stateBlob: rooms.stateBlob })
@@ -350,6 +406,8 @@ export class RoomManager {
 		if (entry) {
 			entry.unsubscribePersister();
 			entry.unsubscribeMetrics();
+			entry.unsubscribeFightStats();
+			entry.unsubscribeFightSummary();
 			entry.game.dispose();
 		}
 		this.active.delete(roomId);
@@ -362,6 +420,8 @@ export class RoomManager {
 			// Stop persisting events for this room.
 			entry.unsubscribePersister();
 			entry.unsubscribeMetrics();
+			entry.unsubscribeFightStats();
+			entry.unsubscribeFightSummary();
 			// saveState is a getter returning the bound persist function — call it to flush
 			// any state not yet written by the 30s debounce.
 			entry.game.saveState();
@@ -540,7 +600,18 @@ export class RoomManager {
 		const eventBus = game.eventBus;
 		const unsubscribePersister = attachEventPersister(eventBus, this.db, this.log);
 		const unsubscribeMetrics = attachMetricsCollector(eventBus, game.ring, roomId);
-		const entry: ActiveRoom = { game, eventBus, lastActivityAt: Date.now(), unsubscribePersister, unsubscribeMetrics };
+		const unsubscribeFightStats = attachFightStatsSubscriber(eventBus, this.db, this.log);
+		const unsubscribeFightSummary = attachFightSummaryWriter(eventBus, this.db, this.log);
+		this._attachGameAnalytics(roomId, game);
+		const entry: ActiveRoom = {
+			game,
+			eventBus,
+			lastActivityAt: Date.now(),
+			unsubscribePersister,
+			unsubscribeMetrics,
+			unsubscribeFightStats,
+			unsubscribeFightSummary,
+		};
 		this.active.set(roomId, entry);
 		roomsActive.set(this.active.size);
 		return entry;

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -9,6 +9,23 @@ import { protectedProcedure, serviceProcedure } from './middleware.js';
 import type { RoomManager } from '../room-manager.js';
 import { ensureConnectorUser } from '../auth/connector-users.js';
 import { commandsTotal, wsConnectionsActive } from '../metrics/index.js';
+import { db } from '../db/index.js';
+import {
+	loadFightEventsForSummary,
+	queryFightByNumber,
+	queryMonsterFightHistory,
+	queryRecentFights,
+	queryGlobalMonsters,
+	queryGlobalPlayers,
+	queryRoomMonsters,
+	queryRoomPlayers,
+	buildCatchUpText,
+	formatSinceLabel,
+	getMemberLastSeen,
+	queryFightsSince,
+	touchMemberLastSeen,
+	type LeaderboardSort,
+} from '../analytics-queries.js';
 
 export type AppRouter = ReturnType<typeof createRouter>;
 
@@ -26,7 +43,108 @@ const BUILD_VERSION = process.env['BUILD_VERSION'] ?? 'dev';
 // on the same Game (see packages/engine/src/helpers/room-engine-queue.ts).
 export const activeFlows = new Set<string>();
 
+const sortBySchema = z.enum(['xp', 'wins', 'winRate', 'coins']);
+
 export function createRouter(roomManager: RoomManager) {
+	const leaderboardRouter = t.router({
+		roomPlayers: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					limit: z.number().min(1).max(50).optional(),
+					sortBy: sortBySchema.optional(),
+				})
+			)
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const limit = input.limit ?? 25;
+				const rows = await queryRoomPlayers(db, input.roomId, (input.sortBy ?? 'xp') as LeaderboardSort, limit);
+				return rows.map((r, i) => ({
+					rank: i + 1,
+					displayName: r.displayName,
+					xp: r.xp,
+					wins: r.wins,
+					losses: r.losses,
+					draws: r.draws,
+					winRate: r.winRate,
+					coinsEarned: r.coinsEarned,
+				}));
+			}),
+
+		roomMonsters: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					limit: z.number().min(1).max(50).optional(),
+					sortBy: sortBySchema.optional(),
+				})
+			)
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const limit = input.limit ?? 25;
+				const rows = await queryRoomMonsters(db, input.roomId, (input.sortBy ?? 'xp') as LeaderboardSort, limit);
+				return rows.map((r, i) => ({
+					rank: i + 1,
+					displayName: r.displayName,
+					monsterType: r.monsterType,
+					ownerName: r.ownerName,
+					xp: r.xp,
+					level: r.level,
+					wins: r.wins,
+					losses: r.losses,
+					draws: r.draws,
+					winRate: r.winRate,
+				}));
+			}),
+
+		globalPlayers: protectedProcedure
+			.input(
+				z.object({
+					limit: z.number().min(1).max(50).optional(),
+					sortBy: sortBySchema.optional(),
+				})
+			)
+			.query(async ({ input }) => {
+				const limit = input.limit ?? 25;
+				const rows = await queryGlobalPlayers(db, (input.sortBy ?? 'xp') as LeaderboardSort, limit);
+				return rows.map((r, i) => ({
+					rank: i + 1,
+					displayName: r.displayName,
+					xp: r.xp,
+					wins: r.wins,
+					losses: r.losses,
+					draws: r.draws,
+					winRate: r.winRate,
+					coinsEarned: r.coinsEarned,
+					roomCount: r.roomCount,
+				}));
+			}),
+
+		globalMonsters: protectedProcedure
+			.input(
+				z.object({
+					limit: z.number().min(1).max(50).optional(),
+					sortBy: sortBySchema.optional(),
+				})
+			)
+			.query(async ({ input }) => {
+				const limit = input.limit ?? 25;
+				const rows = await queryGlobalMonsters(db, (input.sortBy ?? 'xp') as LeaderboardSort, limit);
+				return rows.map((r, i) => ({
+					rank: i + 1,
+					displayName: r.displayName,
+					monsterType: r.monsterType,
+					ownerName: r.ownerName,
+					xp: r.xp,
+					level: r.level,
+					wins: r.wins,
+					losses: r.losses,
+					draws: r.draws,
+					winRate: r.winRate,
+				}));
+			}),
+	});
+
 	const roomRouter = t.router({
 		create: protectedProcedure
 			.input(z.object({ name: z.string().min(1).max(100) }))
@@ -182,6 +300,8 @@ export function createRouter(roomManager: RoomManager) {
 
 				// TODO: emit quick_actions event after command completes with contextual suggestions
 
+				void touchMemberLastSeen(db, input.roomId, ctx.userId).catch(() => {});
+
 				commandsTotal.inc({ room_id: input.roomId, result: 'ok' });
 				return { ok: true, commandId };
 				} catch (err) {
@@ -261,6 +381,7 @@ export function createRouter(roomManager: RoomManager) {
 			)
 			.subscription(async function* ({ input, ctx, signal }) {
 			await roomManager.assertMember(ctx.userId, input.roomId);
+			void touchMemberLastSeen(db, input.roomId, ctx.userId).catch(() => {});
 			const eventBus = await roomManager.getEventBus(input.roomId);
 			const game = await roomManager.getGame(input.roomId);
 			const ring = game.ring;
@@ -350,6 +471,75 @@ export function createRouter(roomManager: RoomManager) {
 					wsConnectionsActive.dec({ room_id: input.roomId });
 				}
 			}),
+
+		recentFights: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					limit: z.number().min(1).max(50).optional(),
+					before: z.string().datetime().optional(),
+				})
+			)
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const limit = input.limit ?? 10;
+				const before = input.before ? new Date(input.before) : undefined;
+				return queryRecentFights(db, input.roomId, limit, before);
+			}),
+
+		fight: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					fightNumber: z.number().int().positive(),
+				})
+			)
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const summary = await queryFightByNumber(db, input.roomId, input.fightNumber);
+				if (!summary) throw new TRPCError({ code: 'NOT_FOUND' });
+				const events = await loadFightEventsForSummary(db, input.roomId, summary.startedAt, summary.endedAt);
+				return { summary, events };
+			}),
+
+		monsterFightHistory: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterId: z.string().min(1),
+					limit: z.number().min(1).max(50).optional(),
+				})
+			)
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				return queryMonsterFightHistory(db, input.roomId, input.monsterId, input.limit ?? 10);
+			}),
+
+		catchUp: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					since: z.string().datetime().optional(),
+					touchLastSeen: z.boolean().optional(),
+				})
+			)
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				let sinceDate: Date;
+				if (input.since) {
+					sinceDate = new Date(input.since);
+				} else {
+					const ls = await getMemberLastSeen(db, input.roomId, ctx.userId);
+					sinceDate = ls ?? new Date(Date.now() - 60 * 60 * 1000);
+				}
+				const summaries = await queryFightsSince(db, input.roomId, sinceDate);
+				const label = formatSinceLabel(sinceDate);
+				const { fightCount, textSummary } = buildCatchUpText(summaries, label);
+				if (input.touchLastSeen !== false) {
+					await touchMemberLastSeen(db, input.roomId, ctx.userId);
+				}
+				return { fightCount, summaries, textSummary };
+			}),
 	});
 
 	const adminRouter = t.router({
@@ -387,6 +577,7 @@ export function createRouter(roomManager: RoomManager) {
 	return t.router({
 		room: roomRouter,
 		game: gameRouter,
+		leaderboard: leaderboardRouter,
 		admin: adminRouter,
 		auth: authRouter,
 		health: t.procedure.query(() => ({

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -20,8 +20,12 @@ import {
 	queryRoomMonsters,
 	queryRoomPlayers,
 	buildCatchUpText,
+	computeMonsterWinStreaksForRoom,
+	computeWinStreaksForMonsters,
+	formatCatchUpStreakLines,
 	formatSinceLabel,
 	getMemberLastSeen,
+	monsterIdsFromSummaries,
 	queryFightsSince,
 	touchMemberLastSeen,
 	type LeaderboardSort,
@@ -83,8 +87,14 @@ export function createRouter(roomManager: RoomManager) {
 				await roomManager.assertMember(ctx.userId, input.roomId);
 				const limit = input.limit ?? 25;
 				const rows = await queryRoomMonsters(db, input.roomId, (input.sortBy ?? 'xp') as LeaderboardSort, limit);
+				const streaks = await computeMonsterWinStreaksForRoom(
+					db,
+					input.roomId,
+					rows.map((r) => r.monsterId)
+				);
 				return rows.map((r, i) => ({
 					rank: i + 1,
+					monsterId: r.monsterId,
 					displayName: r.displayName,
 					monsterType: r.monsterType,
 					ownerName: r.ownerName,
@@ -94,6 +104,7 @@ export function createRouter(roomManager: RoomManager) {
 					losses: r.losses,
 					draws: r.draws,
 					winRate: r.winRate,
+					winStreak: streaks.get(r.monsterId) ?? 0,
 				}));
 			}),
 
@@ -534,7 +545,10 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const summaries = await queryFightsSince(db, input.roomId, sinceDate);
 				const label = formatSinceLabel(sinceDate);
-				const { fightCount, textSummary } = buildCatchUpText(summaries, label);
+				const ids = monsterIdsFromSummaries(summaries);
+				const streakMap = await computeWinStreaksForMonsters(db, input.roomId, ids);
+				const streakLines = formatCatchUpStreakLines(streakMap, summaries);
+				const { fightCount, textSummary } = buildCatchUpText(summaries, label, streakLines);
 				if (input.touchLastSeen !== false) {
 					await touchMemberLastSeen(db, input.roomId, ctx.userId);
 				}

--- a/supabase/migrations/20260410120000_leaderboard_fight_stats.sql
+++ b/supabase/migrations/20260410120000_leaderboard_fight_stats.sql
@@ -66,3 +66,7 @@ create index if not exists fight_summaries_room_loser_monster_idx
 
 create unique index if not exists fight_summaries_room_fight_number_key
   on public.fight_summaries (room_id, fight_number);
+
+-- GIN index for JSONB containment queries on participants (e.g. monster fight history).
+create index if not exists fight_summaries_participants_gin_idx
+  on public.fight_summaries using gin (participants);

--- a/supabase/migrations/20260410120000_leaderboard_fight_stats.sql
+++ b/supabase/migrations/20260410120000_leaderboard_fight_stats.sql
@@ -1,0 +1,68 @@
+-- Leaderboard stats, fight summaries, room fight counter, last_seen_at
+
+alter table public.rooms
+  add column if not exists fight_counter integer not null default 0;
+
+alter table public.room_members
+  add column if not exists last_seen_at timestamptz;
+
+create table if not exists public.room_player_stats (
+  room_id uuid not null references public.rooms (id) on delete cascade,
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  xp integer not null default 0,
+  wins integer not null default 0,
+  losses integer not null default 0,
+  draws integer not null default 0,
+  coins_earned integer not null default 0,
+  updated_at timestamptz not null default now(),
+  primary key (room_id, user_id)
+);
+
+create table if not exists public.room_monster_stats (
+  room_id uuid not null references public.rooms (id) on delete cascade,
+  monster_id text not null,
+  owner_user_id uuid references public.profiles (id) on delete set null,
+  display_name text not null,
+  monster_type text not null,
+  xp integer not null default 0,
+  level integer not null default 1,
+  wins integer not null default 0,
+  losses integer not null default 0,
+  draws integer not null default 0,
+  updated_at timestamptz not null default now(),
+  primary key (room_id, monster_id)
+);
+
+create table if not exists public.fight_summaries (
+  id bigserial primary key,
+  room_id uuid not null references public.rooms (id) on delete cascade,
+  fight_number integer not null,
+  started_at timestamptz not null,
+  ended_at timestamptz not null,
+  outcome text not null,
+  winner_monster_id text,
+  winner_monster_name text,
+  winner_owner_user_id uuid,
+  loser_monster_id text,
+  loser_monster_name text,
+  loser_owner_user_id uuid,
+  round_count integer not null,
+  winner_xp_gained integer not null default 0,
+  loser_xp_gained integer not null default 0,
+  card_drop_name text,
+  notable_cards text[],
+  participants jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists fight_summaries_room_ended_idx
+  on public.fight_summaries (room_id, ended_at desc);
+
+create index if not exists fight_summaries_room_winner_monster_idx
+  on public.fight_summaries (room_id, winner_monster_id);
+
+create index if not exists fight_summaries_room_loser_monster_idx
+  on public.fight_summaries (room_id, loser_monster_id);
+
+create unique index if not exists fight_summaries_room_fight_number_key
+  on public.fight_summaries (room_id, fight_number);

--- a/supabase/migrations/20260411120000_fight_summaries_participants_gin.sql
+++ b/supabase/migrations/20260411120000_fight_summaries_participants_gin.sql
@@ -1,0 +1,4 @@
+-- Idempotent: add GIN index on fight_summaries.participants for JSONB containment
+-- (e.g. monster fight history). Safe if already applied in an earlier migration.
+create index if not exists fight_summaries_participants_gin_idx
+  on public.fight_summaries using gin (participants);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements roadmap plans **13–14** (leaderboard + fight stats). Recent work:

- **Win streaks**: consecutive wins from the last 80 `fight_summaries` per room — appended to **catch-up** text (≥3 wins), **`leaderboard.roomMonsters`** returns `winStreak`, Discord-style monster leaderboard shows `streak N`, web table has **Streak** column + badge for ≥3.
- **Win rate**: table header **tooltips** explain W÷(W+L), draws excluded.
- **Multi-monster fights**: shared `apps/web/src/utils/fight-display.ts` for titles/subtitles; **Fight log** and **Ring** last-fight line use `participants` when 3+ contestants.
- **Bugfix**: stray `)}` in **RingPane** event map (was a syntax error).
- **DB**: idempotent migration `20260411120000_fight_summaries_participants_gin.sql` for GIN on `participants` (safe if index already exists from earlier migration).

## Testing

- `pnpm --filter @deck-monsters/server test`
- `pnpm --filter @deck-monsters/web build` + `lint`

Draft PR — rebase/push completed after upstream docs commit on the same branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58986073-df2f-4b01-8c04-133131d58a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58986073-df2f-4b01-8c04-133131d58a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

