### PR TITLE
Fix room-scoped ring bleed and console UX polish

### DIFF
--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -91,6 +91,10 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const [reconnecting, setReconnecting] = useState(false);
   const [quickActions, setQuickActions] = useState<QuickAction[]>([]);
   const [suggestionIndex, setSuggestionIndex] = useState(-1);
+  const [ftuxComplete, setFtuxComplete] = useState(
+    () => typeof localStorage !== 'undefined' && localStorage.getItem('ftuxComplete') === 'true'
+  );
+  const [hasFoughtFirstFight, setHasFoughtFirstFight] = useState(false);
 
   // Resume cursor for reconnects. Updated only on errors so we don't restart
   // the subscription on every event.
@@ -200,10 +204,24 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
       sendableMonsterNames,
     }
   );
-  const showFtux = useMemo(
-    () => (history?.length ?? 0) === 0 && consoleEvents.length === 0 && monsterRows.length === 0,
-    [history, consoleEvents.length, monsterRows.length]
-  );
+  const hasMonsters = monsterRows.length > 0;
+  const hasMonsterInRing = monsterRows.some((m) => m.inRing);
+  const hasDeadMonster = monsterRows.some((m) => m.dead);
+
+  type FtuxPhase = 'spawn' | 'equip_send' | 'waiting' | 'post_fight' | 'hidden';
+  const ftuxPhase = useMemo((): FtuxPhase => {
+    if (ftuxComplete) return 'hidden';
+    if (!hasMonsters) return 'spawn';
+    if (hasFoughtFirstFight && !hasDeadMonster) return 'hidden';
+    if (hasFoughtFirstFight && hasDeadMonster) return 'post_fight';
+    if (hasMonsterInRing) return 'waiting';
+    return 'equip_send';
+  }, [ftuxComplete, hasMonsters, hasMonsterInRing, hasFoughtFirstFight, hasDeadMonster]);
+
+  // Monster names used by FTUX chips — pick first available in each category.
+  const ftuxSendableName = sendableMonsterNames[0] ?? monsterNames.find((n) => !deadMonsterNames.includes(n)) ?? '';
+  const ftuxInRingName = monsterRows.find((m) => m.inRing)?.name ?? '';
+  const ftuxDeadName = deadMonsterNames[0] ?? '';
 
   const sendCommand = trpc.game.command.useMutation();
   const respondToPrompt = trpc.game.respondToPrompt.useMutation();
@@ -293,6 +311,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         onEvent?.(event);
         if (MONSTER_REFRESH_EVENT_TYPES.has(event.type)) {
           void refetchMyMonsters();
+          setHasFoughtFirstFight(true);
         }
 
         const payload = event.payload as Record<string, unknown>;
@@ -564,6 +583,11 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     void handleSubmitCommand(command);
   }
 
+  function dismissFtux() {
+    setFtuxComplete(true);
+    localStorage.setItem('ftuxComplete', 'true');
+  }
+
   const placeholder = activePromptId
     ? 'Type your answer or click a choice above…'
     : inputLocked
@@ -676,33 +700,70 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         </nav>
       )}
 
-      {showFtux && (
+      {ftuxPhase !== 'hidden' && (
         <section
           className="quick-actions"
           aria-label="Getting started guide"
-          style={{ marginBottom: '0.75rem' }}
+          style={{ marginBottom: '0.75rem', position: 'relative' }}
         >
-          <p
+          <button
+            onClick={dismissFtux}
+            aria-label="Dismiss guide"
+            title="Dismiss guide"
             style={{
-              margin: '0 0 0.5rem 0',
-              fontSize: '0.85rem',
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              background: 'transparent',
+              border: 'none',
               color: 'var(--color-fg-dim)',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+              padding: '0 0.25rem',
+              lineHeight: 1,
             }}
           >
-            New here? Start by spawning a monster, then send it to the ring.
+            ✕
+          </button>
+          <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.85rem', color: 'var(--color-fg-dim)' }}>
+            {ftuxPhase === 'spawn' && 'Welcome, Beastmaster. Spawn your first monster to begin your journey.'}
+            {ftuxPhase === 'equip_send' && `Outfit ${ftuxSendableName} with cards, then send them into battle.`}
+            {ftuxPhase === 'waiting' && `${ftuxInRingName} is in the ring. Fights begin once there are 2 or more monsters.`}
+            {ftuxPhase === 'post_fight' && `${ftuxDeadName} has fallen. Revive them to fight again.`}
           </p>
-          <button className="quick-action-chip" onClick={() => setInputValue('spawn monster')}>
-            spawn monster
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('look at monsters')}>
-            look at monsters
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('send [monster] to the ring')}>
-            send [monster] to the ring
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('look at handbook')}>
-            look at handbook
-          </button>
+          {ftuxPhase === 'spawn' && (
+            <>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('spawn a monster')}>
+                spawn a monster
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('look at player handbook')}>
+                look at player handbook
+              </button>
+            </>
+          )}
+          {ftuxPhase === 'equip_send' && (
+            <>
+              <button className="quick-action-chip" onClick={() => handleQuickAction(`equip ${ftuxSendableName}`)}>
+                equip {ftuxSendableName}
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction(`send ${ftuxSendableName} to the ring`)}>
+                send {ftuxSendableName} to the ring
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
+                look at ring
+              </button>
+            </>
+          )}
+          {ftuxPhase === 'waiting' && (
+            <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
+              look at ring
+            </button>
+          )}
+          {ftuxPhase === 'post_fight' && (
+            <button className="quick-action-chip" onClick={() => handleQuickAction(`revive ${ftuxDeadName}`)}>
+              revive {ftuxDeadName}
+            </button>
+          )}
         </section>
       )}
 

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -51,6 +51,13 @@ interface MonsterAutocompleteRow {
 }
 
 const EMPTY_MONSTERS: MonsterAutocompleteRow[] = [];
