### PR TITLE
refactor: consolidate streak functions and fix fight-display helpers

### DIFF
--- a/apps/web/src/utils/fight-display.ts
+++ b/apps/web/src/utils/fight-display.ts
@@ -15,22 +15,25 @@ export type FightSummaryLike = {
   participants: FightParticipantLike[];
 };
 
+/** Join a list of names with natural-language "and". */
 function nameList(names: string[]): string {
   if (names.length === 0) return '?';
   if (names.length === 1) return names[0]!;
-  if (names.length === 2) return `${names[0]} vs ${names[1]}`;
-  return `${names.slice(0, -1).join(', ')}, vs ${names[names.length - 1]}`;
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
 }
 
-/** One-line title: e.g. "A vs B" or "A, B vs C, D" for multi-monster. */
+/**
+ * One-line title: "A vs B" for 1v1, "A vs B vs C" for multi-monster.
+ * Always uses the participants array when available (covers draws and multi-monster
+ * fights where winnerMonsterName / loserMonsterName are null).
+ */
 export function fightTitleOneLine(f: FightSummaryLike): string {
   const ps = f.participants ?? [];
-  if (ps.length <= 2 && f.winnerMonsterName && f.loserMonsterName) {
-    return `${f.winnerMonsterName} vs ${f.loserMonsterName}`;
+  if (ps.length > 0) {
+    return ps.map((p) => p.monsterName).join(' vs ');
   }
-  if (ps.length >= 3) {
-    return nameList(ps.map((p) => p.monsterName));
-  }
+  // Fallback for legacy rows that pre-date the participants column.
   return `${f.winnerMonsterName ?? '?'} vs ${f.loserMonsterName ?? '?'}`;
 }
 

--- a/packages/server/src/analytics-queries.ts
+++ b/packages/server/src/analytics-queries.ts
@@ -545,7 +545,7 @@ export function buildCatchUpText(
 	return { fightCount: summaries.length, textSummary: lines.join('\n') };
 }
 
-const STREAK_MIN = 3;
+export const STREAK_MIN = 3;
 const STREAK_LOOKBACK = 80;
 
 /** Count consecutive wins for `monsterId` from most recent fights (fights ordered endedAt DESC). */
@@ -572,17 +572,21 @@ export function monsterIdsFromSummaries(summaries: FightSummaryRow[]): string[] 
 }
 
 /**
- * Current win streak for each monster (most recent fights first). Only monsters with streak >= minStreak are returned.
+ * Compute current consecutive-win streaks for the given monsters in a room.
+ *
+ * Fetches the last `STREAK_LOOKBACK` fights once, then counts consecutive wins
+ * per monster in memory. When `minStreak > 0` only monsters that meet the
+ * threshold are included in the returned map; callers that need all values
+ * (including zero) should pass `minStreak = 0` (the default).
  */
