### PR TITLE
Fix stuck console prompt flow recovery

### DIFF
--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -85,13 +85,13 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const [quickActions, setQuickActions] = useState<QuickAction[]>([]);
   const [suggestionIndex, setSuggestionIndex] = useState(-1);
 
-  // Always undefined — the server delivers the last 100 events on connect and
-  // seenRef handles deduplication with DB history. Previously this was set from
-  // the history effect, but changing a subscription input restarts the WebSocket.
-  const subLastEventId: string | undefined = undefined;
+  // Resume cursor for reconnects. Updated only on errors so we don't restart
+  // the subscription on every event.
+  const [subLastEventId, setSubLastEventId] = useState<string | undefined>(undefined);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const seenRef = useRef(new Set<string>());
+  const latestTrackedEventIdRef = useRef<string | undefined>(undefined);
   const historyApplied = useRef(false);
 
   // Register command-insert function so external callers (CommandReference, etc.) can populate the input
@@ -104,7 +104,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
 
   // Fetch persistent console history from DB on mount
   const { data: history } = trpc.game.consoleHistory.useQuery({ roomId });
-  const { data: pendingPrompt } = trpc.game.pendingPrompt.useQuery(
+  const { data: pendingPrompt, refetch: refetchPendingPrompt } = trpc.game.pendingPrompt.useQuery(
     { roomId },
     { enabled: !!roomId },
   );
@@ -269,6 +269,8 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         // Keep-alive ping from server — no UI action needed
         if (event.type === 'heartbeat') return;
 
+        latestTrackedEventIdRef.current = tracked.id;
+
         if (seenRef.current.has(tracked.id)) return;
         seenRef.current.add(tracked.id);
 
@@ -373,6 +375,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
           });
         }
         setReconnecting(true);
+        setSubLastEventId(latestTrackedEventIdRef.current);
       },
     }
   );
@@ -484,8 +487,17 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
 
     try {
       await respondToPrompt.mutateAsync({ roomId, requestId, answer });
-    } catch {
-      // Silent — the prompt is already visually resolved
+    } catch (err) {
+      addConsoleEvent({
+        id: `sys-${Date.now()}`,
+        type: 'system',
+        text: `! ${err instanceof Error ? err.message : 'Prompt is no longer active'}`,
+      });
+      // Recover latest pending prompt snapshot after stale requestId races.
+      const latest = await refetchPendingPrompt();
+      if (latest.data) {
+        upsertPendingPrompt(latest.data);
+      }
     } finally {
       inputRef.current?.focus();
     }

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -25,6 +25,13 @@ interface ActivePrompt {
   arrivedAt: number;
 }
 