+const MONSTER_REFRESH_EVENT_TYPES = new Set([
+  'ring.win',
+  'ring.loss',
+  'ring.draw',
+  'ring.fled',
+  'ring.permaDeath',
+]);
 
 interface ConsolePaneProps {
   roomId: string;
@@ -167,7 +174,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     setIsAtBottom(true);
   }, []);
 
-  const { data: myMonsters } = trpc.game.myMonsters.useQuery(
+  const { data: myMonsters, refetch: refetchMyMonsters } = trpc.game.myMonsters.useQuery(
     { roomId },
     { enabled: !!roomId },
   );
@@ -192,6 +199,10 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
       deadMonsterNames,
       sendableMonsterNames,
     }
+  );
+  const showFtux = useMemo(
+    () => (history?.length ?? 0) === 0 && consoleEvents.length === 0 && monsterRows.length === 0,
+    [history, consoleEvents.length, monsterRows.length]
   );
 
   const sendCommand = trpc.game.command.useMutation();
@@ -280,6 +291,9 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         if (!isPrivate && !isPublicSystem) return;
 
         onEvent?.(event);
+        if (MONSTER_REFRESH_EVENT_TYPES.has(event.type)) {
+          void refetchMyMonsters();
+        }
 
         const payload = event.payload as Record<string, unknown>;
         if (event.type === 'system' && payload.consoleInput) {
@@ -427,13 +441,6 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     setInputValue('');
     setInputLocked(true);
 
-    // Echo the command back into the feed
-    addConsoleEvent({
-      id: `input-${Date.now()}`,
-      type: 'input',
-      text: command,
-    });
-
     try {
       const result = await sendCommand.mutateAsync({
         roomId,
@@ -462,6 +469,8 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
             text: '-- type "cancel" or click Cancel on the active prompt to abort it --',
           });
         }
+      } else {
+        void refetchMyMonsters();
       }
     } catch (err) {
       addConsoleEvent({
@@ -499,6 +508,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         upsertPendingPrompt(latest.data);
       }
     } finally {
+      void refetchMyMonsters();
       inputRef.current?.focus();
     }
   }
@@ -664,6 +674,36 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
             </button>
           ))}
         </nav>
+      )}
+
+      {showFtux && (
+        <section
+          className="quick-actions"
+          aria-label="Getting started guide"
+          style={{ marginBottom: '0.75rem' }}
+        >
+          <p
+            style={{
+              margin: '0 0 0.5rem 0',
+              fontSize: '0.85rem',
+              color: 'var(--color-fg-dim)',
+            }}
+          >
+            New here? Start by spawning a monster, then send it to the ring.
+          </p>
+          <button className="quick-action-chip" onClick={() => setInputValue('spawn monster')}>
+            spawn monster
+          </button>
+          <button className="quick-action-chip" onClick={() => setInputValue('look at monsters')}>
+            look at monsters
+          </button>
+          <button className="quick-action-chip" onClick={() => setInputValue('send [monster] to the ring')}>
+            send [monster] to the ring
+          </button>
+          <button className="quick-action-chip" onClick={() => setInputValue('look at handbook')}>
+            look at handbook
+          </button>
+        </section>
       )}
 
       <form

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -91,6 +91,10 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const [reconnecting, setReconnecting] = useState(false);
   const [quickActions, setQuickActions] = useState<QuickAction[]>([]);
   const [suggestionIndex, setSuggestionIndex] = useState(-1);
