### PR TITLE
Fix ring feed crashes, ordering, and live UX

### DIFF
--- a/apps/web/src/__tests__/console-history-event-map.test.ts
+++ b/apps/web/src/__tests__/console-history-event-map.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { mapConsoleHistoryEvent } from '../utils/console-history-event-map.js';
+
+describe('mapConsoleHistoryEvent', () => {
+  it('maps console input system events to input rows', () => {
+    const mapped = mapConsoleHistoryEvent({
+      id: 'evt-1',
+      type: 'system',
+      text: 'send elm to the ring',
+      payload: { consoleInput: true },
+    });
+
+    expect(mapped).toEqual({
+      id: 'evt-1',
+      type: 'input',
+      text: 'send elm to the ring',
+    });
+  });
+
+  it('keeps regular system events as system rows', () => {
+    const mapped = mapConsoleHistoryEvent({
+      id: 'evt-2',
+      type: 'system',
+      text: '-- reconnecting --',
+      payload: {},
+    });
+
+    expect(mapped).toEqual({
+      id: 'evt-2',
+      type: 'system',
+      text: '-- reconnecting --',
+    });
+  });
+});

--- a/apps/web/src/__tests__/useCommandAutocomplete.test.ts
+++ b/apps/web/src/__tests__/useCommandAutocomplete.test.ts
@@ -42,4 +42,28 @@ describe('useCommandAutocomplete', () => {
       expect(equip.insertValue).not.toContain(']');
     }
   });
+
+  it('suggests monster-name command variants for send/revive placeholders', () => {
+    const { result } = renderHook(() => useCommandAutocomplete('send e', true, {
+      monsterNames: ['Elm', 'Westley'],
+      sendableMonsterNames: ['Elm'],
+      deadMonsterNames: ['Westley'],
+    }));
+    const labels = result.current.map(s => s.label.toLowerCase());
+    const inserts = result.current.map(s => s.insertValue.toLowerCase());
+
+    expect(labels).toContain('send elm to the ring');
+    expect(inserts).toContain('send elm to the ring');
+  });
+
+  it('suggests revive commands only when a dead monster name is available', () => {
+    const { result } = renderHook(() => useCommandAutocomplete('revive', true, {
+      monsterNames: ['Elm', 'Westley'],
+      sendableMonsterNames: ['Elm'],
+      deadMonsterNames: ['Westley'],
+    }));
+    const labels = result.current.map(s => s.label.toLowerCase());
+    expect(labels).toContain('revive westley');
+    expect(labels).not.toContain('revive elm');
+  });
 });

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import type { GameEvent } from '@deck-monsters/server/types';
 
 type TrackedEvent = { id: string; data: GameEvent };
@@ -40,6 +40,8 @@ interface MonsterAutocompleteRow {
   dead: boolean;
   inRing: boolean;
 }
+
+const EMPTY_MONSTERS: MonsterAutocompleteRow[] = [];
 
 interface ConsolePaneProps {
   roomId: string;
@@ -161,18 +163,30 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     setIsAtBottom(true);
   }, []);
 