+interface PendingPromptSnapshot {
+  requestId: string;
+  question: string;
+  choices: string[];
+  timeoutSeconds?: number;
+}
+
 interface ConsoleEvent {
   id: string;
   type: 'announce' | 'input' | 'system' | 'prompt' | 'tombstone';
@@ -50,6 +57,18 @@ interface ConsolePaneProps {
   isActive: boolean;
   /** Called with each incoming private event so Terminal can track lastEventId */
   onEvent?: (event: unknown) => void;
+}
+
+function isPendingPromptSnapshot(value: unknown): value is PendingPromptSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.requestId === 'string'
+    && typeof entry.question === 'string'
+    && Array.isArray(entry.choices)
+    && entry.choices.every(choice => typeof choice === 'string')
+    && (entry.timeoutSeconds === undefined || typeof entry.timeoutSeconds === 'number')
+  );
 }
 
 export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePaneProps) {
@@ -85,6 +104,10 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
 
   // Fetch persistent console history from DB on mount
   const { data: history } = trpc.game.consoleHistory.useQuery({ roomId });
+  const { data: pendingPrompt } = trpc.game.pendingPrompt.useQuery(
+    { roomId },
+    { enabled: !!roomId },
+  );
 
   // Apply DB history once — pre-populate seenRef and seed stable subscription lastEventId.
   useEffect(() => {
@@ -179,6 +202,55 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   function addConsoleEvent(ev: ConsoleEvent) {
     setConsoleEvents(prev => [...prev, ev]);
   }
+
+  const upsertPendingPrompt = useCallback((prompt: PendingPromptSnapshot) => {
+    setConsoleEvents(prev => {
+      const existingIndex = prev.findIndex(ev => ev.promptData?.requestId === prompt.requestId);
+      if (existingIndex === -1) {
+        return [
+          ...prev,
+          {
+            id: `prompt-resume-${prompt.requestId}`,
+            type: 'prompt',
+            text: prompt.question,
+            promptData: {
+              requestId: prompt.requestId,
+              question: prompt.question,
+              choices: prompt.choices,
+              timedOut: false,
+              cancelled: false,
+              selectedAnswer: null,
+              timeoutSeconds: prompt.timeoutSeconds,
+              arrivedAt: Date.now(),
+            },
+          },
+        ];
+      }
+
+      return prev.map((ev, index) => {
+        if (index !== existingIndex || !ev.promptData) return ev;
+        return {
+          ...ev,
+          text: prompt.question,
+          promptData: {
+            ...ev.promptData,
+            question: prompt.question,
+            choices: prompt.choices,
+            timedOut: false,
+            cancelled: false,
+            selectedAnswer: null,
+            timeoutSeconds: prompt.timeoutSeconds ?? ev.promptData.timeoutSeconds,
+          },
+        };
+      });
+    });
+    setActivePromptId(prompt.requestId);
+  }, []);
+
+  useEffect(() => {
+    if (!pendingPrompt) return;
+    upsertPendingPrompt(pendingPrompt);
+  }, [pendingPrompt, upsertPendingPrompt]);
 
   trpc.game.ringFeed.useSubscription(
     { roomId, lastEventId: subLastEventId },
@@ -368,11 +440,17 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
 
       if (!result.ok) {
         const msg = 'message' in result ? result.message : 'Command failed';
+        const blockedPrompt = 'pendingPrompt' in result && isPendingPromptSnapshot(result.pendingPrompt)
+          ? result.pendingPrompt
+          : null;
         addConsoleEvent({
           id: `sys-${Date.now()}`,
           type: 'system',
           text: `! ${msg}`,
         });
+        if (blockedPrompt) {
+          upsertPendingPrompt(blockedPrompt);
+        }
         // If blocked by an in-progress flow, offer a force-cancel shortcut
         if (typeof msg === 'string' && msg.includes('already in progress')) {
           addConsoleEvent({

--- a/apps/web/src/components/RingPane.tsx
+++ b/apps/web/src/components/RingPane.tsx
@@ -117,13 +117,13 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
     nextBossSpawnAt: null,
     monsterCount: 0,
   });
-  // Always undefined — the server delivers the last 100 events on connect and
-  // seenRef handles deduplication with DB history. Previously this was set from
-  // the history effect, but changing a subscription input restarts the WebSocket,
-  // causing a burst of duplicate events mid-stream.
-  const subLastEventId: string | undefined = undefined;
+  // Resume cursor for reconnects. We keep this stable during normal streaming,
+  // and only update it on connection errors so we don't restart the subscription
+  // on every incoming event.
+  const [subLastEventId, setSubLastEventId] = useState<string | undefined>(undefined);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const seenRef = useRef(new Set<string>());
+  const latestTrackedEventIdRef = useRef<string | undefined>(undefined);
   const historyApplied = useRef(false);
   const { handleHandshakeEvent } = useHandshake();
 
@@ -215,11 +215,13 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
 
         // ring.state is a state-sync signal — update timers but don't show in the feed
         if (event.type === 'ring.state') {
+          latestTrackedEventIdRef.current = tracked.id;
           const s = event.payload as unknown as TimerState;
           setTimerState({ nextFightAt: s.nextFightAt, nextBossSpawnAt: s.nextBossSpawnAt, monsterCount: s.monsterCount });
           return;
         }
 
+        latestTrackedEventIdRef.current = tracked.id;
         if (!shouldRenderRingEvent(event)) return;
 
         // Only show public events in the Ring pane
@@ -234,6 +236,7 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
       onError() {
         setConnected(false);
         setReconnecting(true);
+        setSubLastEventId(latestTrackedEventIdRef.current);
       },
     }
   );

--- a/packages/engine/src/events/room-event-bus.test.ts
+++ b/packages/engine/src/events/room-event-bus.test.ts
@@ -124,3 +124,27 @@ describe('RoomEventBus sendPrompt payload', () => {
 		return p.then((a) => expect(a).to.equal('__cancelled__'));
 	});
 });
+
+describe('RoomEventBus pending prompt snapshots', () => {
+	it('returns pending prompt details for a specific user', async () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		const p = bus.sendPrompt('user-a', 'Choose one', ['0', '1'], 90_000);
+
+		const pending = bus.getPendingPromptForUser('user-a');
+		expect(pending).to.deep.equal({
+			requestId: pending?.requestId,
+			question: 'Choose one',
+			choices: ['0', '1'],
+			timeoutSeconds: 90,
+		});
+		expect(pending?.requestId).to.be.a('string').and.not.empty;
+
+		bus.cancelPrompt(pending!.requestId, 'user-a');
+		await p;
+	});
+
+	it('returns null when the user has no pending prompts', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		expect(bus.getPendingPromptForUser('nobody')).to.equal(null);
+	});
+});