+  const [ftuxComplete, setFtuxComplete] = useState(
+    () => typeof localStorage !== 'undefined' && localStorage.getItem('ftuxComplete') === 'true'
+  );
+  const [hasFoughtFirstFight, setHasFoughtFirstFight] = useState(false);
 
   // Resume cursor for reconnects. Updated only on errors so we don't restart
   // the subscription on every event.
@@ -200,10 +204,24 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
       sendableMonsterNames,
     }
   );
-  const showFtux = useMemo(
-    () => (history?.length ?? 0) === 0 && consoleEvents.length === 0 && monsterRows.length === 0,
-    [history, consoleEvents.length, monsterRows.length]
-  );
+  const hasMonsters = monsterRows.length > 0;
+  const hasMonsterInRing = monsterRows.some(m => m.inRing);
+  const hasDeadMonster = monsterRows.some(m => m.dead);
+
+  type FtuxPhase = 'spawn' | 'equip_send' | 'waiting' | 'post_fight' | 'hidden';
+  const ftuxPhase = useMemo((): FtuxPhase => {
+    if (ftuxComplete) return 'hidden';
+    if (!hasMonsters) return 'spawn';
+    if (hasFoughtFirstFight && !hasDeadMonster) return 'hidden';
+    if (hasFoughtFirstFight && hasDeadMonster) return 'post_fight';
+    if (hasMonsterInRing) return 'waiting';
+    return 'equip_send';
+  }, [ftuxComplete, hasMonsters, hasMonsterInRing, hasFoughtFirstFight, hasDeadMonster]);
+
+  // Monster names used by FTUX chips — pick first available in each category
+  const ftuxSendableName = sendableMonsterNames[0] ?? monsterNames.find(n => !deadMonsterNames.includes(n)) ?? '';
+  const ftuxInRingName = monsterRows.find(m => m.inRing)?.name ?? '';
+  const ftuxDeadName = deadMonsterNames[0] ?? '';
 
   const sendCommand = trpc.game.command.useMutation();
   const respondToPrompt = trpc.game.respondToPrompt.useMutation();
@@ -293,6 +311,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         onEvent?.(event);
         if (MONSTER_REFRESH_EVENT_TYPES.has(event.type)) {
           void refetchMyMonsters();
+          setHasFoughtFirstFight(true);
         }
 
         const payload = event.payload as Record<string, unknown>;
@@ -564,6 +583,11 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     void handleSubmitCommand(command);
   }
 
+  function dismissFtux() {
+    setFtuxComplete(true);
+    localStorage.setItem('ftuxComplete', 'true');
+  }
+
   const placeholder = activePromptId
     ? 'Type your answer or click a choice above…'
     : inputLocked
@@ -676,33 +700,70 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         </nav>
       )}
 
-      {showFtux && (
+      {ftuxPhase !== 'hidden' && (
         <section
           className="quick-actions"
           aria-label="Getting started guide"
-          style={{ marginBottom: '0.75rem' }}
+          style={{ marginBottom: '0.75rem', position: 'relative' }}
         >
-          <p
+          <button
+            onClick={dismissFtux}
+            aria-label="Dismiss guide"
+            title="Dismiss guide"
             style={{
-              margin: '0 0 0.5rem 0',
-              fontSize: '0.85rem',
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              background: 'transparent',
+              border: 'none',
               color: 'var(--color-fg-dim)',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+              padding: '0 0.25rem',
+              lineHeight: 1,
             }}
           >
-            New here? Start by spawning a monster, then send it to the ring.
+            ✕
+          </button>
+          <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.85rem', color: 'var(--color-fg-dim)' }}>
+            {ftuxPhase === 'spawn' && 'Welcome, Beastmaster. Spawn your first monster to begin your journey.'}
+            {ftuxPhase === 'equip_send' && `Outfit ${ftuxSendableName} with cards, then send them into battle.`}
+            {ftuxPhase === 'waiting' && `${ftuxInRingName} is in the ring. Fights begin once there are 2 or more monsters.`}
+            {ftuxPhase === 'post_fight' && `${ftuxDeadName} has fallen. Revive them to fight again.`}
           </p>
-          <button className="quick-action-chip" onClick={() => setInputValue('spawn monster')}>
-            spawn monster
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('look at monsters')}>
-            look at monsters
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('send [monster] to the ring')}>
-            send [monster] to the ring
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('look at handbook')}>
-            look at handbook
-          </button>
+          {ftuxPhase === 'spawn' && (
+            <>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('spawn monster')}>
+                spawn monster
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('look at handbook')}>
+                look at handbook
+              </button>
+            </>
+          )}
+          {ftuxPhase === 'equip_send' && (
+            <>
+              <button className="quick-action-chip" onClick={() => handleQuickAction(`equip ${ftuxSendableName}`)}>
+                equip {ftuxSendableName}
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction(`send ${ftuxSendableName} to the ring`)}>
+                send {ftuxSendableName} to the ring
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
+                look at ring
+              </button>
+            </>
+          )}
+          {ftuxPhase === 'waiting' && (
+            <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
+              look at ring
+            </button>
+          )}
+          {ftuxPhase === 'post_fight' && (
+            <button className="quick-action-chip" onClick={() => handleQuickAction(`revive ${ftuxDeadName}`)}>
+              revive {ftuxDeadName}
+            </button>
+          )}
         </section>
       )}
 

