### PR TITLE
Fix ringFeed abort listener accumulation during heartbeat loop

### DIFF
--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -544,20 +544,25 @@ export function createRouter(roomManager: RoomManager) {
 						// prevents load-balancer idle timeouts (typically 30–60 s).
 						let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 						await new Promise<void>((res) => {
-							resolve = () => {
-								if (heartbeatTimer !== null) { clearTimeout(heartbeatTimer); heartbeatTimer = null; }
+							let settled = false;
+							let onAbort: (() => void) | null = null;
+
+							const finish = () => {
+								if (settled) return;
+								settled = true;
+								resolve = null;
+								if (heartbeatTimer !== null) {
+									clearTimeout(heartbeatTimer);
+									heartbeatTimer = null;
+								}
+								if (onAbort) signal?.removeEventListener('abort', onAbort);
 								res();
 							};
-							heartbeatTimer = setTimeout(() => {
-								resolve = null;
-								heartbeatTimer = null;
-								res();
-							}, 20_000);
-							signal?.addEventListener('abort', () => {
-								resolve = null;
-								if (heartbeatTimer !== null) { clearTimeout(heartbeatTimer); heartbeatTimer = null; }
-								res();
-							}, { once: true });
+
+							onAbort = () => finish();
+							resolve = finish;
+							heartbeatTimer = setTimeout(finish, 20_000);
+							signal?.addEventListener('abort', onAbort, { once: true });
 						});
 
 						// If the queue is still empty after the wait it was a 20-s timeout —


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevent listener accumulation in `game.ringFeed` subscription wait loop by cleaning up the `abort` listener on every settle path (event, timeout, or abort).
- Keep heartbeat behavior unchanged while making wait-cycle cleanup idempotent to avoid long-lived WebSocket memory growth.

## Testing
- `pnpm --filter @deck-monsters/engine build`
- `pnpm --filter @deck-monsters/server lint`
- `pnpm --filter @deck-monsters/server test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d6b51ab-f061-4b6c-bf54-3cb868741549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d6b51ab-f061-4b6c-bf54-3cb868741549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