--- a/packages/engine/src/events/room-event-bus.test.ts
+++ b/packages/engine/src/events/room-event-bus.test.ts
@@ -11,7 +11,8 @@ describe('RoomEventBus prompt ownership validation', () => {
 		// Peek at the requestId from pendingPrompts (internal state)
 		const requestId = [...(bus as any).pendingPrompts.keys()][0] as string;
 
-		bus.respondToPrompt(requestId, 'blue', 'user-a');
+		const handled = bus.respondToPrompt(requestId, 'blue', 'user-a');
+		expect(handled).to.equal(true);
 
 		return promptPromise.then((answer) => {
 			expect(answer).to.equal('blue');
@@ -29,7 +30,8 @@ describe('RoomEventBus prompt ownership validation', () => {
 		const requestId = [...(bus as any).pendingPrompts.keys()][0] as string;
 
 		// Wrong caller — should be ignored
-		bus.respondToPrompt(requestId, 'red', 'user-b');
+		const handled = bus.respondToPrompt(requestId, 'red', 'user-b');
+		expect(handled).to.equal(false);
 
 		// Give a tick to let any spurious resolution happen
 		await new Promise(r => setTimeout(r, 20));
@@ -67,11 +69,18 @@ describe('RoomEventBus prompt ownership validation', () => {
 		const promptPromise = bus.sendPrompt('user-a', 'Q?', [], 5000);
 
 		const requestId = [...(bus as any).pendingPrompts.keys()][0] as string;
-		bus.respondToPrompt(requestId, 'yes');
+		const handled = bus.respondToPrompt(requestId, 'yes');
+		expect(handled).to.equal(true);
 
 		return promptPromise.then((answer) => {
 			expect(answer).to.equal('yes');
 		});
+	});
+
+	it('returns false when requestId is stale or unknown', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		const handled = bus.respondToPrompt('missing-request-id', 'yes', 'user-a');
+		expect(handled).to.equal(false);
 	});
 });
 

--- a/packages/engine/src/events/room-event-bus.ts
+++ b/packages/engine/src/events/room-event-bus.ts
@@ -173,13 +173,17 @@ export class RoomEventBus {
 		}
 	}
 
-	respondToPrompt(requestId: string, answer: string, callerId?: string): void {
+	respondToPrompt(requestId: string, answer: string, callerId?: string): boolean {
 		const pending = this.pendingPrompts.get(requestId);
-		if (pending) {
-			if (callerId && pending.userId !== callerId) return;
-			clearTimeout(pending.timer);
-			this.pendingPrompts.delete(requestId);
-			pending.resolve(answer);
-		}
+		if (!pending) return false;
+		if (callerId && pending.userId !== callerId) return false;
+		clearTimeout(pending.timer);
+		this.pendingPrompts.delete(requestId);
+		pending.resolve(answer);
+		return true;
+	}
+
+	hasPendingPrompt(requestId: string): boolean {
+		return this.pendingPrompts.has(requestId);
 	}
 }

--- a/packages/engine/src/events/room-event-bus.ts
+++ b/packages/engine/src/events/room-event-bus.ts
@@ -25,6 +25,9 @@ export class RoomEventBus {
 		reject: (err: Error) => void;
 		timer: ReturnType<typeof setTimeout>;
 		userId: string;
+		question: string;
+		choices: string[];
+		timeoutMs: number;
 	}>();
 
 	constructor(public readonly roomId: string) {}
@@ -97,7 +100,15 @@ export class RoomEventBus {
 				reject(new Error(`Prompt timed out after ${timeoutMs}ms`));
 			}, timeoutMs);
 
-			this.pendingPrompts.set(requestId, { resolve, reject, timer, userId });
+			this.pendingPrompts.set(requestId, {
+				resolve,
+				reject,
+				timer,
+				userId,
+				question,
+				choices,
+				timeoutMs,
+			});
 
 			this.publish({
 				type: 'prompt.request',
@@ -107,6 +118,25 @@ export class RoomEventBus {
 				payload: { requestId, question, choices, timeoutSeconds: Math.round(timeoutMs / 1000) },
 			});
 		});