--- a/docs/follow-up-remote-supabase-manual-test.md
+++ b/docs/follow-up-remote-supabase-manual-test.md
@@ -1,0 +1,58 @@
+# Follow-up: remote Supabase manual test checklist
+
+Use this checklist in a future Cursor Cloud session once secrets are available.
+
+## Required environment variables
+
+Ensure these are set in the session:
+
+- `TEST_USERNAME`
+- `TEST_PASSWORD`
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_PUBLISHABLE_KEY`
+- `SUPABASE_URL`
+- `SUPABASE_SECRET_KEY`
+- `DATABASE_URL`
+- `VITE_SERVER_URL` (optional; empty is fine in dev)
+
+Quick check:
+
+- `for v in TEST_USERNAME TEST_PASSWORD VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_KEY SUPABASE_URL SUPABASE_SECRET_KEY DATABASE_URL; do [ -n "${!v:-}" ] && echo "$v=SET" || echo "$v=MISSING"; done`
+
+## Start services
+
+1. Start API server:
+   - `pnpm --filter @deck-monsters/server dev`
+2. Start web app:
+   - `pnpm --filter @deck-monsters/web dev -- --host 0.0.0.0 --port 5173`
+
+## Manual verification goals
+
+Validate the fixes on branch `cursor/room-console-boss-polish-5554`:
+
+1. **No cross-room boss/ring bleed**
+   - Open two different rooms in separate browser tabs.
+   - Trigger/observe ring events in room A.
+   - Confirm room B does not show mirrored boss/ring announcements.
+
+2. **No duplicate console command echoes**
+   - In Console, run `send <monster> to the ring`.
+   - Confirm only one user command echo appears for that submit.
+
+3. **Autocomplete refreshes without hard reload**
+   - After a fight, verify `revive <monster>` suggestions include newly dead monsters.
+   - After ring changes, verify `send <monster> to the ring` suggestions update.
+
+4. **FTUX guidance appears for new users**
+   - Sign in with a fresh user (or clear to fresh room/user state).
+   - Confirm Console shows starter guidance chips before first actions.
+
+5. **Boss pacing/scaling feels improved for beginner rooms**
+   - In a room with only beginner monsters, observe boss spawn timing and relative strength.
+   - Confirm bosses appear more frequently than before and are not over-leveled.
+
+## Evidence to capture
+
+- One short video covering at least items 1-3 above.
+- At least one screenshot showing FTUX guidance.
+- Optional server logs for boss spawn cadence samples.

--- a/docs/local-testing-guidelines.md
+++ b/docs/local-testing-guidelines.md
@@ -1,0 +1,58 @@
+# Local testing guidelines (env-driven sessions)
+
+This guide captures repeatable local-testing principles for sessions where required env vars are already set externally.
+
+## Core principles
+
+- Keep secrets out of docs, logs, commits, and screenshots. Only document variable names.
+- Verify env var presence early, then fail fast if required values are missing.
+- Run `pnpm build` before tests/manual flows on fresh checkouts so downstream packages see fresh `@deck-monsters/engine` `dist/` output.
+- Start API and web servers in separate long-lived terminal/tmux sessions so logs remain available while testing.
+- Prefer minimal, high-signal checks first (`/health`, auth flow, room list) before long manual scenarios.
+- Record evidence during successful runs only (video/screenshot/log snippets from passing behavior).
+
+## Environment setup checklist (no secret values)
+
+- Required vars should be injected by the shell/session manager, not hardcoded in files.
+- Quick presence check:
+  - `for v in TEST_USERNAME TEST_PASSWORD VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_KEY SUPABASE_URL SUPABASE_SECRET_KEY DATABASE_URL; do [ -n "${!v:-}" ] && echo "$v=SET" || echo "$v=MISSING"; done`
+- Keep URL-style vars normalized when needed by issuer checks (`no trailing slash`), for example:
+  - `SUPABASE_URL="${SUPABASE_URL%/}"`
+
+## Service startup pattern
+
+1. Build once:
+   - `pnpm build`
+2. Start API server:
+   - `pnpm --filter @deck-monsters/server dev`
+3. Start web server:
+   - `pnpm --filter @deck-monsters/web dev -- --host 0.0.0.0 --port 5173`
+4. Confirm API readiness:
+   - `curl -sS http://localhost:3000/health`
+
+## Manual testing heuristics
+
+- Validate auth + room load before gameplay checks.
+- For command parsing checks, use exact supported command strings (for example, `spawn a monster`).
+- For cross-room checks, keep two room tabs open simultaneously and switch frequently while watching both console histories.
+- For autocomplete checks:
+  - Trigger with at least two characters.
+  - Verify context-aware substitutions (e.g., concrete monster names in `send [monster] to the ring` suggestions).
+  - Re-check after state-changing actions (send/revive/fight outcomes) without reloading.
+- For boss pacing/scaling checks:
+  - Use beginner-level monsters in a fresh or low-progress room.
+  - Observe multiple encounter cycles before concluding.
+  - Capture timing/strength notes from ring feed, not memory.
+
+## Reusable rooms from this session
+
+These rooms were created during local manual testing and can be reused in future sessions.
+
+- `Test Room A`
+  - `roomId`: `70cb10d2-4faa-4300-9c20-8befe121a3d1`
+  - `inviteCode`: `717305BE`
+- `Test Room B`
+  - `roomId`: `227ba78e-bca5-4bd4-a59c-9793fac508bd`
+  - `inviteCode`: `328F58D2`
+
+If either room becomes noisy or drifts too far from beginner state, create a fresh room for pacing/scaling verification and add its metadata here.