-  const { data: myMonsters = [] } = trpc.game.myMonsters.useQuery(
+  const { data: myMonsters } = trpc.game.myMonsters.useQuery(
     { roomId },
     { enabled: !!roomId },
   );
-  const monsterRows = myMonsters as MonsterAutocompleteRow[];
+  const monsterRows = (myMonsters ?? EMPTY_MONSTERS) as MonsterAutocompleteRow[];
+  const monsterNames = useMemo(
+    () => monsterRows.map((m) => m.name),
+    [monsterRows]
+  );
+  const deadMonsterNames = useMemo(
+    () => monsterRows.filter((m) => m.dead).map((m) => m.name),
+    [monsterRows]
+  );
+  const sendableMonsterNames = useMemo(
+    () => monsterRows.filter((m) => !m.dead && !m.inRing).map((m) => m.name),
+    [monsterRows]
+  );
   const suggestions = useCommandAutocomplete(
     inputValue,
     !activePromptId && !inputLocked,
     {
-      monsterNames: monsterRows.map((m) => m.name),
-      deadMonsterNames: monsterRows.filter((m) => m.dead).map((m) => m.name),
-      sendableMonsterNames: monsterRows.filter((m) => !m.dead && !m.inRing).map((m) => m.name),
+      monsterNames,
+      deadMonsterNames,
+      sendableMonsterNames,
     }
   );
 

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -10,6 +10,7 @@ import { useCommandAutocomplete } from '../hooks/useCommandAutocomplete.js';
 import CommandSuggestions from './CommandSuggestions.js';
 import InlineChoices from './InlineChoices.js';
 import { formatEventText } from '../utils/format-event-text.js';
+import { mapConsoleHistoryEvent } from '../utils/console-history-event-map.js';
 
 interface ActivePrompt {
   requestId: string;
@@ -45,23 +46,6 @@ interface ConsolePaneProps {
   isActive: boolean;
   /** Called with each incoming private event so Terminal can track lastEventId */
   onEvent?: (event: unknown) => void;
-}
-
-/** Convert a historical GameEvent to a ConsoleEvent for display. Returns null for event types
- *  that don't produce a feed entry (quick_actions, prompt.cancel) or that are handled
- *  interactively (active prompts are not reconstructed from history). */
-function historyEventToConsoleEvent(event: { id: string; type: string; text: string; payload: Record<string, unknown> }): ConsoleEvent | null {
-  if (event.type === 'announce' || event.type === 'system') {
-    return { id: event.id, type: event.type as 'announce' | 'system', text: event.text };
-  }
-  if (event.type === 'prompt.request') {
-    // Show the question text as a plain announce — don't reconstruct interactive state
-    return { id: event.id, type: 'announce', text: event.text || (event.payload as any)?.question || '' };
-  }
-  if (event.type === 'prompt.timeout') {
-    return { id: event.id, type: 'tombstone', text: event.text };
-  }
-  return null;
 }
 
 export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePaneProps) {
@@ -114,7 +98,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     const historyConsoleEvents: ConsoleEvent[] = [];
     for (const ev of dedupedHistory) {
       seenRef.current.add(ev.id);
-      const consoleEv = historyEventToConsoleEvent(ev as any);
+      const consoleEv = mapConsoleHistoryEvent(ev as any);
       if (consoleEv) historyConsoleEvents.push(consoleEv);
     }
 
@@ -224,6 +208,16 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         if (!isPrivate && !isPublicSystem) return;
 
         onEvent?.(event);
+
+        const payload = event.payload as Record<string, unknown>;
+        if (event.type === 'system' && payload.consoleInput) {
+          addConsoleEvent({
+            id: event.id,
+            type: 'input',
+            text: event.text,
+          });
+          return;
+        }
 
         if (event.type === 'announce' || event.type === 'system') {
           addConsoleEvent({

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -34,6 +34,12 @@ interface QuickAction {
   command: string;
 }
 
+interface MonsterAutocompleteRow {
+  name: string;
+  dead: boolean;
+  inRing: boolean;
+}
+
 interface ConsolePaneProps {
   roomId: string;
   isActive: boolean;
@@ -171,7 +177,20 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     setIsAtBottom(true);
   }, []);
 
-  const suggestions = useCommandAutocomplete(inputValue, !activePromptId && !inputLocked);
+  const { data: myMonsters = [] } = trpc.game.myMonsters.useQuery(
+    { roomId },
+    { enabled: !!roomId },
+  );
+  const monsterRows = myMonsters as MonsterAutocompleteRow[];
+  const suggestions = useCommandAutocomplete(
+    inputValue,
+    !activePromptId && !inputLocked,
+    {
+      monsterNames: monsterRows.map((m) => m.name),
+      deadMonsterNames: monsterRows.filter((m) => m.dead).map((m) => m.name),
+      sendableMonsterNames: monsterRows.filter((m) => !m.dead && !m.inRing).map((m) => m.name),
+    }
+  );
 
   const sendCommand = trpc.game.command.useMutation();
   const respondToPrompt = trpc.game.respondToPrompt.useMutation();

--- a/apps/web/src/components/RingPane.tsx
+++ b/apps/web/src/components/RingPane.tsx
@@ -11,6 +11,7 @@ import {
 	formatEventHoverTitle,
 	getKeyRingEventMeta,
 } from '../utils/event-time.js';
+import { shouldRenderRingEvent } from '../utils/ring-feed-events.js';
 
 type TrackedEvent = { id: string; data: GameEvent };
 
@@ -114,6 +115,7 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
   const [subLastEventId, setSubLastEventId] = useState<string | undefined>(undefined);
   const feedRef = useRef<HTMLOListElement>(null);
   const seenRef = useRef(new Set<string>());
+  const autoFollowRef = useRef(true);
   const historyApplied = useRef(false);
   const { handleHandshakeEvent } = useHandshake();
 
@@ -150,13 +152,15 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
       seenRef.current.add(ev.id);
     }
 
+    const visibleHistory = dedupedHistory.filter(shouldRenderRingEvent);
+
     // Merge history with any live events that arrived before history loaded.
     // Live events take priority over history events with the same ID.
     setEvents(prev => {
-      if (prev.length === 0) return dedupedHistory;
+      if (prev.length === 0) return visibleHistory;
       const liveById = new Map(prev.map(ev => [ev.id, ev]));
-      const merged: GameEvent[] = dedupedHistory.map(ev => liveById.get(ev.id) ?? ev);
-      const historyIds = new Set(dedupedHistory.map(ev => ev.id));
+      const merged: GameEvent[] = visibleHistory.map(ev => liveById.get(ev.id) ?? ev);
+      const historyIds = new Set(visibleHistory.map(ev => ev.id));
       for (const ev of prev) {
         if (!historyIds.has(ev.id)) merged.push(ev);
       }
@@ -183,23 +187,26 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
       requestAnimationFrame(() => {
         if (feedRef.current) {
           feedRef.current.scrollTop = feedRef.current.scrollHeight;
+          autoFollowRef.current = true;
           setIsAtBottom(true);
         }
       });
     }
   }, [isActive]);
 
-  // Auto-scroll to bottom when new events arrive, if the user hasn't scrolled up
+  // Keep the feed pinned during live fights unless the user scrolls up.
   useEffect(() => {
-    if (isAtBottom && feedRef.current) {
+    if (autoFollowRef.current && feedRef.current) {
       feedRef.current.scrollTop = feedRef.current.scrollHeight;
+      setIsAtBottom(true);
     }
-  }, [events, isAtBottom]);
+  }, [events]);
 
   const handleScroll = useCallback(() => {
     const el = feedRef.current;
     if (!el) return;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    autoFollowRef.current = atBottom;
     setIsAtBottom(atBottom);
   }, []);
 
@@ -207,6 +214,7 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
     if (feedRef.current) {
       feedRef.current.scrollTop = feedRef.current.scrollHeight;
     }
+    autoFollowRef.current = true;
     setIsAtBottom(true);
   }, []);
 