+	}
+
+	getPendingPromptForUser(userId: string): {
+		requestId: string;
+		question: string;
+		choices: string[];
+		timeoutSeconds: number;
+	} | null {
+		for (const [requestId, pending] of this.pendingPrompts) {
+			if (pending.userId === userId) {
+				return {
+					requestId,
+					question: pending.question,
+					choices: pending.choices,
+					timeoutSeconds: Math.round(pending.timeoutMs / 1000),
+				};
+			}
+		}
+		return null;
 	}
 
 	cancelAllUserPrompts(userId: string): void {

--- a/packages/engine/src/helpers/delay-times.test.ts
+++ b/packages/engine/src/helpers/delay-times.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+
+import { shortDelay, veryShortDelay } from './delay-times.js';
+
+const DELAY_ENV_KEYS = [
+	'DECK_MONSTERS_SKIP_DELAYS',
+	'DECK_MONSTERS_VERY_SHORT_DELAY_MIDPOINT_MS',
+	'DECK_MONSTERS_SHORT_DELAY_MIDPOINT_MS',
+	'DECK_MONSTERS_DELAY_ROUND_FACTOR_STEP',
+	'DECK_MONSTERS_DELAY_ROUND_MIN_FACTOR',
+	'DECK_MONSTERS_DELAY_ROUND_MAX_FACTOR',
+] as const;
+
+describe('delay-times', () => {
+	const originalRandom = Math.random;
+	const originalEnv: Partial<Record<(typeof DELAY_ENV_KEYS)[number], string | undefined>> = {};
+
+	beforeEach(() => {
+		for (const key of DELAY_ENV_KEYS) {
+			originalEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+		Math.random = originalRandom;
+	});
+
+	afterEach(() => {
+		Math.random = originalRandom;
+		for (const key of DELAY_ENV_KEYS) {
+			const value = originalEnv[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	it('keeps default ranges unchanged when no env overrides are set', () => {
+		Math.random = () => 0;
+		expect(veryShortDelay()).to.equal(1000);
+		expect(shortDelay()).to.equal(1500);
+
+		Math.random = () => 0.999999;
+		expect(veryShortDelay()).to.equal(2000);
+		expect(shortDelay()).to.equal(3000);
+	});
+
+	it('uses midpoint env vars to derive min and max ranges', () => {
+		process.env.DECK_MONSTERS_VERY_SHORT_DELAY_MIDPOINT_MS = '3000';
+		process.env.DECK_MONSTERS_SHORT_DELAY_MIDPOINT_MS = '4500';
+
+		Math.random = () => 0;
+		expect(veryShortDelay()).to.equal(2000);
+		expect(shortDelay()).to.equal(3000);
+
+		Math.random = () => 0.999999;
+		expect(veryShortDelay()).to.equal(4000);
+		expect(shortDelay()).to.equal(6000);
+	});
+
+	it('supports round-based pacing shaping with factor caps', () => {
+		process.env.DECK_MONSTERS_DELAY_ROUND_FACTOR_STEP = '0.5';
+		process.env.DECK_MONSTERS_DELAY_ROUND_MIN_FACTOR = '0.5';
+		process.env.DECK_MONSTERS_DELAY_ROUND_MAX_FACTOR = '1.2';
+
+		Math.random = () => 0;
+		// Base veryShort min is 1000ms. Round 3 => factor 1 + 0.5 * 2 = 2.0, capped to 1.2.
+		expect(veryShortDelay(3)).to.equal(1200);
+	});
+
+	it('returns zero delays when delay skipping is enabled', () => {
+		process.env.DECK_MONSTERS_SKIP_DELAYS = '1';
+		Math.random = () => 0.999999;
+		expect(veryShortDelay(9)).to.equal(0);
+		expect(shortDelay(9)).to.equal(0);
+	});
+});

--- a/packages/engine/src/helpers/delay-times.ts
+++ b/packages/engine/src/helpers/delay-times.ts
@@ -1,9 +1,32 @@
-const VERY_SHORT_DELAY = 1000;
-const SHORT_DELAY = 1500;
-const MEDIUM_DELAY = 2000;
-const LONG_DELAY = 3000;
-
 export const ONE_MINUTE = 60000;
+
+type DelayKind = 'very_short' | 'short' | 'medium' | 'long';
+
+// Preserve existing behavior by default:
+// - very_short: 1000–2000ms (midpoint 1500)
+// - short:      1500–3000ms (midpoint 2250)
+// - medium:     2000–4000ms (midpoint 3000)
+// - long:       3000–6000ms (midpoint 4500)
+const DEFAULT_MIDPOINTS: Record<DelayKind, number> = {
+	very_short: 1500,
+	short: 2250,
+	medium: 3000,
+	long: 4500,
+};
+
+const MIDPOINT_ENV: Record<DelayKind, string> = {
+	very_short: 'DECK_MONSTERS_VERY_SHORT_DELAY_MIDPOINT_MS',
+	short: 'DECK_MONSTERS_SHORT_DELAY_MIDPOINT_MS',
+	medium: 'DECK_MONSTERS_MEDIUM_DELAY_MIDPOINT_MS',
+	long: 'DECK_MONSTERS_LONG_DELAY_MIDPOINT_MS',
+};
+
+const CAP_ENV: Record<DelayKind, string> = {
+	very_short: 'DECK_MONSTERS_VERY_SHORT_DELAY_CAP_MS',
+	short: 'DECK_MONSTERS_SHORT_DELAY_CAP_MS',
+	medium: 'DECK_MONSTERS_MEDIUM_DELAY_CAP_MS',
+	long: 'DECK_MONSTERS_LONG_DELAY_CAP_MS',
+};
 
 // When DECK_MONSTERS_SKIP_DELAYS=1 all delay functions return 0.  Set this in
 // test environments so fight tests complete in milliseconds instead of seconds.
@@ -11,19 +34,87 @@ export const ONE_MINUTE = 60000;
 // test-setup file that is evaluated before any spec file runs.
 const skip = (): boolean => !!process.env.DECK_MONSTERS_SKIP_DELAYS;
 
-// 1000–2000 ms — used between player turns in ring combat for natural pacing.
-// Same ±50% variance pattern as the other delays.
-export const veryShortDelay = (): number =>
-	skip() ? 0 : Math.ceil(Math.random() * VERY_SHORT_DELAY) + VERY_SHORT_DELAY;
+const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+	if (!value) return fallback;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+	return parsed;
+};
 
-export const shortDelay = (): number =>
-	skip() ? 0 : Math.ceil(Math.random() * SHORT_DELAY) + SHORT_DELAY;
+const parseFloatWithDefault = (value: string | undefined, fallback: number): number => {
+	if (!value) return fallback;
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) ? parsed : fallback;
+};
 
-export const mediumDelay = (): number =>
-	skip() ? 0 : Math.ceil(Math.random() * MEDIUM_DELAY) + MEDIUM_DELAY;
+const getMidpoint = (kind: DelayKind): number =>
+	parsePositiveInt(process.env[MIDPOINT_ENV[kind]], DEFAULT_MIDPOINTS[kind]);
 
-export const longDelay = (): number =>
-	skip() ? 0 : Math.ceil(Math.random() * LONG_DELAY) + LONG_DELAY;
+const getCap = (kind: DelayKind): number | undefined => {
+	const value = process.env[CAP_ENV[kind]];
+	if (!value) return undefined;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+	return parsed;
+};
+
+const getRangeFromMidpoint = (midpoint: number): { min: number; max: number } => ({
+	min: Math.max(1, Math.round(midpoint * (2 / 3))),
+	max: Math.max(1, Math.round(midpoint * (4 / 3))),
+});
+
+const sampleInRange = (min: number, max: number): number => {
+	const span = max - min + 1;
+	return Math.floor(Math.random() * span) + min;
+};
+
+const applyRoundShaping = (delayMs: number, round: number): number => {
+	// Optional pacing controls (disabled by default):
+	// factor = 1 + step * (round - 1), clamped to [minFactor, maxFactor].
+	// Example: step=-0.08 speeds later rounds; step=+0.08 slows later rounds.
+	const step = parseFloatWithDefault(
+		process.env.DECK_MONSTERS_DELAY_ROUND_FACTOR_STEP,
+		0
+	);
+	if (step === 0 || round <= 1) return delayMs;
+
+	const minFactor = parseFloatWithDefault(
+		process.env.DECK_MONSTERS_DELAY_ROUND_MIN_FACTOR,
+		0.25
+	);
+	const maxFactor = parseFloatWithDefault(
+		process.env.DECK_MONSTERS_DELAY_ROUND_MAX_FACTOR,
+		2
+	);
+	const lower = Math.min(minFactor, maxFactor);
+	const upper = Math.max(minFactor, maxFactor);
+	const rawFactor = 1 + step * (round - 1);
+	const factor = Math.min(upper, Math.max(lower, rawFactor));
+	return Math.max(0, Math.round(delayMs * factor));
+};
+
+const delayFor = (kind: DelayKind, round = 1): number => {
+	if (skip()) return 0;
+	const midpoint = getMidpoint(kind);
+	const { min, max } = getRangeFromMidpoint(midpoint);
+	const sampled = sampleInRange(min, max);
+	const shaped = applyRoundShaping(sampled, round);
+	const cap = getCap(kind);
+	if (!cap) return shaped;
+	return Math.min(shaped, cap);
+};
+
+export const veryShortDelay = (round = 1): number =>
+	delayFor('very_short', round);
+
+export const shortDelay = (round = 1): number =>
+	delayFor('short', round);
+
+export const mediumDelay = (round = 1): number =>
+	delayFor('medium', round);
+
+export const longDelay = (round = 1): number =>
+	delayFor('long', round);
 
 const delayTimes = {
 	veryShortDelay,

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -599,7 +599,8 @@ export class Ring extends BaseClass {
 					.play(player, proposedTarget, ring, getAllActiveContestants())
 					.then(() => {
 						if (getAllActiveContestants().length > 1) {
-							return new Promise<void>(r => setTimeout(r, veryShortDelay())).then(() => next());
+							const waitMs = veryShortDelay();
+							return new Promise<void>(r => setTimeout(r, waitMs)).then(() => next());
 						}
 
 						return Promise.resolve().then(() => resolve(playerContestant));
@@ -644,7 +645,8 @@ export class Ring extends BaseClass {
 						activeContestants = allActiveContestants;
 					}
 
-					setTimeout(() => next(), shortDelay());
+					const waitMs = shortDelay();
+					setTimeout(() => next(), waitMs);
 				}
 			});
 

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -588,7 +588,7 @@ export class Ring extends BaseClass {
 						cardJSON: JSON.stringify(card)?.slice(0, 300),
 					});
 					if (getAllActiveContestants().length > 1) {
-						setTimeout(() => next(), veryShortDelay());
+						setTimeout(() => next(), veryShortDelay(round));
 					} else {
 						resolve(playerContestant);
 					}
@@ -599,7 +599,7 @@ export class Ring extends BaseClass {
 					.play(player, proposedTarget, ring, getAllActiveContestants())
 					.then(() => {
 						if (getAllActiveContestants().length > 1) {
-							const waitMs = veryShortDelay();
+							const waitMs = veryShortDelay(round);
 							return new Promise<void>(r => setTimeout(r, waitMs)).then(() => next());
 						}
 
@@ -615,7 +615,7 @@ export class Ring extends BaseClass {
 						});
 						// Skip the failed card and continue the fight rather than crashing
 						if (getAllActiveContestants().length > 1) {
-							return new Promise<void>(r => setTimeout(r, veryShortDelay())).then(() => next());
+							return new Promise<void>(r => setTimeout(r, veryShortDelay(round))).then(() => next());
 						}
 						return Promise.resolve().then(() => resolve(playerContestant));
 					});
@@ -645,7 +645,7 @@ export class Ring extends BaseClass {
 						activeContestants = allActiveContestants;
 					}
 
-					const waitMs = shortDelay();
+					const waitMs = shortDelay(round);
 					setTimeout(() => next(), waitMs);
 				}
 			});

--- a/packages/server/src/metrics/collector.test.ts
+++ b/packages/server/src/metrics/collector.test.ts
@@ -18,7 +18,7 @@ function readTurnGapSampleCount(roomId: string): Promise<number> {
 	return turnGapMs.get().then((metric) =>
 		metric.values.find(
 			(value) =>
-				value.metricName.endsWith('_count') &&
+				(value.metricName ?? '').endsWith('_count') &&
 				value.labels?.room_id === roomId &&
 				!('le' in (value.labels ?? {}))
 		)?.value ?? 0

--- a/packages/server/src/metrics/collector.test.ts
+++ b/packages/server/src/metrics/collector.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import type { RoomEventBus } from '@deck-monsters/engine';
 import { attachMetricsCollector } from './collector.js';
-import { bossSpawns, registry } from './index.js';
+import { bossSpawns, turnGapMs, registry } from './index.js';
 
 const ROOM_ID = 'room-test';
 
@@ -12,6 +12,17 @@ function readBossSpawnCount(roomId: string): Promise<number> {
 		const sample = metric.values.find((value) => value.labels?.room_id === roomId);
 		return sample?.value ?? 0;
 	});
+}
+
+function readTurnGapSampleCount(roomId: string): Promise<number> {
+	return turnGapMs.get().then((metric) =>
+		metric.values.find(
+			(value) =>
+				value.metricName.endsWith('_count') &&
+				value.labels?.room_id === roomId &&
+				!('le' in (value.labels ?? {}))
+		)?.value ?? 0
+	);
 }
 
 describe('metrics collector ring add listener', () => {
@@ -31,6 +42,39 @@ describe('metrics collector ring add listener', () => {
 		expect(() => ring.emit('add', 'Ring', ring)).to.not.throw();
 
 		expect(await readBossSpawnCount(ROOM_ID)).to.equal(1);
+		cleanup();
+	});
+
+	it('records turn-gap metrics from card.played events and resets on fight boundaries', async () => {
+		let deliverFn: ((event: { type: string; payload?: Record<string, unknown>; timestamp: number }) => void) | null = null;
+		const eventBus = {
+			subscribe: (_id: string, sub: { deliver: (event: { type: string; payload?: Record<string, unknown>; timestamp: number }) => void }) => {
+				deliverFn = sub.deliver;
+				return () => { deliverFn = null; };
+			},
+		} satisfies Pick<RoomEventBus, 'subscribe'>;
+		const ring = new EventEmitter();
+		const cleanup = attachMetricsCollector(eventBus as unknown as RoomEventBus, ring as any, ROOM_ID);
+
+		expect(deliverFn).to.not.equal(null);
+		const emit = (
+			type: string,
+			timestamp: number,
+			payload: Record<string, unknown> = {}
+		) => deliverFn?.({ type, payload, timestamp });
+
+		// Within one encounter, two gaps should be recorded: 1500ms and 2200ms.
+		emit('ring.fight', 1_000, { eventName: 'fightBegins' });
+		emit('card.played', 2_000);
+		emit('card.played', 3_500);
+		emit('card.played', 5_700);
+
+		// New encounter should reset the previous-turn anchor.
+		emit('ring.fight', 8_000, { eventName: 'fightBegins' });
+		emit('card.played', 9_000); // no gap yet (first card after reset)
+		emit('card.played', 10_250); // one gap in second encounter
+
+		expect(await readTurnGapSampleCount(ROOM_ID)).to.equal(3);
 		cleanup();
 	});
 });

--- a/packages/server/src/metrics/collector.ts
+++ b/packages/server/src/metrics/collector.ts
@@ -17,6 +17,7 @@ import {
 	battleMinMonsterLevel,
 	battleMaxMonsterLevel,
 	battleRoundDurationMs,
+	turnGapMs,
 	battlesStarted,
 	battlesCompleted,
 	playerWins,
@@ -53,17 +54,29 @@ export function attachMetricsCollector(
 	// Track the timestamp of the most recent countdown per room so we can
 	// calculate combat duration when ring.fight fires.
 	let countdownAt: number | undefined;
+	// Track spacing between consecutive card.played events inside a fight.
+	let previousCardPlayedAt: number | undefined;
 
 	const unsubscribeEventBus = eventBus.subscribe(`metrics:${roomId}`, {
 		deliver(event: GameEvent) {
 			switch (event.type) {
 				case 'ring.countdown': {
 					countdownAt = event.timestamp;
+					previousCardPlayedAt = undefined;
 					battlesStarted.inc({ room_id: roomId });
 					break;
 				}
 
 				case 'ring.fight': {
+					const eventName = (event.payload as { eventName?: string }).eventName;
+					if (eventName === 'fightBegins') {
+						previousCardPlayedAt = undefined;
+						break;
+					}
+					// For backward compatibility, treat missing eventName as fight completion.
+					if (eventName && eventName !== 'fightConcludes') {
+						break;
+					}
 					battlesCompleted.inc({ room_id: roomId });
 
 					const payload = event.payload as {
@@ -110,6 +123,22 @@ export function attachMetricsCollector(
 					}
 					break;
 				}
+
+				case 'card.played': {
+					if (previousCardPlayedAt !== undefined) {
+						const gap = event.timestamp - previousCardPlayedAt;
+						if (gap >= 0) {
+							turnGapMs.observe({ room_id: roomId }, gap);
+						}
+					}
+					previousCardPlayedAt = event.timestamp;
+					break;
+				}
+
+				case 'ring.fightResolved':
+				case 'ring.clear':
+					previousCardPlayedAt = undefined;
+					break;
 
 				case 'ring.win':
 					playerWins.inc({ room_id: roomId });

--- a/packages/server/src/metrics/index.ts
+++ b/packages/server/src/metrics/index.ts
@@ -70,6 +70,14 @@ export const battleRoundDurationMs = new Histogram({
 	registers: [registry],
 });
 
+export const turnGapMs = new Histogram({
+	name: 'dm_turn_gap_ms',
+	help: 'Elapsed time between consecutive card.played events within an encounter (ms)',
+	labelNames: ['room_id'] as const,
+	buckets: [250, 500, 1_000, 1_500, 2_000, 3_000, 5_000, 8_000],
+	registers: [registry],
+});
+
 // ── Battle event counters ──────────────────────────────────────────────────
 
 export const battlesStarted = new Counter({

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { TRPCError } from '@trpc/server';
+
+import { createRouter } from './router.js';
+
+const ROOM_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const USER_ID = '11111111-2222-3333-4444-555555555555';
+
+describe('trpc/router respondToPrompt', () => {
+	it('forwards a valid prompt response', async () => {
+		const roomManager = {
+			assertMember: async () => undefined,
+			getEventBus: async () => ({
+				respondToPrompt: () => true,
+				getPendingPromptForUser: () => null,
+			}),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+
+		const result = await caller.game.respondToPrompt({
+			roomId: ROOM_ID,
+			requestId: 'req-1',
+			answer: '0',
+		});
+
+		expect(result).to.deep.equal({ ok: true });
+	});
+
+	it('throws PRECONDITION_FAILED when requestId is stale', async () => {
+		const roomManager = {
+			assertMember: async () => undefined,
+			getEventBus: async () => ({
+				respondToPrompt: () => false,
+				getPendingPromptForUser: () => ({ requestId: 'req-2', question: 'Q', choices: ['0'], timeoutSeconds: 120 }),
+			}),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+
+		const err = await caller.game.respondToPrompt({
+			roomId: ROOM_ID,
+			requestId: 'req-1',
+			answer: '0',
+		}).catch((e: unknown) => e);
+
+		expect(err).to.be.instanceOf(TRPCError);
+		expect((err as TRPCError).code).to.equal('PRECONDITION_FAILED');
+	});
+});

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -369,7 +369,18 @@ export function createRouter(roomManager: RoomManager) {
 					requestId: input.requestId,
 				});
 				const eventBus = await roomManager.getEventBus(input.roomId);
-				eventBus.respondToPrompt(input.requestId, input.answer, ctx.userId);
+				const handled = eventBus.respondToPrompt(input.requestId, input.answer, ctx.userId);
+				if (!handled) {
+					const pendingPrompt = eventBus.getPendingPromptForUser(ctx.userId);
+					throw new TRPCError({
+						code: 'PRECONDITION_FAILED',
+						message: 'Prompt is no longer active. Please answer the latest prompt.',
+						cause: {
+							requestId: input.requestId,
+							pendingPromptRequestId: pendingPrompt?.requestId ?? null,
+						},
+					});
+				}
 				return { ok: true };
 			}),
 

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -231,29 +231,32 @@ export function createRouter(roomManager: RoomManager) {
 				const isAdmin = role === 'owner';
 				const game = await roomManager.getGame(input.roomId);
 				const eventBus = await roomManager.getEventBus(input.roomId);
-				const action = game.handleCommand({ command: input.command });
-
-				if (!action) {
-					log.debug('command not recognized', { roomId: input.roomId, command: input.command });
-					commandsTotal.inc({ room_id: input.roomId, result: 'rejected' });
-					return { ok: false, message: 'Command not recognized' };
-				}
 
 				// Prevent concurrent interactive flows for the same user+room.
 				// The engine is not designed for concurrent access — interleaved prompt
 				// flows corrupt game state and produce nonsensical UX.
 				const flowKey = `${input.roomId}:${ctx.userId}`;
 				if (activeFlows.has(flowKey)) {
+					const pendingPrompt = eventBus.getPendingPromptForUser(ctx.userId);
 					log.debug('command blocked — flow already in progress', {
 						roomId: input.roomId,
 						userId: ctx.userId,
 						command: input.command,
+						pendingPromptRequestId: pendingPrompt?.requestId,
 					});
 					commandsTotal.inc({ room_id: input.roomId, result: 'rejected' });
 					return {
 						ok: false,
 						message: 'A command is already in progress — answer the current prompt first.',
+						pendingPrompt,
 					};
+				}
+				const action = game.handleCommand({ command: input.command });
+
+				if (!action) {
+					log.debug('command not recognized', { roomId: input.roomId, command: input.command });
+					commandsTotal.inc({ room_id: input.roomId, result: 'rejected' });
+					return { ok: false, message: 'Command not recognized' };
 				}
 				activeFlows.add(flowKey);
 				log.debug('command dispatched', { roomId: input.roomId, userId: ctx.userId, isAdmin });
@@ -437,6 +440,14 @@ export function createRouter(roomManager: RoomManager) {
 			.input(z.object({ roomId: z.string().uuid() }))
 			.query(async ({ input, ctx }) => {
 				return roomManager.getConsoleHistory(ctx.userId, input.roomId);
+			}),
+
+		pendingPrompt: protectedProcedure
+			.input(z.object({ roomId: z.string().uuid() }))
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const eventBus = await roomManager.getEventBus(input.roomId);
+				return eventBus.getPendingPromptForUser(ctx.userId);
 			}),
 
 		ringFeed: protectedProcedure


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix prompt-flow stickiness by restoring pending prompts server-side and client-side so active prompt answers are routed correctly
- harden prompt responses against stale request IDs: event bus now returns handled/not-handled, router returns `PRECONDITION_FAILED` for stale prompt answers, and the web console refetches and rehydrates the latest pending prompt snapshot when this happens
- reduce perceived "fight flew by" behavior caused by reconnect replay bursts by resuming ring/console subscriptions from the latest tracked event ID after transport errors instead of replaying recent buffered events from scratch
- add configurable delay pacing controls using midpoint env vars per delay type (`*_MIDPOINT_MS`) with derived min/max ranges while preserving existing defaults
- add optional round-based pacing shaping and optional per-delay caps (`*_CAP_MS`) without changing default behavior
- thread current round into ring turn delays so optional round shaping applies to live combat pacing
- add per-room turn-gap telemetry (`dm_turn_gap_ms`) from `card.played` events and reset boundaries across encounters

## Root cause notes
- production logs show rapid `respondToPrompt` bursts and intermittent feed reconnect/open/close cycles
- core ring pacing delays are active in engine; the "fast" feel aligned with replay bursts during reconnect plus relatively short baseline delay values
- equip intermittency aligned with stale prompt responses being silently no-oped before hard-fail + rehydration handling

## Validation
- `pnpm build`
- `pnpm --filter @deck-monsters/engine test -- --grep "delay-times|ring/index\.ts"`
- `pnpm --filter @deck-monsters/server test -- src/metrics/collector.test.ts`

## Files touched
- `packages/engine/src/events/room-event-bus.ts`
- `packages/engine/src/events/room-event-bus.test.ts`
- `packages/server/src/trpc/router.ts`
- `packages/server/src/trpc/router.test.ts`
- `apps/web/src/components/ConsolePane.tsx`
- `apps/web/src/components/RingPane.tsx`
- `packages/engine/src/helpers/delay-times.ts`
- `packages/engine/src/helpers/delay-times.test.ts`
- `packages/engine/src/ring/index.ts`
- `packages/server/src/metrics/index.ts`
- `packages/server/src/metrics/collector.ts`
- `packages/server/src/metrics/collector.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c540bd99-1073-41d4-b8bf-0e78d95d5554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c540bd99-1073-41d4-b8bf-0e78d95d5554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

