### PR TITLE
Add fight-start event publishing and fix persister cleanup

### DIFF
--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -483,6 +483,16 @@ export class Ring extends BaseClass {
 		if (!this.startEncounter()) return Promise.resolve();
 
 		const contestants = [...this.contestants];
+
+		// Publish fight-start event so server-side subscribers (e.g. fight-summary-writer)
+		// can record the accurate startedAt timestamp for this fight.
+		this.eventBus.publish({
+			type: 'ring.fight',
+			scope: 'public',
+			text: `Fight begins with ${contestants.length} contestants`,
+			payload: { contestants, eventName: 'fightBegins' },
+		});
+
 		const isActiveContestant = (contestant: Contestant | undefined): boolean =>
 			!!(contestant && !contestant.monster.dead && !contestant.monster.fled);
 		const getActiveContestants = (currentContestants: Contestant[]): Contestant[] =>

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -245,6 +245,7 @@ export class RoomManager {
 		// Remove from memory first — no state flush needed since the DB row is being deleted.
 		const activeEntry = this.active.get(roomId);
 		if (activeEntry) {
+			activeEntry.unsubscribePersister();
 			activeEntry.unsubscribeMetrics();
 			activeEntry.unsubscribeFightStats();
 			activeEntry.unsubscribeFightSummary();


### PR DESCRIPTION
## Summary
This PR adds event publishing for fight start events and fixes a resource cleanup issue in the room manager.

## Key Changes
- **Fight-start event publishing**: Added an event bus publication in the `Ring.startFight()` method that emits a `ring.fight` event when a fight begins. This allows server-side subscribers (such as the fight-summary-writer) to record the accurate `startedAt` timestamp for fights.
- **Persister cleanup**: Fixed a resource leak in `RoomManager` by ensuring the persister unsubscriber is called during room cleanup, alongside the existing metrics, fight stats, and fight summary unsubscribers.

## Implementation Details
- The fight-start event includes the list of contestants and an `eventName: 'fightBegins'` payload to identify the event type
- The event is published with `scope: 'public'` to make it available to all subscribers
- The persister unsubscription is now called first in the cleanup sequence to ensure proper resource release order

https://claude.ai/code/session_019UD3Dk6UfrrTter3mCxTxu