@@ -232,6 +240,8 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
           setTimerState({ nextFightAt: s.nextFightAt, nextBossSpawnAt: s.nextBossSpawnAt, monsterCount: s.monsterCount });
           return;
         }
+
+        if (!shouldRenderRingEvent(event)) return;
 
         // Only show public events in the Ring pane
         if (event.scope !== 'public') return;

--- a/apps/web/src/components/Terminal.tsx
+++ b/apps/web/src/components/Terminal.tsx
@@ -16,9 +16,6 @@ export default function Terminal({ roomId }: TerminalProps) {
   const [ringWidthFraction, setRingWidthFraction] = useState(0.5);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Track tab scroll positions so they're preserved on tab switch
-  const scrollPosRef = useRef<Record<TabId, number>>({ ring: 0, console: 0 });
-
   // Detect layout breakpoint
   useEffect(() => {
     const observer = new ResizeObserver(entries => {

--- a/apps/web/src/hooks/useCommandAutocomplete.ts
+++ b/apps/web/src/hooks/useCommandAutocomplete.ts
@@ -6,43 +6,84 @@ export interface AutocompleteSuggestion {
   insertValue: string;
 }
 
+const MONSTER_COMMAND_RE = /\[monster\]/i;
+
+type MonsterAutocompleteContext = {
+  monsterNames?: string[];
+  deadMonsterNames?: string[];
+  sendableMonsterNames?: string[];
+};
+
+function normalizeCommand(input: string): string {
+  return input.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function expandMonsterPlaceholder(command: string, monsterName: string): string {
+  return command.replace(/\[monster\]/gi, monsterName);
+}
+
 /**
  * Returns up to 5 command suggestions for the current input.
  * Matches on command prefix or any word in the command.
  */
-export function useCommandAutocomplete(input: string, enabled = true): AutocompleteSuggestion[] {
+export function useCommandAutocomplete(
+  input: string,
+  enabled = true,
+  context: MonsterAutocompleteContext = {},
+): AutocompleteSuggestion[] {
   return useMemo(() => {
     const q = input.trim().toLowerCase();
     if (!enabled || q.length < 2) return [];
 
     const results: AutocompleteSuggestion[] = [];
-    const seen = new Set<string>();
+    const seenInsertValues = new Set<string>();
+    const normalizedQuery = normalizeCommand(q);
+    const monsterNames = context.monsterNames ?? [];
+    const deadMonsterNames = context.deadMonsterNames ?? [];
+    const sendableMonsterNames = context.sendableMonsterNames ?? [];
 
     for (const entry of COMMAND_CATALOG) {
-      const cmd = entry.command.toLowerCase();
-      // Exact prefix match (highest priority)
-      const prefixMatch = cmd.startsWith(q);
-      // Any-word match
-      const wordMatch = !prefixMatch && cmd.split(' ').some(word => word.startsWith(q));
-
-      if (prefixMatch || wordMatch) {
-        const insertValue = entry.command.replace(/\[.*?\]/g, '').replace(/\s+/g, ' ').trimEnd();
-        if (!seen.has(entry.command)) {
-          seen.add(entry.command);
-          results.push({ label: entry.command, insertValue });
-        }
+      const hasMonsterPlaceholder = MONSTER_COMMAND_RE.test(entry.command);
+      let namesForTemplate = monsterNames;
+      if (/^revive \[monster\]$/i.test(entry.command)) {
+        namesForTemplate = deadMonsterNames;
+      } else if (/^send \[monster\] to the ring$/i.test(entry.command)) {
+        namesForTemplate = sendableMonsterNames;
       }
+      const expandedCommands = hasMonsterPlaceholder && monsterNames.length > 0
+        ? namesForTemplate.map((name) => ({
+            label: expandMonsterPlaceholder(entry.command, name),
+            insertValue: expandMonsterPlaceholder(entry.command, name),
+          }))
+        : [{
+            label: entry.command,
+            insertValue: entry.command.replace(/\[.*?\]/g, '').replace(/\s+/g, ' ').trimEnd(),
+          }];
 
+      for (const candidate of expandedCommands) {
+        const cmd = normalizeCommand(candidate.label);
+        const prefixMatch = cmd.startsWith(normalizedQuery);
+        const wordMatch = !prefixMatch && cmd.split(' ').some(word => word.startsWith(normalizedQuery));
+
+        if (prefixMatch || wordMatch) {
+          if (!seenInsertValues.has(candidate.insertValue)) {
+            seenInsertValues.add(candidate.insertValue);
+            results.push(candidate);
+          }
+        }
+
+        if (results.length >= 5) break;
+      }
       if (results.length >= 5) break;
     }
 
     // Sort: prefix matches first
     results.sort((a, b) => {
-      const aPrefix = a.label.toLowerCase().startsWith(q) ? 0 : 1;
-      const bPrefix = b.label.toLowerCase().startsWith(q) ? 0 : 1;
+      const aPrefix = normalizeCommand(a.label).startsWith(normalizedQuery) ? 0 : 1;
+      const bPrefix = normalizeCommand(b.label).startsWith(normalizedQuery) ? 0 : 1;
       return aPrefix - bPrefix;
     });
 
     return results.slice(0, 5);
-  }, [input, enabled]);
+  }, [input, enabled, context.monsterNames, context.deadMonsterNames, context.sendableMonsterNames]);
 }

--- a/apps/web/src/utils/console-history-event-map.ts
+++ b/apps/web/src/utils/console-history-event-map.ts
@@ -1,0 +1,31 @@
+export type ConsoleHistoryEvent = {
+  id: string;
+  type: string;
+  text: string;
+  payload: Record<string, unknown>;
+};
+
+export type ConsoleHistoryDisplayEvent =
+  | { id: string; type: 'announce' | 'system' | 'input' | 'tombstone'; text: string }
+  | null;
+
+/**
+ * Convert a historical GameEvent row into a Console feed event.
+ * Returns null for event types that should not render as a history line.
+ */
+export function mapConsoleHistoryEvent(event: ConsoleHistoryEvent): ConsoleHistoryDisplayEvent {
+  const payload = event.payload ?? {};
+  if (event.type === 'system' && payload.consoleInput) {
+    return { id: event.id, type: 'input', text: event.text };
+  }
+  if (event.type === 'announce' || event.type === 'system') {
+    return { id: event.id, type: event.type as 'announce' | 'system', text: event.text };
+  }
+  if (event.type === 'prompt.request') {
+    return { id: event.id, type: 'announce', text: event.text || String(payload.question ?? '') };
+  }
+  if (event.type === 'prompt.timeout') {
+    return { id: event.id, type: 'tombstone', text: event.text };
+  }
+  return null;
+}

--- a/apps/web/src/utils/ring-feed-events.test.ts
+++ b/apps/web/src/utils/ring-feed-events.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GameEvent } from '@deck-monsters/server/types';
+import { shouldRenderRingEvent } from './ring-feed-events.js';
+
+function event(type: GameEvent['type'], scope: GameEvent['scope'] = 'public'): GameEvent {
+  return {
+    id: `evt-${type}`,
+    roomId: 'room-1',
+    timestamp: Date.now(),
+    type,
+    scope,
+    text: type,
+    payload: {},
+  };
+}
+
+describe('shouldRenderRingEvent', () => {
+  it('hides ring.fightResolved system analytics event', () => {
+    expect(shouldRenderRingEvent(event('ring.fightResolved'))).to.equal(false);
+  });
+
+  it('keeps player-facing ring narration events', () => {
+    expect(shouldRenderRingEvent(event('ring.add'))).to.equal(true);
+    expect(shouldRenderRingEvent(event('ring.fight'))).to.equal(true);
+    expect(shouldRenderRingEvent(event('ring.xp'))).to.equal(true);
+  });
+});

--- a/apps/web/src/utils/ring-feed-events.ts
+++ b/apps/web/src/utils/ring-feed-events.ts
@@ -1,0 +1,10 @@
+import type { GameEvent } from '@deck-monsters/server/types';
+
+const HIDDEN_RING_EVENT_TYPES = new Set<string>([
+  // Internal analytics event; users already see flavorful fight-conclusion text.
+  'ring.fightResolved',
+]);
+
+export function shouldRenderRingEvent(event: Pick<GameEvent, 'type'>): boolean {
+  return !HIDDEN_RING_EVENT_TYPES.has(event.type);
+}

--- a/packages/engine/src/cards/survival-knife.test.ts
+++ b/packages/engine/src/cards/survival-knife.test.ts
@@ -58,6 +58,7 @@ describe('./cards/survival-knife.ts', () => {
 		const player = new Basilisk({ name: 'player' });
 		const target = new Basilisk({ name: 'target' });
 		(player as any).hp = 1;
+		const before = (player as any).hp;
 
 		const ring: any = {
 			contestants: [{ monster: player }, { monster: target }],
@@ -65,13 +66,28 @@ describe('./cards/survival-knife.ts', () => {
 		};
 
 		const healEffectSpy = sinon.spy((survivalKnife as any).healCard, 'effect');
+		const checkSuccessStub = sinon.stub(HealCard.prototype, 'checkSuccess').returns({
+			curseOfLoki: false,
+			healRoll: { result: 5 },
+			result: 5,
+			strokeOfLuck: false,
+			success: true,
+		});
 
 		return survivalKnife
 			.play(player, target, ring, ring.contestants)
 			.then(() => {
-				expect((player as any).hp).to.be.above(1);
+				expect((player as any).hp).to.be.above(before);
 				expect(healEffectSpy.callCount).to.equal(1);
 			})
-			.then(() => healEffectSpy.restore());
+			.then(() => {
+				healEffectSpy.restore();
+				checkSuccessStub.restore();
+			})
+			.catch((err: unknown) => {
+				healEffectSpy.restore();
+				checkSuccessStub.restore();
+				throw err;
+			});
 	});
 });

--- a/packages/server/src/db/game-event-map.test.ts
+++ b/packages/server/src/db/game-event-map.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'chai';
+
+import { dbRowToGameEvent } from './game-event-map.js';
+
+describe('dbRowToGameEvent', () => {
+	it('uses embedded eventId timestamp for deterministic history ordering', () => {
+		const row = {
+			id: 42,
+			roomId: 'room-1',
+			type: 'ring.fight',
+			scope: 'public',
+			targetUserId: null,
+			payload: {},
+			text: 'fight event',
+			eventId: '1712835000123-abcd1234',
+			createdAt: new Date('2026-04-11T07:50:50.999Z'),
+		};
+
+		const mapped = dbRowToGameEvent(row);
+		expect(mapped.timestamp).to.equal(1712835000123);
+	});
+
+	it('falls back to createdAt when eventId has no timestamp prefix', () => {
+		const createdAt = new Date('2026-04-11T07:50:50.999Z');
+		const row = {
+			id: 43,
+			roomId: 'room-1',
+			type: 'ring.fight',
+			scope: 'public',
+			targetUserId: null,
+			payload: {},
+			text: 'legacy event',
+			eventId: 'legacy-id',
+			createdAt,
+		};
+
+		const mapped = dbRowToGameEvent(row);
+		expect(mapped.timestamp).to.equal(createdAt.getTime());
+	});
+});

--- a/packages/server/src/db/game-event-map.test.ts
+++ b/packages/server/src/db/game-event-map.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'chai';
+import { expect } from 'chai';
 
 import { dbRowToGameEvent } from './game-event-map.js';
 

--- a/packages/server/src/db/game-event-map.ts
+++ b/packages/server/src/db/game-event-map.ts
@@ -12,11 +12,22 @@ type DbRoomEvent = {
 	createdAt: Date;
 };
 
+function timestampFromEventId(eventId: string | null): number | undefined {
+	if (!eventId) return undefined;
+	const [prefix] = eventId.split('-', 1);
+	if (!prefix) return undefined;
+	const ts = Number.parseInt(prefix, 10);
+	if (!Number.isFinite(ts)) return undefined;
+	if (ts <= 0) return undefined;
+	return ts;
+}
+
 export function dbRowToGameEvent(row: DbRoomEvent): GameEvent {
+	const eventTimestamp = timestampFromEventId(row.eventId) ?? row.createdAt.getTime();
 	return {
 		id: row.eventId ?? `hist:${row.id}`,
 		roomId: row.roomId,
-		timestamp: row.createdAt.getTime(),
+		timestamp: eventTimestamp,
 		type: row.type as GameEvent['type'],
 		scope: row.scope as GameEvent['scope'],
 		targetUserId: row.targetUserId ?? undefined,

--- a/packages/server/src/event-persister.test.ts
+++ b/packages/server/src/event-persister.test.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+
+import { RoomEventBus } from '@deck-monsters/engine';
+import { attachEventPersister } from './event-persister.js';
+
+type InsertCall = {
+	roomId: string;
+	type: string;
+	eventId: string | null;
+};
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('event persister', () => {
+	it('writes events to DB in publish order even with async inserts', async () => {
+		const eventBus = new RoomEventBus('room-1');
+		const insertOrder: InsertCall[] = [];
+		const dbCompletes: Array<ReturnType<typeof deferred<void>>> = [];
+		let activeInserts = 0;
+
+		const db = {
+			insert() {
+				return {
+					values(input: InsertCall) {
+						insertOrder.push(input);
+						activeInserts += 1;
+						const d = deferred<void>();
+						dbCompletes.push(d);
+						return {
+							onConflictDoNothing() {
+								return d.promise.finally(() => {
+									activeInserts -= 1;
+								});
+							},
+						};
+					},
+				};
+			},
+		};
+
+		attachEventPersister(eventBus, db as any, () => {});
+
+		const e1 = eventBus.publish({
+			type: 'announce',
+			scope: 'public',
+			text: 'one',
+			payload: {},
+		});
+		const e2 = eventBus.publish({
+			type: 'announce',
+			scope: 'public',
+			text: 'two',
+			payload: {},
+		});
+
+		// Only the first insert should have started due to serialization.
+		expect(insertOrder.map((r) => r.eventId)).to.deep.equal([e1.id]);
+		expect(activeInserts).to.equal(1);
+
+		dbCompletes[0]?.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Second insert starts only after first resolves.
+		expect(insertOrder.map((r) => r.eventId)).to.deep.equal([e1.id, e2.id]);
+		expect(activeInserts).to.equal(1);
+
+		dbCompletes[1]?.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(activeInserts).to.equal(0);
+	});
+});

--- a/packages/server/src/event-persister.test.ts
+++ b/packages/server/src/event-persister.test.ts
@@ -19,6 +19,10 @@ function deferred<T>() {
 	return { promise, resolve, reject };
 }
 
+async function flushMacrotask(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 describe('event persister', () => {
 	it('writes events to DB in publish order even with async inserts', async () => {
 		const eventBus = new RoomEventBus('room-1');
@@ -61,21 +65,23 @@ describe('event persister', () => {
 			payload: {},
 		});
 
+		await flushMacrotask();
+
 		// Only the first insert should have started due to serialization.
 		expect(insertOrder.map((r) => r.eventId)).to.deep.equal([e1.id]);
 		expect(activeInserts).to.equal(1);
 
 		dbCompletes[0]?.resolve();
-		await Promise.resolve();
-		await Promise.resolve();
+		await flushMacrotask();
+		await flushMacrotask();
 
 		// Second insert starts only after first resolves.
 		expect(insertOrder.map((r) => r.eventId)).to.deep.equal([e1.id, e2.id]);
 		expect(activeInserts).to.equal(1);
 
 		dbCompletes[1]?.resolve();
-		await Promise.resolve();
-		await Promise.resolve();
+		await flushMacrotask();
+		await flushMacrotask();
 		expect(activeInserts).to.equal(0);
 	});
 });

--- a/packages/server/src/event-persister.ts
+++ b/packages/server/src/event-persister.ts
@@ -54,6 +54,7 @@ export function attachEventPersister(
 							eventId: event.id,
 						})
 						.onConflictDoNothing()
+						.then(() => undefined)
 				)
 				.catch((err: unknown) => onError(err));
 		},

--- a/packages/server/src/event-persister.ts
+++ b/packages/server/src/event-persister.ts
@@ -22,6 +22,7 @@ export function attachEventPersister(
 	onError: (err: unknown) => void = () => {}
 ): () => void {
 	const subscriberId = `${SUBSCRIBER_ID_PREFIX}:${eventBus.roomId}`;
+	let writeQueue = Promise.resolve();
 
 	// Event types that are transient state-sync signals and should not be
 	// persisted to the history table — they have no replay value.
@@ -38,17 +39,22 @@ export function attachEventPersister(
 					eventId: event.id,
 				});
 			}
-			db.insert(roomEvents)
-				.values({
-					roomId: event.roomId,
-					type: event.type,
-					scope: event.scope,
-					targetUserId: event.targetUserId ?? null,
-					payload: event.payload as Record<string, unknown>,
-					text: event.text,
-					eventId: event.id,
-				})
-				.onConflictDoNothing()
+			// Preserve persistence order even when DB latency varies between writes.
+			// This keeps history replay stable across browser reloads.
+			writeQueue = writeQueue
+				.then(() =>
+					db.insert(roomEvents)
+						.values({
+							roomId: event.roomId,
+							type: event.type,
+							scope: event.scope,
+							targetUserId: event.targetUserId ?? null,
+							payload: event.payload as Record<string, unknown>,
+							text: event.text,
+							eventId: event.id,
+						})
+						.onConflictDoNothing()
+				)
 				.catch((err: unknown) => onError(err));
 		},
 	});

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -260,6 +260,19 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 
+				// Persist a user-input echo event so console history can show
+				// previously submitted commands after reload.
+				eventBus.publish({
+					type: 'system',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: input.command,
+					payload: {
+						consoleInput: true,
+						causedByCommandId: commandId,
+					},
+				});
+
 				// Channel callback: all output (announcements and prompts) goes through
 				// the event bus so the web client receives it via the ringFeed WebSocket.
 				//

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -419,7 +419,7 @@ export function createRouter(roomManager: RoomManager) {
 				);
 
 				return monsters
-					.map((monster: any) => ({
+					.map((monster: { givenName?: unknown; dead?: unknown }) => ({
 						name: String(monster?.givenName ?? '').trim(),
 						dead: Boolean(monster?.dead),
 						inRing: inRing.has(monster),
@@ -441,7 +441,7 @@ export function createRouter(roomManager: RoomManager) {
 				);
 
 				return monsters
-					.map((monster: any) => ({
+					.map((monster: { givenName?: unknown; dead?: unknown }) => ({
 						name: String(monster?.givenName ?? '').trim(),
 						dead: Boolean(monster?.dead),
 						inRing: inRing.has(monster),

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -427,28 +427,6 @@ export function createRouter(roomManager: RoomManager) {
 					.filter((monster: { name: string }) => monster.name.length > 0);
 			}),
 
-		autocompleteMonsters: protectedProcedure
-			.input(z.object({ roomId: z.string().uuid() }))
-			.query(async ({ input, ctx }) => {
-				await roomManager.assertMember(ctx.userId, input.roomId);
-				const game = await roomManager.getGame(input.roomId);
-				const character = game.characters?.[ctx.userId];
-				const monsters = Array.isArray(character?.monsters) ? character.monsters : [];
-				const inRing = new Set(
-					game.ring.contestants
-						.filter((contestant) => contestant?.userId === ctx.userId && !contestant?.isBoss)
-						.map((contestant) => contestant?.monster)
-				);
-
-				return monsters
-					.map((monster: { givenName?: unknown; dead?: unknown }) => ({
-						name: String(monster?.givenName ?? '').trim(),
-						dead: Boolean(monster?.dead),
-						inRing: inRing.has(monster),
-					}))
-					.filter((monster: { name: string }) => monster.name.length > 0);
-			}),
-
 		ringHistory: protectedProcedure
 			.input(z.object({ roomId: z.string().uuid() }))
 			.query(async ({ input, ctx }) => {

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -392,6 +392,50 @@ export function createRouter(roomManager: RoomManager) {
 				return roomManager.getRingState(ctx.userId, input.roomId);
 			}),
 
+		myMonsters: protectedProcedure
+			.input(z.object({ roomId: z.string().uuid() }))
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const game = await roomManager.getGame(input.roomId);
+				const character = game.characters?.[ctx.userId];
+				const monsters = Array.isArray(character?.monsters) ? character.monsters : [];
+				const inRing = new Set(
+					game.ring.contestants
+						.filter((contestant) => contestant?.userId === ctx.userId && !contestant?.isBoss)
+						.map((contestant) => contestant?.monster)
+				);
+
+				return monsters
+					.map((monster: any) => ({
+						name: String(monster?.givenName ?? '').trim(),
+						dead: Boolean(monster?.dead),
+						inRing: inRing.has(monster),
+					}))
+					.filter((monster: { name: string }) => monster.name.length > 0);
+			}),
+
+		autocompleteMonsters: protectedProcedure
+			.input(z.object({ roomId: z.string().uuid() }))
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const game = await roomManager.getGame(input.roomId);
+				const character = game.characters?.[ctx.userId];
+				const monsters = Array.isArray(character?.monsters) ? character.monsters : [];
+				const inRing = new Set(
+					game.ring.contestants
+						.filter((contestant) => contestant?.userId === ctx.userId && !contestant?.isBoss)
+						.map((contestant) => contestant?.monster)
+				);
+
+				return monsters
+					.map((monster: any) => ({
+						name: String(monster?.givenName ?? '').trim(),
+						dead: Boolean(monster?.dead),
+						inRing: inRing.has(monster),
+					}))
+					.filter((monster: { name: string }) => monster.name.length > 0);
+			}),
+
 		ringHistory: protectedProcedure
 			.input(z.object({ roomId: z.string().uuid() }))
 			.query(async ({ input, ctx }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix server ring `add` listeners to parse BaseClass emitter args safely, eliminating `contestant.isBoss` undefined crashes
- improve Ring pane UX by keeping auto-follow while the user is at bottom and hiding internal `ring.fightResolved` analytics events from player-facing feed rows
- fix ring history replay ordering after reload by serializing event persistence writes and deriving timestamps from eventId prefixes when available
- add monster-name autocomplete expansion for placeholder commands (e.g. `send [monster] to the ring`, `revive [monster]`) using the current user’s monster list
- persist user-submitted console commands as private history events and render them as input rows on reload so users see both what they sent and what the game responded with
- resolve PR review comments by removing duplicate `autocompleteMonsters` endpoint and memoizing monster-name arrays passed into command autocomplete
- stabilize `SurvivalKnifeCard` low-health test by stubbing heal outcome randomness so it no longer flakes on poison/zero-heal rolls

## Validation
- `pnpm --filter @deck-monsters/web build`
- `pnpm --filter @deck-monsters/web test -- src/__tests__/console-history-event-map.test.ts src/__tests__/useCommandAutocomplete.test.ts`
- `pnpm --filter @deck-monsters/server test -- src/integration/command-flow.test.ts src/room-manager.test.ts`
- `pnpm lint`
- `pnpm --filter @deck-monsters/engine exec mocha src/cards/survival-knife.test.ts`
- `for i in $(seq 1 30); do pnpm --filter @deck-monsters/engine exec mocha src/cards/survival-knife.test.ts >/tmp/survival_fixed_$i.log 2>&1 || { echo FAIL:$i; break; }; done; echo DONE`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-034efe16-ad46-44a9-847f-4f1102c8d9db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-034efe16-ad46-44a9-847f-4f1102c8d9db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

