### PR TITLE
Fix engine recursive save scheduling during ring persistence

### DIFF
--- a/packages/engine/src/game.test.ts
+++ b/packages/engine/src/game.test.ts
@@ -66,6 +66,51 @@ describe('game.ts', () => {
 		}
 	});
 
+	it('does not schedule recursive saves while persisting ring contestants', () => {
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		const game = new Game();
+		const saveStateStub = sinon.stub();
+
+		try {
+			game.ring.contestants = [
+				{
+					userId: 'user-1',
+					character: { givenName: 'Hero' },
+					monster: { stableId: 'monster-1', givenName: 'Fang' },
+				},
+				{
+					userId: 'boss-1',
+					isBoss: true,
+					character: { givenName: 'Boss' },
+					monster: { stableId: 'boss-monster', givenName: 'Big Boss' },
+				},
+			] as any;
+
+			game.saveState = saveStateStub;
+			game.emit('stateChange');
+
+			clock.tick(31_000);
+			expect(saveStateStub.calledOnce).to.equal(true);
+
+			// Advance another debounce window without new state changes: no extra save.
+			clock.tick(31_000);
+			expect(saveStateStub.calledOnce).to.equal(true);
+
+			const arg = saveStateStub.firstCall.args[0] as string;
+			const decoded = zlib.gunzipSync(Buffer.from(arg, 'base64')).toString();
+			const persisted = JSON.parse(decoded) as {
+				options?: { ringContestantRefs?: Array<{ userId: string; stableId: string }> };
+			};
+
+			expect(persisted.options?.ringContestantRefs).to.deep.equal([
+				{ userId: 'user-1', stableId: 'monster-1' },
+			]);
+		} finally {
+			game.saveState = undefined;
+			clock.restore();
+		}
+	});
+
 	it('can draw a card', () => {
 		const game = new Game();
 		const card = game.drawCard({ useless: 'option' });

--- a/packages/engine/src/game.ts
+++ b/packages/engine/src/game.ts
@@ -129,7 +129,17 @@ export class Game extends BaseClass {
 		const ringContestantRefs = this.ring.contestants
 			.filter(c => !c.isBoss)
 			.map(c => ({ userId: c.userId, stableId: c.monster.stableId }));
-		this.setOptions({ ringContestantRefs } as any);
+		// Avoid setOptions() here: it emits stateChange which would re-schedule another
+		// debounced save and create an unintended save loop.
+		if (ringContestantRefs.length > 0) {
+			this.optionsStore = {
+				...this.optionsStore,
+				ringContestantRefs,
+			};
+		} else {
+			const { ringContestantRefs: _omit, ...rest } = this.optionsStore as any;
+			this.optionsStore = rest;
+		}
 
 		const buffer = zlib.gzipSync(JSON.stringify(this));
 		const string = buffer.toString('base64');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevent `Game.persistState()` from calling `setOptions()` while snapshotting `ringContestantRefs`.
- Update `optionsStore` directly so saving state does not emit `stateChange` and schedule another debounce save.
- Add a regression test ensuring one save occurs per actual state change and that only non-boss ring contestants are persisted.

## Testing
- `pnpm --filter @deck-monsters/engine build`
- `node --import tsx /workspace/node_modules/.pnpm/mocha@11.7.5/node_modules/mocha/bin/mocha.js --no-config --no-package --file src/shared/test-setup.ts src/game.test.ts --exit`
- `pnpm --filter @deck-monsters/web build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7620f9d-b99c-4263-a7e6-16c4a0f61ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7620f9d-b99c-4263-a7e6-16c4a0f61ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