--- a/packages/engine/src/announcements/index.ts
+++ b/packages/engine/src/announcements/index.ts
@@ -55,7 +55,7 @@ export function initialize(game: any): () => void {
 	const wrap = (fn: (eb: RoomEventBus, ...args: any[]) => void) =>
 		(...args: any[]) => fn(eb, ...args);
 
-	const events: Array<{ event: string; listener: (...args: any[]) => void }> = [
+	const gameEvents: Array<{ event: string; listener: (...args: any[]) => void }> = [
 		{ event: 'card.effect', listener: wrap(announceEffect) },
 		{ event: 'card.miss', listener: wrap(announceMiss) },
 		{ event: 'card.narration', listener: wrap(announceNarration) },
@@ -73,32 +73,42 @@ export function initialize(game: any): () => void {
 		{ event: 'item.used', listener: wrap(announceItemUsed) },
 		{ event: 'potion.narration', listener: wrap(announceNarration) },
 		{ event: 'potion.used', listener: wrap(announceItemUsed) },
-		{ event: 'ring.add', listener: wrap(announceContestant) },
-		{ event: 'ring.bossWillSpawn', listener: wrap(announceBossWillSpawn) },
-		{ event: 'ring.endOfDeck', listener: wrap(announceEndOfDeck) },
-		{ event: 'ring.fight', listener: wrap(announceFight) },
-		{ event: 'ring.fightConcludes', listener: wrap(announceFightConcludes) },
-		{ event: 'ring.gainedXP', listener: wrap(announceXPGain) },
 		{
 			event: 'creature.levelUp',
 			listener: (_className: string, _instance: any, { monster, level }: { monster: any; level: number }) =>
 				announceLevelUp(eb, monster, level),
 		},
-		{ event: 'ring.narration', listener: wrap(announceNarration) },
-		{ event: 'ring.remove', listener: wrap(announceContestantLeave) },
-		{ event: 'ring.roundComplete', listener: wrap(announceNextRound) },
-		{ event: 'ring.startTurn', listener: wrap(announceNextTurn) },
-		{ event: 'ring.playerTurnBegin', listener: wrap(announceTurnBegin) },
 		{ event: 'scroll.narration', listener: wrap(announceNarration) },
 		{ event: 'scroll.used', listener: wrap(announceItemUsed) },
+	];
+
+	// Ring events must be bound to this room's ring instance (not game/global),
+	// otherwise the global emitter path can mirror ring announcements across rooms.
+	const ringEvents: Array<{ event: string; listener: (...args: any[]) => void }> = [
+		{ event: 'add', listener: wrap(announceContestant) },
+		{ event: 'bossWillSpawn', listener: wrap(announceBossWillSpawn) },
+		{ event: 'endOfDeck', listener: wrap(announceEndOfDeck) },
+		{ event: 'fight', listener: wrap(announceFight) },
+		{ event: 'fightConcludes', listener: wrap(announceFightConcludes) },
+		{ event: 'gainedXP', listener: wrap(announceXPGain) },
+		{ event: 'narration', listener: wrap(announceNarration) },
+		{ event: 'remove', listener: wrap(announceContestantLeave) },
+		{ event: 'roundComplete', listener: wrap(announceNextRound) },
+		{ event: 'startTurn', listener: wrap(announceNextTurn) },
+		{ event: 'playerTurnBegin', listener: wrap(announceTurnBegin) },
 	];
 
 	// Collect bound listeners so they can be removed on dispose
 	const registered: Array<{ event: string; bound: (...args: any[]) => void }> = [];
 
-	events.forEach(({ event, listener }) => {
+	gameEvents.forEach(({ event, listener }) => {
 		const bound = game.on(event, listener);
 		registered.push({ event, bound });
+	});
+
+	ringEvents.forEach(({ event, listener }) => {
+		const bound = game.ring.on(event, listener);
+		registered.push({ event: `ring.${event}`, bound });
 	});
 
 	// heal is special: ring is passed as an extra argument before the standard args
@@ -109,6 +119,12 @@ export function initialize(game: any): () => void {
 	registered.push({ event: 'creature.heal', bound: boundHeal });
 
 	return () => {
-		registered.forEach(({ event, bound }) => game.off(event, bound));
+		registered.forEach(({ event, bound }) => {
+			if (event.startsWith('ring.')) {
+				game.ring.off(event.replace(/^ring\./, ''), bound);
+				return;
+			}
+			game.off(event, bound);
+		});
 	};
 }

--- a/packages/engine/src/game.test.ts
+++ b/packages/engine/src/game.test.ts
@@ -33,6 +33,29 @@ describe('game.ts', () => {
 		expect(game.getRing()).to.equal(game.ring);
 	});
 
+	it('keeps ring announcements scoped to the room that emitted them', () => {
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+		const roomAEvents: Array<{ type: string }> = [];
+		const roomBEvents: Array<{ type: string }> = [];
+
+		roomA.eventBus.subscribe('room-a-spy', {
+			deliver: (event) => roomAEvents.push({ type: event.type }),
+		});
+		roomB.eventBus.subscribe('room-b-spy', {
+			deliver: (event) => roomBEvents.push({ type: event.type }),
+		});
+
+		try {
+			roomA.ring.emit('bossWillSpawn', { delay: 120_000 });
+			expect(roomAEvents.some((event) => event.type === 'announce')).to.equal(true);
+			expect(roomBEvents.some((event) => event.type === 'announce')).to.equal(false);
+		} finally {
+			roomA.dispose();
+			roomB.dispose();
+		}
+	});
+
 	it('can look at the ring', () => {
 		const game = new Game();
 		const lookStub = sinon.stub(game.ring, 'look');

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -132,6 +132,26 @@ describe('ring/index.ts', () => {
 			expect(ring.contestants.length).to.equal(1);
 			expect(contestant).to.be.undefined;
 		});
+
+		it('spawns lower-level bosses when only beginner monsters are present', () => {
+			const game = new Game();
+			const ring = game.getRing();
+			const beginnerA = randomContestant({
+				isBoss: false,
+				battles: { total: 0, wins: 0, losses: 0 },
+			});
+			const beginnerB = randomContestant({
+				isBoss: false,
+				battles: { total: 0, wins: 0, losses: 0 },
+			});
+
+			ring.addMonster(beginnerA);
+			ring.addMonster(beginnerB);
+
+			const boss = ring.spawnBoss();
+			expect(boss).to.not.be.undefined;
+			expect(boss!.monster.level).to.be.at.most(2);
+		});
 	});
 
 	describe('fightConcludes', () => {

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -13,6 +13,13 @@ const MAX_BOSSES = 5;
 const MAX_MONSTERS = 12;
 const MIN_MONSTERS = 2;
 const FIGHT_DELAY = 60000;
+const BOSS_WARNING_DELAY_MS = 120000;
+const BOSS_DESPAWN_DELAY_MS = 600000;
+const BOSS_SPAWN_MIN_DELAY_MS = 1_200_000; // 20 min
+const BOSS_SPAWN_MAX_DELAY_MS = 2_100_000; // 35 min
+const BOSS_SPAWN_BEGINNER_MIN_DELAY_MS = 720_000; // 12 min
+const BOSS_SPAWN_BEGINNER_MAX_DELAY_MS = 1_320_000; // 22 min
+const BEGINNER_LEVEL_THRESHOLD = 2;
 
 export interface Contestant {
 	monster: any;
@@ -892,12 +899,50 @@ export class Ring extends BaseClass {
 		contestant.monster.emit('fled', { contestant });
 	}
 
+	private getPlayerMonsterLevels(): number[] {
+		return this.contestants
+			.filter(contestant => !contestant.isBoss)
+			.map(contestant => Number(contestant.monster?.level ?? 0))
+			.filter(level => Number.isFinite(level) && level >= 0);
+	}
+
+	private hasOnlyBeginnerPlayers(): boolean {
+		const levels = this.getPlayerMonsterLevels();
+		return levels.length > 0 && levels.every(level => level <= BEGINNER_LEVEL_THRESHOLD);
+	}
+
+	private getBossSpawnOuterDelayMs(): number {
+		if (this.hasOnlyBeginnerPlayers()) {
+			return random(BOSS_SPAWN_BEGINNER_MIN_DELAY_MS, BOSS_SPAWN_BEGINNER_MAX_DELAY_MS);
+		}
+		return random(BOSS_SPAWN_MIN_DELAY_MS, BOSS_SPAWN_MAX_DELAY_MS);
+	}
+
+	private getSpawnedBossContestant(): Contestant {
+		const playerContestants = this.contestants.filter(contestant => !contestant.isBoss);
+		if (!this.hasOnlyBeginnerPlayers() || playerContestants.length === 0) {
+			return randomContestant();
+		}
+
+		const averagePlayerXp = Math.round(
+			playerContestants.reduce(
+				(sum, contestant) => sum + Number(contestant.monster?.xp ?? 0),
+				0
+			) / playerContestants.length
+		);
+		const minBossXp = Math.max(0, averagePlayerXp - 20);
+		const maxBossXp = Math.max(minBossXp, averagePlayerXp + 40);
+		const scaledBossXp = random(minBossXp, maxBossXp);
+
+		return randomContestant({ xp: scaledBossXp });
+	}
+
 	startBossTimer(): void {
 		const ring = this;
 
 		if (this.spawnBosses) {
-			const outerDelay = random(2100000, 3480000); // 35–58 min
-			this.nextBossSpawnAt = Date.now() + outerDelay + 120000; // includes 2-min warn window
+			const outerDelay = this.getBossSpawnOuterDelayMs();
+			this.nextBossSpawnAt = Date.now() + outerDelay + BOSS_WARNING_DELAY_MS;
 			this.publishState();
 
 			this.bossTimer = setTimeout(() => {
@@ -907,7 +952,7 @@ export class Ring extends BaseClass {
 					0
 				);
 				if (!ring.inEncounter && numberOfBossesInRing < MAX_BOSSES) {
-					ring.emit('bossWillSpawn', { delay: 120000 });
+					ring.emit('bossWillSpawn', { delay: BOSS_WARNING_DELAY_MS });
 				}
 
 				this.bossTimer = setTimeout(() => {
@@ -918,7 +963,7 @@ export class Ring extends BaseClass {
 						ring.spawnBoss();
 					}
 					ring.startBossTimer();
-				}, 120000);
+				}, BOSS_WARNING_DELAY_MS);
 			}, outerDelay);
 		}
 	}
@@ -930,7 +975,7 @@ export class Ring extends BaseClass {
 		);
 
 		if (!this.inEncounter && numberOfBossesInRing < MAX_BOSSES) {
-			const contestant = randomContestant();
+			const contestant = this.getSpawnedBossContestant();
 
 			this.addMonster(contestant);
 
@@ -938,7 +983,7 @@ export class Ring extends BaseClass {
 				const ring = this;
 				setTimeout(() => {
 					ring.removeBoss(contestant);
-				}, 600000);
+				}, BOSS_DESPAWN_DELAY_MS);
 			}
 
 			return contestant;

--- a/packages/server/src/trpc/context.test.ts
+++ b/packages/server/src/trpc/context.test.ts
@@ -111,6 +111,15 @@ describe('trpc/context.ts', () => {
 			expect(ctx.userId).to.equal('user-abc');
 		});
 
+		it('extracts userId when SUPABASE_URL has trailing slash', async () => {
+			process.env['SUPABASE_URL'] = 'https://test.supabase.co/';
+			const token = await signJwt('user-trailing-slash');
+			const ctx = await createContext(
+				makeCtxOpts(makeReq({ authorization: `Bearer ${token}` }))
+			);
+			expect(ctx.userId).to.equal('user-trailing-slash');
+		});
+
 		it('extracts userId from ?token= query param (WebSocket fallback via req.query)', async () => {
 			const token = await signJwt('user-ws');
 			const ctx = await createContext(

--- a/packages/server/src/trpc/context.ts
+++ b/packages/server/src/trpc/context.ts
@@ -14,11 +14,17 @@ let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 let cachedUrl: string | null = null;
 let jwksOverride: ReturnType<typeof createRemoteJWKSet> | null = null;
 
-function getJWKS(): ReturnType<typeof createRemoteJWKSet> | null {
+function normalizeSupabaseUrl(raw: string | undefined): string | null {
+	if (!raw) return null;
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+	return trimmed.replace(/\/+$/, '');
+}
+
+function getJWKS(supabaseUrl: string | null): ReturnType<typeof createRemoteJWKSet> | null {
 	if (jwksOverride !== null) return jwksOverride;
-	const supabaseUrl = process.env['SUPABASE_URL'];
 	if (!supabaseUrl) return null;
-	const url = new URL('/auth/v1/.well-known/jwks.json', supabaseUrl).toString();
+	const url = new URL('/auth/v1/.well-known/jwks.json', `${supabaseUrl}/`).toString();
 	if (url !== cachedUrl) {
 		jwks = createRemoteJWKSet(new URL(url));
 		cachedUrl = url;
@@ -79,8 +85,9 @@ export async function createContext({ req }: CreateFastifyContextOptions): Promi
 	log.debug('verifying JWT', { source: tokenSource });
 
 	try {
-		const keySet = getJWKS();
-		if (!keySet) {
+		const supabaseUrl = normalizeSupabaseUrl(process.env['SUPABASE_URL']);
+		const keySet = getJWKS(supabaseUrl);
+		if (!keySet || !supabaseUrl) {
 			log.debug('SUPABASE_URL not configured — skipping JWT verification');
 			throw new Error('SUPABASE_URL is not configured');
 		}
@@ -90,7 +97,7 @@ export async function createContext({ req }: CreateFastifyContextOptions): Promi
 			// audience verification when the aud claim is present.
 			audience: 'authenticated',
 			// Verify the issuer so tokens from other Supabase projects are rejected.
-			issuer: `${process.env['SUPABASE_URL']}/auth/v1`,
+			issuer: `${supabaseUrl}/auth/v1`,
 			// Allow minor clock skew between API host and auth provider.
 			clockTolerance: 60,
 		});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scope ring announcement listeners to each room's `ring` instance so boss/ring messaging does not leak across rooms when multiple rooms are active
- remove optimistic command echo in Console (server already emits `system.consoleInput`) to prevent duplicate `send ... to the ring` style entries
- refresh autocomplete monster lists automatically after command/prompt interactions and battle outcome events so `send`/`revive` suggestions stay current without page refresh
- add first-time Console guidance chips for users with no history and no monsters
- tune boss behavior: shorter spawn cadence overall and beginner-room scaling so rooms with only beginner monsters spawn lower-level bosses more often
- add a docs follow-up checklist for remote-Supabase manual verification when secrets are available in a future session

## Validation
- `pnpm build`
- `pnpm --filter @deck-monsters/engine test -- --grep "game.ts|ring/index.ts"`
- `pnpm --filter @deck-monsters/web test -- src/__tests__/useCommandAutocomplete.test.ts`

## Manual verification attempt
- API and web dev servers were started locally, but full browser workflow is blocked in this environment because Supabase auth is required for `RequireAuth` routes and local Supabase cannot be started here (container runtime unavailable: Docker/Podman setup failed).
- Also checked runtime env in this session and remote test secrets (`TEST_USERNAME`, `TEST_PASSWORD`, Supabase vars) are not visible yet.
- Added `docs/follow-up-remote-supabase-manual-test.md` with exact next-session steps and acceptance checks.

## Files touched
- `packages/engine/src/announcements/index.ts`
- `packages/engine/src/ring/index.ts`
- `packages/engine/src/game.test.ts`
- `packages/engine/src/ring/index.test.ts`
- `apps/web/src/components/ConsolePane.tsx`
- `docs/follow-up-remote-supabase-manual-test.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c540bd99-1073-41d4-b8bf-0e78d95d5554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c540bd99-1073-41d4-b8bf-0e78d95d5554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

