### PR TITLE
Fix ring add listener crash on contestant.isBoss access

### DIFF
--- a/packages/server/src/debug-event-logger.ts
+++ b/packages/server/src/debug-event-logger.ts
@@ -13,6 +13,7 @@
  */
 import type { RoomEventBus, GameEvent } from '@deck-monsters/engine';
 import { createLogger, isDebugEnabled, isTraceEnabled } from './logger.js';
+import { extractRingAddContestant } from './ring-event-args.js';
 
 const log = createLogger('events');
 
@@ -213,8 +214,8 @@ export function attachDebugEventLogger(
 	// 'bossWillSpawn' fires 2 minutes before the boss appears.
 
 	const onAdd = (...args: unknown[]) => {
-		const data = args[0] as { contestant: { isBoss?: boolean; monster?: { givenName?: string }; character?: { name?: string }; userId?: string } };
-		const { contestant } = data;
+		const contestant = extractRingAddContestant(args);
+		if (!contestant) return;
 		log.debug(contestant.isBoss ? 'boss entered ring' : 'monster entered ring', {
 			roomId,
 			monster: contestant.monster?.givenName,

--- a/packages/server/src/metrics/collector.test.ts
+++ b/packages/server/src/metrics/collector.test.ts
@@ -1,0 +1,36 @@
+import { EventEmitter } from 'node:events';
+import { expect } from 'chai';
+
+import type { RoomEventBus } from '@deck-monsters/engine';
+import { attachMetricsCollector } from './collector.js';
+import { bossSpawns, registry } from './index.js';
+
+const ROOM_ID = 'room-test';
+
+function readBossSpawnCount(roomId: string): Promise<number> {
+	return bossSpawns.get().then((metric) => {
+		const sample = metric.values.find((value) => value.labels?.room_id === roomId);
+		return sample?.value ?? 0;
+	});
+}
+
+describe('metrics collector ring add listener', () => {
+	beforeEach(() => {
+		registry.resetMetrics();
+	});
+
+	it('handles BaseClass ring add event args and counts boss spawns', async () => {
+		const eventBus = {
+			subscribe: () => () => {},
+		} satisfies Pick<RoomEventBus, 'subscribe'>;
+		const ring = new EventEmitter();
+		const cleanup = attachMetricsCollector(eventBus as RoomEventBus, ring as any, ROOM_ID);
+
+		expect(() => ring.emit('add', 'Ring', ring, { contestant: { isBoss: true } })).to.not.throw();
+		expect(() => ring.emit('add', 'Ring', ring, { contestant: { isBoss: false } })).to.not.throw();
+		expect(() => ring.emit('add', 'Ring', ring)).to.not.throw();
+
+		expect(await readBossSpawnCount(ROOM_ID)).to.equal(1);
+		cleanup();
+	});
+});

--- a/packages/server/src/metrics/collector.test.ts
+++ b/packages/server/src/metrics/collector.test.ts
@@ -24,7 +24,7 @@ describe('metrics collector ring add listener', () => {
 			subscribe: () => () => {},
 		} satisfies Pick<RoomEventBus, 'subscribe'>;
 		const ring = new EventEmitter();
-		const cleanup = attachMetricsCollector(eventBus as RoomEventBus, ring as any, ROOM_ID);
+		const cleanup = attachMetricsCollector(eventBus as unknown as RoomEventBus, ring as any, ROOM_ID);
 
 		expect(() => ring.emit('add', 'Ring', ring, { contestant: { isBoss: true } })).to.not.throw();
 		expect(() => ring.emit('add', 'Ring', ring, { contestant: { isBoss: false } })).to.not.throw();

--- a/packages/server/src/metrics/collector.ts
+++ b/packages/server/src/metrics/collector.ts
@@ -28,6 +28,7 @@ import {
 	monstersInRing,
 	promptTimeouts,
 } from './index.js';
+import { extractRingAddContestant } from '../ring-event-args.js';
 
 // The ring countdown fires FIGHT_DELAY ms before combat starts.
 // We record the countdown timestamp and add this offset to get the
@@ -36,8 +37,8 @@ const FIGHT_DELAY_MS = 60_000;
 
 // Duck-typed interface — only the EventEmitter methods we actually use.
 interface RingLike {
-	on(event: 'add', listener: (data: { contestant: { isBoss?: boolean } }) => void): unknown;
-	off(event: 'add', listener: (data: { contestant: { isBoss?: boolean } }) => void): unknown;
+	on(event: 'add', listener: (...args: unknown[]) => void): unknown;
+	off(event: 'add', listener: (...args: unknown[]) => void): unknown;
 }
 
 type FightContestant = {
@@ -146,8 +147,9 @@ export function attachMetricsCollector(
 	// Boss spawns: detected via the ring's internal EventEmitter since bosses
 	// don't have a separate external event. ring.emit('add', { contestant })
 	// fires for every monster added including bosses.
-	const onRingAdd = (data: { contestant: { isBoss?: boolean } }) => {
-		if (data.contestant.isBoss) {
+	const onRingAdd = (...args: unknown[]) => {
+		const contestant = extractRingAddContestant(args);
+		if (contestant?.isBoss) {
 			bossSpawns.inc({ room_id: roomId });
 		}
 	};

--- a/packages/server/src/ring-event-args.test.ts
+++ b/packages/server/src/ring-event-args.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import { extractRingAddContestant } from './ring-event-args.js';
+
+describe('extractRingAddContestant', () => {
+	it('reads contestant from BaseClass event args', () => {
+		const contestant = extractRingAddContestant([
+			'Ring',
+			{ any: 'instance' },
+			{ contestant: { isBoss: true, userId: 'u1' } },
+		]);
+
+		expect(contestant?.isBoss).to.equal(true);
+		expect(contestant?.userId).to.equal('u1');
+	});
+
+	it('reads contestant from direct payload args', () => {
+		const contestant = extractRingAddContestant([{ contestant: { isBoss: false, userId: 'u2' } }]);
+
+		expect(contestant?.isBoss).to.equal(false);
+		expect(contestant?.userId).to.equal('u2');
+	});
+
+	it('returns undefined for malformed args', () => {
+		expect(extractRingAddContestant([])).to.equal(undefined);
+		expect(extractRingAddContestant(['Ring', {}])).to.equal(undefined);
+	});
+});

--- a/packages/server/src/ring-event-args.ts
+++ b/packages/server/src/ring-event-args.ts
@@ -1,0 +1,31 @@
+type RingAddContestant = {
+	isBoss?: boolean;
+	monster?: { givenName?: string };
+	character?: { name?: string };
+	userId?: string;
+};
+
+type RingAddPayload = { contestant?: RingAddContestant };
+
+function asRingAddPayload(value: unknown): RingAddPayload | undefined {
+	if (!value || typeof value !== 'object') return undefined;
+	if (!('contestant' in value)) return undefined;
+	return value as RingAddPayload;
+}
+
+/**
+ * Ring add listeners may receive either:
+ *  - BaseClass emitter args: (className, instance, { contestant })
+ *  - direct args from mocks/tests: ({ contestant })
+ */
+export function extractRingAddContestant(args: unknown[]): RingAddContestant | undefined {
+	if (args.length <= 0) return undefined;
+
+	// Preferred: BaseClass payload position.
+	const baseClassPayload = asRingAddPayload(args[2]);
+	if (baseClassPayload?.contestant) return baseClassPayload.contestant;
+
+	// Compatibility: direct payload as first arg.
+	const directPayload = asRingAddPayload(args[0]);
+	return directPayload?.contestant;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix server-side ring `add` listeners to handle BaseClass event args (`className, instance, payload`) instead of assuming payload is first arg
- add a shared `extractRingAddContestant()` helper used by both debug logging and metrics collection
- add regression tests for ring add arg extraction and metrics collector boss-spawn counting
- fix test typing cast for strict TypeScript build compatibility

## Why
Production logs show `Cannot read properties of undefined (reading 'isBoss')` right after command dispatch. This prevented monsters from entering the ring and disrupted boss-spawn flow.

## Validation
- `pnpm build`
- `pnpm --filter @deck-monsters/server test -- src/ring-event-args.test.ts src/metrics/collector.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-034efe16-ad46-44a9-847f-4f1102c8d9db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-034efe16-ad46-44a9-847f-4f1102c8d9db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

