### PR TITLE
fix(web): correct ring-feed-timestamps implementation issues

### DIFF
--- a/apps/web/src/components/RingPane.tsx
+++ b/apps/web/src/components/RingPane.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type { GameEvent } from '@deck-monsters/server/types';
-
-type TrackedEvent = { id: string; data: GameEvent };
 import { trpc } from '../lib/trpc.js';
 import { useHandshake } from '../hooks/useHandshake.js';
 import { useRingKeyTimestamps } from '../hooks/useRingKeyTimestamps.js';
@@ -13,6 +11,8 @@ import {
 	formatEventHoverTitle,
 	getKeyRingEventMeta,
 } from '../utils/event-time.js';
+
+type TrackedEvent = { id: string; data: GameEvent };
 
 interface RingPaneProps {
   roomId: string;

--- a/apps/web/src/hooks/useRingKeyTimestamps.ts
+++ b/apps/web/src/hooks/useRingKeyTimestamps.ts
@@ -15,7 +15,11 @@ export function useRingKeyTimestamps() {
 	const [ringKeyTimestampsEnabled, setState] = useState(readStored);
 
 	const setRingKeyTimestampsEnabled = useCallback((next: boolean) => {
-		localStorage.setItem(STORAGE_KEY, next ? '1' : '0');
+		if (next) {
+			localStorage.setItem(STORAGE_KEY, '1');
+		} else {
+			localStorage.removeItem(STORAGE_KEY);
+		}
 		setState(next);
 	}, []);
 

--- a/apps/web/src/styles/terminal.css
+++ b/apps/web/src/styles/terminal.css
@@ -143,18 +143,6 @@
   border: 0;
 }
 
-/* Absolute time for assistive tech — same clip pattern as .event-sr-only */
-.event time.event-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
 
 .event p,
 .event .event-text {

--- a/apps/web/src/utils/event-time.test.ts
+++ b/apps/web/src/utils/event-time.test.ts
@@ -17,6 +17,34 @@ describe('getKeyRingEventMeta', () => {
     ).to.deep.equal({ label: 'Joined' });
   });
 
+  it('returns Left for ring.remove', () => {
+    expect(
+      getKeyRingEventMeta({
+        id: '1',
+        roomId: 'r',
+        timestamp: 0,
+        type: 'ring.remove',
+        scope: 'public',
+        text: '',
+        payload: {},
+      })
+    ).to.deep.equal({ label: 'Left' });
+  });
+
+  it('returns null for non-key events', () => {
+    expect(
+      getKeyRingEventMeta({
+        id: '1',
+        roomId: 'r',
+        timestamp: 0,
+        type: 'ring.xp',
+        scope: 'public',
+        text: '',
+        payload: {},
+      })
+    ).to.equal(null);
+  });
+
   it('returns Fight began vs Fight ended for ring.fight', () => {
     expect(
       getKeyRingEventMeta({

--- a/docs/roadmap/15-ring-feed-timestamps.md
+++ b/docs/roadmap/15-ring-feed-timestamps.md
@@ -50,9 +50,11 @@ Every feed item:
 - `data-event-at="{ISO8601}"` — machine-readable instant (event `timestamp` ms → ISO).
 - `title="{locale absolute string}"` — full date/time on hover (e.g. `Intl.DateTimeFormat` with `dateStyle` + `timeStyle`).
 
-Key-event inline span (optional):
+Key-event inline span (when toggle is on):
 
-- `class="event-key-timeago"` for potential `timeago.js` `render()` hooks later.
+- `class="event-key-meta"` — flex column wrapper (label + time)
+- `class="event-key-label"` — uppercased short label (e.g. `JOINED`)
+- `class="event-key-time"` — tabular-nums timeago string
 
 ## Updating relative strings
 
@@ -70,3 +72,5 @@ Key-event inline span (optional):
 - [x] Add `timeago.js` to `apps/web`
 - [x] `useTimeAgo` + `formatEventHoverTitle` using `Intl.DateTimeFormat`
 - [x] `RingPane`: `data-event-at` + `title` on every row; inline timeago for key events only (`ring.add`, `ring.remove`, `ring.fight` start/end)
+- [x] Opt-in toggle under Account → Appearance (`useRingKeyTimestamps`, `localStorage` key `deck-monsters-ring-key-timestamps`)
+- [x] Last-fight footer shows timeago only when toggle is on; hover title always present


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes five issues found during review of the ring feed timestamps feature (#311).

## Changes

### `RingPane.tsx` — misplaced type declaration
`type TrackedEvent` was declared between two `import` statements (after `@deck-monsters/server/types` but before `trpc`). Moved it after all imports where type declarations belong.

### `useRingKeyTimestamps.ts` — stale storage value on disable
`setRingKeyTimestampsEnabled(false)` was writing `'0'` to localStorage. Since `readStored()` only returns `true` for the string `'1'`, writing `'0'` worked functionally but left garbage in storage that would never be read as truthy. Fixed to call `localStorage.removeItem()` when disabling, consistent with the "absent = off" contract in `readStored`.

### `terminal.css` — duplicate screen-reader rule removed
`.event time.event-sr-only` repeated the same 10 declarations as `.event-sr-only`. The `<time>` element inside `.event` already picks up `.event-sr-only` via its class; the higher-specificity duplicate was redundant and added maintenance surface.

### `event-time.test.ts` — missing test coverage
Added:
- `ring.remove` → `{ label: 'Left' }` (was tested in code but not in the suite)
- `ring.xp` (non-key event) → `null` (no test for the null path at all)

### `docs/roadmap/15-ring-feed-timestamps.md` — wrong CSS class names + incomplete task list
The doc referenced a class `event-key-timeago` that does not exist in the implementation (actual classes are `event-key-meta`, `event-key-label`, `event-key-time`). Updated the metadata section to match the real class hierarchy. Also ticked the two tasks that were done but not marked complete (opt-in toggle + last-fight footer).

## Testing

- ✅ `pnpm --filter @deck-monsters/web build` — TypeScript + Vite clean
- ✅ `pnpm --filter @deck-monsters/web lint` — ESLint clean
- ✅ `pnpm --filter @deck-monsters/web test` — 36/36 tests pass (4 tests in `event-time.test.ts`, including the 2 new cases)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24ea0025-d4ff-49a9-9e2c-5771a73d6e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24ea0025-d4ff-49a9-9e2c-5771a73d6e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