-export async function computeWinStreaksForMonsters(
+export async function computeMonsterWinStreaks(
 	db: Db,
 	roomId: string,
 	monsterIds: string[],
-	minStreak = STREAK_MIN
+	minStreak = 0
 ): Promise<Map<string, number>> {
 	const out = new Map<string, number>();
 	if (monsterIds.length === 0) return out;
-
 	const recent = await queryRecentFights(db, roomId, STREAK_LOOKBACK);
 	for (const mid of monsterIds) {
 		const streak = winStreakFromRecentFights(recent, mid);
@@ -610,21 +614,6 @@ export function formatCatchUpStreakLines(
 		lines.push(`${name} is on a ${n}-fight winning streak.`);
 	}
 	return lines;
-}
-
-/** Win streak for leaderboard rows — uses recent fights once. */
-export async function computeMonsterWinStreaksForRoom(
-	db: Db,
-	roomId: string,
-	monsterIds: string[]
-): Promise<Map<string, number>> {
-	const out = new Map<string, number>();
-	if (monsterIds.length === 0) return out;
-	const recent = await queryRecentFights(db, roomId, STREAK_LOOKBACK);
-	for (const mid of monsterIds) {
-		out.set(mid, winStreakFromRecentFights(recent, mid));
-	}
-	return out;
 }
 
 export async function loadFightEventsForSummary(

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -21,8 +21,7 @@ import { attachFightStatsSubscriber } from './fight-stats-subscriber.js';
 import { attachFightSummaryWriter } from './fight-summary-writer.js';
 import {
 	buildCatchUpText,
-	computeMonsterWinStreaksForRoom,
-	computeWinStreaksForMonsters,
+	computeMonsterWinStreaks,
 	formatCatchUpStreakLines,
 	formatGlobalMonsterLeaderboard,
 	formatGlobalPlayerLeaderboard,
@@ -36,6 +35,7 @@ import {
 	queryGlobalPlayers,
 	queryRoomMonsters,
 	queryRoomPlayers,
+	STREAK_MIN,
 	touchMemberLastSeen,
 	type LeaderboardSort,
 } from './analytics-queries.js';
@@ -93,7 +93,7 @@ export class RoomManager {
 			},
 			fetchRoomMonsterLeaderboard: async (sortBy: LeaderboardSortKey, limit: number) => {
 				const rows = await queryRoomMonsters(this.db, roomId, sortBy as LeaderboardSort, limit);
-				const streaks = await computeMonsterWinStreaksForRoom(
+				const streaks = await computeMonsterWinStreaks(
 					this.db,
 					roomId,
 					rows.map((r) => r.monsterId)
@@ -117,7 +117,7 @@ export class RoomManager {
 				const summaries = await queryFightsSince(this.db, roomId, sinceDate);
 				const label = formatSinceLabel(sinceDate);
 				const ids = monsterIdsFromSummaries(summaries);
-				const streakMap = await computeWinStreaksForMonsters(this.db, roomId, ids);
+				const streakMap = await computeMonsterWinStreaks(this.db, roomId, ids, STREAK_MIN);
 				const streakLines = formatCatchUpStreakLines(streakMap, summaries);
 				const { textSummary } = buildCatchUpText(summaries, label, streakLines);
 				await touchMemberLastSeen(this.db, roomId, userId);

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -20,13 +20,13 @@ import {
 	queryRoomMonsters,
 	queryRoomPlayers,
 	buildCatchUpText,
-	computeMonsterWinStreaksForRoom,
-	computeWinStreaksForMonsters,
+	computeMonsterWinStreaks,
 	formatCatchUpStreakLines,
 	formatSinceLabel,
 	getMemberLastSeen,
 	monsterIdsFromSummaries,
 	queryFightsSince,
+	STREAK_MIN,
 	touchMemberLastSeen,
 	type LeaderboardSort,
 } from '../analytics-queries.js';
@@ -87,7 +87,7 @@ export function createRouter(roomManager: RoomManager) {
 				await roomManager.assertMember(ctx.userId, input.roomId);
 				const limit = input.limit ?? 25;
 				const rows = await queryRoomMonsters(db, input.roomId, (input.sortBy ?? 'xp') as LeaderboardSort, limit);
-				const streaks = await computeMonsterWinStreaksForRoom(
+				const streaks = await computeMonsterWinStreaks(
 					db,
 					input.roomId,
 					rows.map((r) => r.monsterId)
@@ -546,7 +546,7 @@ export function createRouter(roomManager: RoomManager) {
 				const summaries = await queryFightsSince(db, input.roomId, sinceDate);
 				const label = formatSinceLabel(sinceDate);
 				const ids = monsterIdsFromSummaries(summaries);
-				const streakMap = await computeWinStreaksForMonsters(db, input.roomId, ids);
+				const streakMap = await computeMonsterWinStreaks(db, input.roomId, ids, STREAK_MIN);
 				const streakLines = formatCatchUpStreakLines(streakMap, summaries);
 				const { fightCount, textSummary } = buildCatchUpText(summaries, label, streakLines);
 				if (input.touchLastSeen !== false) {

--- a/supabase/migrations/20260410120000_leaderboard_fight_stats.sql
+++ b/supabase/migrations/20260410120000_leaderboard_fight_stats.sql
@@ -66,7 +66,3 @@ create index if not exists fight_summaries_room_loser_monster_idx
 
 create unique index if not exists fight_summaries_room_fight_number_key
   on public.fight_summaries (room_id, fight_number);
-
--- GIN index for JSONB containment queries on participants (e.g. monster fight history).
-create index if not exists fight_summaries_participants_gin_idx
-  on public.fight_summaries using gin (participants);


### PR DESCRIPTION
- Merge computeWinStreaksForMonsters + computeMonsterWinStreaksForRoom into single computeMonsterWinStreaks(db, roomId, ids, minStreak=0); export STREAK_MIN
- Update all callers in router.ts and room-manager.ts to use the unified function
- Fix fight-display.ts: nameList uses "and" connector (not "vs") for prose contexts; fightTitleOneLine now reads participants[] to avoid "? vs ?" on draws
- Remove duplicate GIN index from 20260410 migration (already added in 20260411)

https://claude.ai/code/session_019Sm9iBep7LdFHKiRVGyEe6