### PR TITLE
Fix critical auth, websocket, and engine command regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ See [CLAUDE.md](CLAUDE.md) for the full action method list and deeper architectu
 pnpm install
 ```
 
+### One-command local bootstrap (Supabase + env + test user)
+
+```bash
+pnpm setup:local
+```
+
+This script now bootstraps the full local environment by:
+- installing workspace dependencies
+- ensuring a working container runtime (Docker recommended; Podman fallback supported)
+- starting/resetting local Supabase
+- writing `.env.local`, `packages/server/.env.local`, and `apps/web/.env.local`
+- creating a reusable local auth test user (default: `localtester@example.com`)
+
+Common options:
+
+```bash
+bash scripts/setup-local.sh --runtime docker
+bash scripts/setup-local.sh --runtime podman
+bash scripts/setup-local.sh --skip-seed-user
+bash scripts/setup-local.sh --seed-user-email you@example.com --seed-user-password 'strong-password'
+bash scripts/setup-local.sh --dry-run
+```
+
 ### Test
 
 ```bash

--- a/apps/web/src/lib/auth-context.tsx
+++ b/apps/web/src/lib/auth-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from './supabase.js';
-import { setTRPCToken } from './trpc.js';
+import { reconnectWsClient, setTRPCToken } from './trpc.js';
 
 interface AuthContextValue {
   session: Session | null;
@@ -32,9 +32,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       })
       .finally(() => setLoading(false));
 
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, s) => {
+    const { data: listener } = supabase.auth.onAuthStateChange((event, s) => {
       setSession(s);
       setTRPCToken(s?.access_token ?? null);
+      if (event === 'TOKEN_REFRESHED') {
+        reconnectWsClient();
+      }
     });
 
     return () => listener.subscription.unsubscribe();

--- a/apps/web/src/lib/trpc.test.ts
+++ b/apps/web/src/lib/trpc.test.ts
@@ -1,21 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const createWSClientMock = vi.fn();
-const wsLinkMock = vi.fn();
-const httpBatchLinkMock = vi.fn();
-const splitLinkMock = vi.fn();
-const createClientMock = vi.fn();
+const mocks = vi.hoisted(() => ({
+  createWSClientMock: vi.fn(),
+  wsLinkMock: vi.fn(),
+  httpBatchLinkMock: vi.fn(),
+  splitLinkMock: vi.fn(),
+  createClientMock: vi.fn(),
+}));
 
 vi.mock('@trpc/client', () => ({
-  createWSClient: createWSClientMock,
-  wsLink: wsLinkMock,
-  httpBatchLink: httpBatchLinkMock,
-  splitLink: splitLinkMock,
+  createWSClient: mocks.createWSClientMock,
+  wsLink: mocks.wsLinkMock,
+  httpBatchLink: mocks.httpBatchLinkMock,
+  splitLink: mocks.splitLinkMock,
 }));
 
 vi.mock('@trpc/react-query', () => ({
   createTRPCReact: () => ({
-    createClient: createClientMock,
+    createClient: mocks.createClientMock,
   }),
 }));
 
@@ -23,20 +25,20 @@ import { createTRPCClient, reconnectWsClient, setTRPCToken } from './trpc.js';
 
 describe('lib/trpc', () => {
   beforeEach(() => {
-    createWSClientMock.mockReset();
-    wsLinkMock.mockReset();
-    httpBatchLinkMock.mockReset();
-    splitLinkMock.mockReset();
-    createClientMock.mockReset();
+    mocks.createWSClientMock.mockReset();
+    mocks.wsLinkMock.mockReset();
+    mocks.httpBatchLinkMock.mockReset();
+    mocks.splitLinkMock.mockReset();
+    mocks.createClientMock.mockReset();
     reconnectWsClient();
 
-    createWSClientMock.mockImplementation(() => ({
+    mocks.createWSClientMock.mockImplementation(() => ({
       close: vi.fn(),
     }));
-    wsLinkMock.mockReturnValue({ type: 'ws-link' });
-    httpBatchLinkMock.mockReturnValue({ type: 'http-link' });
-    splitLinkMock.mockImplementation((opts) => opts.true);
-    createClientMock.mockReturnValue({ ok: true });
+    mocks.wsLinkMock.mockReturnValue({ type: 'ws-link' });
+    mocks.httpBatchLinkMock.mockReturnValue({ type: 'http-link' });
+    mocks.splitLinkMock.mockImplementation((opts) => opts.true);
+    mocks.createClientMock.mockReturnValue({ ok: true });
     setTRPCToken(null);
   });
 
@@ -44,9 +46,9 @@ describe('lib/trpc', () => {
     setTRPCToken('token-one');
     createTRPCClient();
 
-    expect(createWSClientMock).toHaveBeenCalledTimes(1);
+    expect(mocks.createWSClientMock).toHaveBeenCalledTimes(1);
 
-    const firstClient = createWSClientMock.mock.results[0]?.value as { close: ReturnType<typeof vi.fn> };
+    const firstClient = mocks.createWSClientMock.mock.results[0]?.value as { close: ReturnType<typeof vi.fn> };
     reconnectWsClient();
 
     expect(firstClient.close).toHaveBeenCalledTimes(1);
@@ -54,8 +56,8 @@ describe('lib/trpc', () => {
     setTRPCToken('token-two');
     createTRPCClient();
 
-    expect(createWSClientMock).toHaveBeenCalledTimes(2);
-    const secondUrlFactory = createWSClientMock.mock.calls[1]?.[0]?.url as () => string;
+    expect(mocks.createWSClientMock).toHaveBeenCalledTimes(2);
+    const secondUrlFactory = mocks.createWSClientMock.mock.calls[1]?.[0]?.url as () => string;
     expect(secondUrlFactory()).toContain('token-two');
   });
 });

--- a/apps/web/src/lib/trpc.test.ts
+++ b/apps/web/src/lib/trpc.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createWSClientMock = vi.fn();
+const wsLinkMock = vi.fn();
+const httpBatchLinkMock = vi.fn();
+const splitLinkMock = vi.fn();
+const createClientMock = vi.fn();
+
+vi.mock('@trpc/client', () => ({
+  createWSClient: createWSClientMock,
+  wsLink: wsLinkMock,
+  httpBatchLink: httpBatchLinkMock,
+  splitLink: splitLinkMock,
+}));
+
+vi.mock('@trpc/react-query', () => ({
+  createTRPCReact: () => ({
+    createClient: createClientMock,
+  }),
+}));
+
+import { createTRPCClient, reconnectWsClient, setTRPCToken } from './trpc.js';
+
+describe('lib/trpc', () => {
+  beforeEach(() => {
+    createWSClientMock.mockReset();
+    wsLinkMock.mockReset();
+    httpBatchLinkMock.mockReset();
+    splitLinkMock.mockReset();
+    createClientMock.mockReset();
+    reconnectWsClient();
+
+    createWSClientMock.mockImplementation(() => ({
+      close: vi.fn(),
+    }));
+    wsLinkMock.mockReturnValue({ type: 'ws-link' });
+    httpBatchLinkMock.mockReturnValue({ type: 'http-link' });
+    splitLinkMock.mockImplementation((opts) => opts.true);
+    createClientMock.mockReturnValue({ ok: true });
+    setTRPCToken(null);
+  });
+
+  it('recreates the websocket client after reconnect', () => {
+    setTRPCToken('token-one');
+    createTRPCClient();
+
+    expect(createWSClientMock).toHaveBeenCalledTimes(1);
+
+    const firstClient = createWSClientMock.mock.results[0]?.value as { close: ReturnType<typeof vi.fn> };
+    reconnectWsClient();
+
+    expect(firstClient.close).toHaveBeenCalledTimes(1);
+
+    setTRPCToken('token-two');
+    createTRPCClient();
+
+    expect(createWSClientMock).toHaveBeenCalledTimes(2);
+    const secondUrlFactory = createWSClientMock.mock.calls[1]?.[0]?.url as () => string;
+    expect(secondUrlFactory()).toContain('token-two');
+  });
+});

--- a/apps/web/src/lib/trpc.ts
+++ b/apps/web/src/lib/trpc.ts
@@ -26,6 +26,13 @@ export function setTRPCToken(token: string | null): void {
   // errors when onAuthStateChange fired multiple times during the OAuth flow.
 }
 
+export function reconnectWsClient(): void {
+  if (wsClient) {
+    wsClient.close();
+    wsClient = null;
+  }
+}
+
 function getServerUrl(): string {
   return import.meta.env['VITE_SERVER_URL'] as string ?? '';
 }

--- a/packages/engine/src/characters/beastmaster.ts
+++ b/packages/engine/src/characters/beastmaster.ts
@@ -432,7 +432,7 @@ class Beastmaster extends BaseCharacter {
 				if (monster.cards.length < monster.cardSlots) {
 					return Promise.reject(
 						channel({
-							announce: 'Only an evil master would send their monster into battle with enough cards.',
+							announce: 'Only an evil master would send their monster into battle without enough cards.',
 						}),
 					);
 				}

--- a/packages/engine/src/commands/index.ts
+++ b/packages/engine/src/commands/index.ts
@@ -121,7 +121,7 @@ export function registerHandler(
 
 let handlersLoaded = false;
 
-export function 	loadHandlers(): void {
+export function loadHandlers(): void {
 	if (handlersLoaded) return;
 	handlersLoaded = true;
 	preCharacterHandlers.push(helpHandler);

--- a/packages/server/src/trpc/context.test.ts
+++ b/packages/server/src/trpc/context.test.ts
@@ -81,14 +81,19 @@ describe('trpc/context.ts', () => {
 		}
 	});
 
-	async function signJwt(sub: string): Promise<string> {
+	async function signJwt(
+		sub: string,
+		options?: { issuedAt?: number; expiresInSeconds?: number },
+	): Promise<string> {
+		const issuedAt = options?.issuedAt ?? Math.floor(Date.now() / 1000);
+		const expiresInSeconds = options?.expiresInSeconds ?? 3600;
 		return new SignJWT({ sub })
 			.setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
 			.setAudience('authenticated')
 			// Matches the issuer expected by createContext: `${SUPABASE_URL}/auth/v1`
 			.setIssuer('https://test.supabase.co/auth/v1')
-			.setIssuedAt()
-			.setExpirationTime('1h')
+			.setIssuedAt(issuedAt)
+			.setExpirationTime(issuedAt + expiresInSeconds)
 			.sign(privateKey);
 	}
 
@@ -138,6 +143,15 @@ describe('trpc/context.ts', () => {
 				makeCtxOpts(makeReq({ authorization: 'Bearer not.a.valid.jwt' }))
 			);
 			expect(ctx.userId).to.be.null;
+		});
+
+		it('accepts a token slightly past exp when within clock tolerance', async () => {
+			const now = Math.floor(Date.now() / 1000);
+			const token = await signJwt('user-skew', { issuedAt: now - 90, expiresInSeconds: 70 });
+			const ctx = await createContext(
+				makeCtxOpts(makeReq({ authorization: `Bearer ${token}` }))
+			);
+			expect(ctx.userId).to.equal('user-skew');
 		});
 
 		it('returns null userId when SUPABASE_URL is not configured', async () => {

--- a/packages/server/src/trpc/context.ts
+++ b/packages/server/src/trpc/context.ts
@@ -79,6 +79,8 @@ export async function createContext({ req }: CreateFastifyContextOptions): Promi
 			audience: 'authenticated',
 			// Verify the issuer so tokens from other Supabase projects are rejected.
 			issuer: `${process.env['SUPABASE_URL']}/auth/v1`,
+			// Allow minor clock skew between API host and auth provider.
+			clockTolerance: 60,
 		});
 		const sub = payload.sub;
 

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,54 +1,431 @@
 #!/usr/bin/env bash
 # scripts/setup-local.sh
 #
-# Fully autonomous local dev environment setup.
-# Requires: Docker Desktop running, pnpm, npx (supabase CLI via npx).
+# Bootstrap a full local Deck Monsters environment:
+# - install dependencies
+# - ensure a container runtime is available (Docker first, Podman fallback)
+# - start/reset local Supabase
+# - write .env.local files
+# - build engine
+# - optionally seed a local auth user for quick sign-in testing
 #
 # Usage:
 #   bash scripts/setup-local.sh
-#
-# Re-running is safe: supabase start is skipped when already up,
-# db reset wipes and recreates the DB, and .env.local files are overwritten.
+#   bash scripts/setup-local.sh --runtime docker
+#   bash scripts/setup-local.sh --runtime podman
+#   bash scripts/setup-local.sh --skip-seed-user
+#   bash scripts/setup-local.sh --dry-run
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-echo "==> Installing dependencies"
-pnpm install
+RUNTIME_MODE="auto"
+SKIP_INSTALL=0
+SKIP_SEED_USER=0
+DRY_RUN=0
+SEED_USER_EMAIL="${LOCAL_TEST_USER_EMAIL:-localtester@example.com}"
+SEED_USER_PASSWORD="${LOCAL_TEST_USER_PASSWORD:-deck-monsters-local}"
+CONTAINER_RUNTIME=""
+NEEDS_PODMAN_DOCKER_HOST=0
 
-echo ""
-echo "==> Starting local Supabase stack (Docker required)"
-if npx supabase status &>/dev/null; then
-  echo "    Already running — skipping supabase start"
-else
-  npx supabase start
-fi
+print_help() {
+  cat <<'EOF'
+Deck Monsters local setup bootstrap
 
-echo ""
-echo "==> Applying migrations (db reset)"
-# Pass 'y' on stdin in case the CLI asks for confirmation
-echo "y" | npx supabase db reset
+Options:
+  --runtime <auto|docker|podman>   Select preferred runtime (default: auto)
+  --skip-install                   Skip installing missing system runtime dependencies
+  --skip-seed-user                 Skip creating/upserting local auth test user
+  --seed-user-email <email>        Test user email (default: localtester@example.com)
+  --seed-user-password <password>  Test user password (default: deck-monsters-local)
+  --dry-run                        Print commands without executing
+  -h, --help                       Show this help
+EOF
+}
 
-echo ""
-echo "==> Reading local Supabase credentials"
-STATUS=$(npx supabase status 2>/dev/null)
+log() {
+  printf '==> %s\n' "$1"
+}
 
-ANON_KEY=$(echo "$STATUS" | grep "anon key" | grep -oE 'eyJ[A-Za-z0-9._-]+')
-SERVICE_KEY=$(echo "$STATUS" | grep "service_role key" | grep -oE 'eyJ[A-Za-z0-9._-]+')
+warn() {
+  printf 'WARNING: %s\n' "$1" >&2
+}
 
-if [[ -z "$ANON_KEY" || -z "$SERVICE_KEY" ]]; then
-  echo "ERROR: Could not extract keys from 'supabase status'. Output was:"
-  echo "$STATUS"
+die() {
+  printf 'ERROR: %s\n' "$1" >&2
   exit 1
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run() {
+  if ((DRY_RUN)); then
+    printf '[dry-run] %s\n' "$*"
+    return 0
+  fi
+  "$@"
+}
+
+run_pipe_yes() {
+  if ((DRY_RUN)); then
+    printf '[dry-run] echo "y" | %s\n' "$*"
+    return 0
+  fi
+  echo "y" | "$@"
+}
+
+ensure_sudo_available() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    return 0
+  fi
+  has_cmd sudo || die "This step needs root privileges. Re-run with sudo or install runtime manually."
+}
+
+apt_install() {
+  ensure_sudo_available
+  if [[ "${EUID}" -eq 0 ]]; then
+    run apt-get update
+    run apt-get install -y "$@"
+  else
+    run sudo apt-get update
+    run sudo apt-get install -y "$@"
+  fi
+}
+
+dnf_install() {
+  ensure_sudo_available
+  if [[ "${EUID}" -eq 0 ]]; then
+    run dnf install -y "$@"
+  else
+    run sudo dnf install -y "$@"
+  fi
+}
+
+brew_install() {
+  has_cmd brew || die "Homebrew is required for this install path."
+  run brew install "$@"
+}
+
+install_runtime_dependencies() {
+  case "$1" in
+    docker)
+      log "Installing Docker runtime prerequisites"
+      if has_cmd apt-get; then
+        apt_install docker.io docker-compose-plugin
+      elif has_cmd dnf; then
+        dnf_install docker docker-compose-plugin
+      elif has_cmd brew; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+          run brew install --cask docker
+        else
+          brew_install docker docker-compose
+        fi
+      else
+        die "Unable to auto-install Docker on this OS. Install Docker Desktop/Engine manually, then re-run."
+      fi
+      ;;
+    podman)
+      log "Installing Podman runtime prerequisites"
+      if has_cmd apt-get; then
+        apt_install podman podman-docker slirp4netns uidmap
+      elif has_cmd dnf; then
+        dnf_install podman podman-docker
+      elif has_cmd brew; then
+        brew_install podman
+      else
+        die "Unable to auto-install Podman on this OS. Install Podman manually, then re-run."
+      fi
+      ;;
+    *)
+      die "Unknown runtime '$1'"
+      ;;
+  esac
+}
+
+try_start_docker_daemon() {
+  if has_cmd systemctl; then
+    if [[ "${EUID}" -eq 0 ]]; then
+      run systemctl enable --now docker || true
+    elif has_cmd sudo; then
+      run sudo systemctl enable --now docker || true
+    fi
+  elif has_cmd service; then
+    if [[ "${EUID}" -eq 0 ]]; then
+      run service docker start || true
+    elif has_cmd sudo; then
+      run sudo service docker start || true
+    fi
+  fi
+}
+
+docker_ready() {
+  has_cmd docker && docker info >/dev/null 2>&1
+}
+
+ensure_docker_runtime() {
+  if docker_ready; then
+    CONTAINER_RUNTIME="docker"
+    return 0
+  fi
+
+  if has_cmd docker; then
+    log "Docker CLI found but daemon unavailable; attempting to start daemon"
+    try_start_docker_daemon
+  elif ((SKIP_INSTALL)); then
+    return 1
+  else
+    install_runtime_dependencies docker
+    try_start_docker_daemon
+  fi
+
+  if ((DRY_RUN)); then
+    warn "Dry-run: assuming Docker would be available after install/start steps."
+    CONTAINER_RUNTIME="docker"
+    return 0
+  fi
+
+  if docker_ready; then
+    CONTAINER_RUNTIME="docker"
+    return 0
+  fi
+  return 1
+}
+
+ensure_podman_service() {
+  if ((DRY_RUN)); then
+    if [[ -z "${XDG_RUNTIME_DIR:-}" ]]; then
+      export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+    fi
+    local podman_socket="${XDG_RUNTIME_DIR}/podman/podman.sock"
+    export DOCKER_HOST="unix://${podman_socket}"
+    NEEDS_PODMAN_DOCKER_HOST=1
+    printf '[dry-run] would start podman socket: %s\n' "${DOCKER_HOST}"
+    return 0
+  fi
+
+  has_cmd podman || return 1
+  podman info >/dev/null 2>&1 || return 1
+
+  if [[ -z "${XDG_RUNTIME_DIR:-}" ]]; then
+    export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+  fi
+  local podman_socket="${XDG_RUNTIME_DIR}/podman/podman.sock"
+
+  if [[ ! -S "$podman_socket" ]]; then
+    mkdir -p "$(dirname "$podman_socket")"
+    if ((DRY_RUN)); then
+      printf '[dry-run] nohup podman system service --time=0 "unix://%s" >/tmp/podman-system-service.log 2>&1 &\n' "$podman_socket"
+    else
+      nohup podman system service --time=0 "unix://${podman_socket}" >/tmp/podman-system-service.log 2>&1 &
+      sleep 1
+    fi
+  fi
+
+  export DOCKER_HOST="unix://${podman_socket}"
+  NEEDS_PODMAN_DOCKER_HOST=1
+  return 0
+}
+
+ensure_podman_runtime() {
+  if has_cmd docker && docker info >/dev/null 2>&1; then
+    CONTAINER_RUNTIME="docker"
+    return 0
+  fi
+
+  if ! has_cmd podman && (( ! SKIP_INSTALL )); then
+    install_runtime_dependencies podman
+  fi
+  if ((DRY_RUN)); then
+    ensure_podman_service || return 1
+    CONTAINER_RUNTIME="podman"
+    return 0
+  fi
+  has_cmd podman || return 1
+
+  ensure_podman_service || return 1
+  if has_cmd docker; then
+    if docker info >/dev/null 2>&1; then
+      CONTAINER_RUNTIME="podman"
+      return 0
+    fi
+  else
+    warn "'docker' CLI not found. Install podman-docker or Docker CLI shim for Supabase compatibility."
+    return 1
+  fi
+  return 1
+}
+
+ensure_container_runtime() {
+  log "Ensuring a supported container runtime is available"
+
+  case "$RUNTIME_MODE" in
+    docker)
+      ensure_docker_runtime || die "Docker runtime unavailable. Install/start Docker and retry."
+      ;;
+    podman)
+      ensure_podman_runtime || die "Podman runtime unavailable for Supabase. Install podman-docker or choose --runtime docker."
+      ;;
+    auto)
+      if ensure_docker_runtime; then
+        :
+      elif ensure_podman_runtime; then
+        :
+      else
+        die "No working container runtime found. Install Docker Desktop/Engine (recommended) or Podman+podman-docker."
+      fi
+      ;;
+    *)
+      die "Invalid --runtime value: $RUNTIME_MODE"
+      ;;
+  esac
+}
+
+extract_status_value() {
+  local label="$1"
+  local text="$2"
+  printf '%s\n' "$text" | awk -F': ' -v k="$label" '$1 ~ k {print $2; exit}'
+}
+
+seed_local_user() {
+  ((SKIP_SEED_USER)) && return 0
+
+  log "Seeding local auth user (${SEED_USER_EMAIL})"
+
+  local payload
+  payload=$(printf '{"email":"%s","password":"%s"}' "$SEED_USER_EMAIL" "$SEED_USER_PASSWORD")
+
+  if ((DRY_RUN)); then
+    printf '[dry-run] curl -sS -X POST "http://localhost:54321/auth/v1/signup" ...\n'
+    return 0
+  fi
+
+  has_cmd curl || die "curl is required to seed local auth users."
+
+  local response
+  response=$(
+    curl -sS -X POST "http://localhost:54321/auth/v1/signup" \
+      -H "apikey: ${ANON_KEY}" \
+      -H "Content-Type: application/json" \
+      -d "$payload"
+  ) || die "Failed to call local Supabase auth signup endpoint."
+
+  if [[ "$response" == *'"access_token"'* ]]; then
+    printf '    Created user: %s\n' "$SEED_USER_EMAIL"
+    return 0
+  fi
+
+  if [[ "$response" == *'User already registered'* ]]; then
+    printf '    User already exists: %s\n' "$SEED_USER_EMAIL"
+    return 0
+  fi
+
+  warn "Unexpected signup response. You may need to create the test account manually."
+  printf '    response: %s\n' "$response"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runtime)
+      shift
+      [[ $# -gt 0 ]] || die "--runtime requires a value"
+      RUNTIME_MODE="$1"
+      ;;
+    --skip-install)
+      SKIP_INSTALL=1
+      ;;
+    --skip-seed-user)
+      SKIP_SEED_USER=1
+      ;;
+    --seed-user-email)
+      shift
+      [[ $# -gt 0 ]] || die "--seed-user-email requires a value"
+      SEED_USER_EMAIL="$1"
+      ;;
+    --seed-user-password)
+      shift
+      [[ $# -gt 0 ]] || die "--seed-user-password requires a value"
+      SEED_USER_PASSWORD="$1"
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1 (run with --help for usage)"
+      ;;
+  esac
+  shift
+done
+
+has_cmd pnpm || die "pnpm is required."
+has_cmd npx || die "npx is required."
+
+log "Installing dependencies"
+run pnpm install
+
+ensure_container_runtime
+printf '    runtime: %s\n' "$CONTAINER_RUNTIME"
+if ((NEEDS_PODMAN_DOCKER_HOST)); then
+  printf '    DOCKER_HOST: %s\n' "${DOCKER_HOST}"
 fi
 
-echo "    anon key:         ${ANON_KEY:0:20}..."
-echo "    service_role key: ${SERVICE_KEY:0:20}..."
+log "Starting local Supabase stack"
+if ((DRY_RUN)); then
+  printf '[dry-run] npx supabase status\n'
+  printf '[dry-run] npx supabase start\n'
+else
+  if npx supabase status &>/dev/null; then
+    printf '    Already running — skipping supabase start\n'
+  else
+    run npx supabase start
+  fi
+fi
 
-echo ""
-echo "==> Writing packages/server/.env.local"
+log "Applying migrations (db reset)"
+run_pipe_yes npx supabase db reset
+
+log "Reading local Supabase credentials"
+if ((DRY_RUN)); then
+  STATUS=$'API URL: http://localhost:54321\nanon key: eyJexample-anon\nservice_role key: eyJexample-service'
+else
+  STATUS="$(npx supabase status 2>/dev/null)"
+fi
+
+ANON_KEY="$(extract_status_value "anon key" "$STATUS")"
+SERVICE_KEY="$(extract_status_value "service_role key" "$STATUS")"
+
+if [[ -z "${ANON_KEY}" || -z "${SERVICE_KEY}" ]]; then
+  printf 'Supabase status output:\n%s\n' "$STATUS" >&2
+  die "Could not extract anon/service_role keys from 'supabase status'."
+fi
+
+printf '    anon key:         %s...\n' "${ANON_KEY:0:20}"
+printf '    service_role key: %s...\n' "${SERVICE_KEY:0:20}"
+
+log "Writing .env.local files"
+if ((DRY_RUN)); then
+  printf '[dry-run] write %s\n' ".env.local"
+  printf '[dry-run] write %s\n' "packages/server/.env.local"
+  printf '[dry-run] write %s\n' "apps/web/.env.local"
+  if ((NEEDS_PODMAN_DOCKER_HOST)); then
+    printf '[dry-run] write %s\n' ".env.local.runtime"
+  fi
+else
+cat > .env.local <<EOF
+DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
+SUPABASE_URL=http://localhost:54321
+SUPABASE_PUBLISHABLE_KEY=${ANON_KEY}
+SUPABASE_SECRET_KEY=${SERVICE_KEY}
+CONNECTOR_SERVICE_TOKEN=dev-service-token
+EOF
+
 cat > packages/server/.env.local <<EOF
 DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
 SUPABASE_URL=http://localhost:54321
@@ -57,16 +434,24 @@ SUPABASE_SECRET_KEY=${SERVICE_KEY}
 CONNECTOR_SERVICE_TOKEN=dev-service-token
 EOF
 
-echo "==> Writing apps/web/.env.local"
 cat > apps/web/.env.local <<EOF
 VITE_SUPABASE_URL=http://localhost:54321
 VITE_SUPABASE_PUBLISHABLE_KEY=${ANON_KEY}
 VITE_SERVER_URL=
 EOF
 
-echo ""
-echo "==> Building engine"
-pnpm --filter engine build
+if ((NEEDS_PODMAN_DOCKER_HOST)); then
+  cat > .env.local.runtime <<EOF
+# Source this file before running supabase commands when using Podman.
+DOCKER_HOST=${DOCKER_HOST}
+EOF
+fi
+fi
+
+seed_local_user
+
+log "Building engine"
+run pnpm --filter @deck-monsters/engine build
 
 echo ""
 echo "========================================="
@@ -74,13 +459,24 @@ echo "  Local environment ready!"
 echo "========================================="
 echo ""
 echo "  Supabase Studio:  http://localhost:54323"
+echo "  Test user email:  ${SEED_USER_EMAIL}"
+if ((SKIP_SEED_USER)); then
+  echo "  Test user status: skipped (--skip-seed-user)"
+else
+  echo "  Test user password: ${SEED_USER_PASSWORD}"
+fi
 echo ""
+if ((NEEDS_PODMAN_DOCKER_HOST)); then
+  echo "  Podman mode detected. Run this before supabase commands in new shells:"
+  echo "    source .env.local.runtime"
+  echo ""
+fi
 echo "  Start the API server (terminal 1):"
 echo "    pnpm --filter @deck-monsters/server dev"
 echo ""
 echo "  Start the web app (terminal 2):"
 echo "    pnpm --filter @deck-monsters/web dev"
-echo "    → http://localhost:5173"
+echo "    -> http://localhost:5173"
 echo ""
 echo "  To stop Supabase later:"
 echo "    npx supabase stop"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add 60-second JWT `clockTolerance` in server tRPC context to prevent moderate host clock drift from invalidating fresh Supabase tokens
- reconnect web tRPC WebSocket client on Supabase `TOKEN_REFRESHED` events so refreshed tokens are picked up immediately
- fix Beastmaster ring-entry message wording from "with enough cards" to "without enough cards"
- remove stray tab character in `loadHandlers` declaration for readability/consistency
- add regression tests for server JWT skew tolerance and web WebSocket reconnect token propagation
- harden `scripts/setup-local.sh` into a reusable bootstrap script:
  - runtime bootstrap (`--runtime auto|docker|podman`) with install/start checks
  - Docker-first behavior with Podman compatibility mode via `DOCKER_HOST`
  - optional auth test-user seeding (`--seed-user-email`, `--seed-user-password`, `--skip-seed-user`)
  - safer parsing/validation and `--dry-run` support
  - writes root + package env files and prints clearer next steps
- document the improved bootstrap usage in `README.md`

## Validation
- `pnpm build`
- `pnpm --filter @deck-monsters/server test`
- `pnpm --filter @deck-monsters/engine test`
- `pnpm --filter @deck-monsters/web test`
- `pnpm --filter @deck-monsters/web test -- src/lib/trpc.test.ts`
- `pnpm lint` (warnings-only baseline, no new errors)
- `bash scripts/setup-local.sh --help`
- `bash scripts/setup-local.sh --dry-run --runtime auto --seed-user-email localtester@example.com --seed-user-password deck-monsters-local`
- `bash -n scripts/setup-local.sh`

## Follow-up context
- merged latest `origin/main` into this branch to pick up new local setup baseline
- cloud VM still cannot run full local Supabase stack because it has no actual container engine available at runtime (`docker` missing / daemon unavailable), but script behavior is now robust for real local machines and persistent onboarding

## Walkthrough artifacts
[web-login-stable-render.mp4](https://cursor.com/agents/bc-483ca79c-febe-4321-98b6-54a5ab13501b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb-login-stable-render.mp4)
[Deck Monsters login loaded](https://cursor.com/agents/bc-483ca79c-febe-4321-98b6-54a5ab13501b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeck_monsters_login_loaded.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-483ca79c-febe-4321-98b6-54a5ab13501b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-483ca79c-febe-4321-98b6-54a5ab13501b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

