### PR TITLE
docs: add reusable local testing guidelines and room references

### DIFF
--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -91,6 +91,10 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const [reconnecting, setReconnecting] = useState(false);
   const [quickActions, setQuickActions] = useState<QuickAction[]>([]);
   const [suggestionIndex, setSuggestionIndex] = useState(-1);
+  const [ftuxComplete, setFtuxComplete] = useState(
+    () => typeof localStorage !== 'undefined' && localStorage.getItem('ftuxComplete') === 'true'
+  );
+  const [hasFoughtFirstFight, setHasFoughtFirstFight] = useState(false);
 
   // Resume cursor for reconnects. Updated only on errors so we don't restart
   // the subscription on every event.
@@ -200,10 +204,24 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
       sendableMonsterNames,
     }
   );
-  const showFtux = useMemo(
-    () => (history?.length ?? 0) === 0 && consoleEvents.length === 0 && monsterRows.length === 0,
-    [history, consoleEvents.length, monsterRows.length]
-  );
+  const hasMonsters = monsterRows.length > 0;
+  const hasMonsterInRing = monsterRows.some((m) => m.inRing);
+  const hasDeadMonster = monsterRows.some((m) => m.dead);
+
+  type FtuxPhase = 'spawn' | 'equip_send' | 'waiting' | 'post_fight' | 'hidden';
+  const ftuxPhase = useMemo((): FtuxPhase => {
+    if (ftuxComplete) return 'hidden';
+    if (!hasMonsters) return 'spawn';
+    if (hasFoughtFirstFight && !hasDeadMonster) return 'hidden';
+    if (hasFoughtFirstFight && hasDeadMonster) return 'post_fight';
+    if (hasMonsterInRing) return 'waiting';
+    return 'equip_send';
+  }, [ftuxComplete, hasMonsters, hasMonsterInRing, hasFoughtFirstFight, hasDeadMonster]);
+
+  // Monster names used by FTUX chips — pick first available in each category.
+  const ftuxSendableName = sendableMonsterNames[0] ?? monsterNames.find((n) => !deadMonsterNames.includes(n)) ?? '';
+  const ftuxInRingName = monsterRows.find((m) => m.inRing)?.name ?? '';
+  const ftuxDeadName = deadMonsterNames[0] ?? '';
 
   const sendCommand = trpc.game.command.useMutation();
   const respondToPrompt = trpc.game.respondToPrompt.useMutation();
@@ -293,6 +311,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         onEvent?.(event);
         if (MONSTER_REFRESH_EVENT_TYPES.has(event.type)) {
           void refetchMyMonsters();
+          setHasFoughtFirstFight(true);
         }
 
         const payload = event.payload as Record<string, unknown>;
@@ -564,6 +583,11 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     void handleSubmitCommand(command);
   }
 
+  function dismissFtux() {
+    setFtuxComplete(true);
+    localStorage.setItem('ftuxComplete', 'true');
+  }
+
   const placeholder = activePromptId
     ? 'Type your answer or click a choice above…'
     : inputLocked
@@ -676,33 +700,70 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         </nav>
       )}
 
-      {showFtux && (
+      {ftuxPhase !== 'hidden' && (
         <section
           className="quick-actions"
           aria-label="Getting started guide"
-          style={{ marginBottom: '0.75rem' }}
+          style={{ marginBottom: '0.75rem', position: 'relative' }}
         >
-          <p
+          <button
+            onClick={dismissFtux}
+            aria-label="Dismiss guide"
+            title="Dismiss guide"
             style={{
-              margin: '0 0 0.5rem 0',
-              fontSize: '0.85rem',
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              background: 'transparent',
+              border: 'none',
               color: 'var(--color-fg-dim)',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+              padding: '0 0.25rem',
+              lineHeight: 1,
             }}
           >
-            New here? Start by spawning a monster, then send it to the ring.
+            ✕
+          </button>
+          <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.85rem', color: 'var(--color-fg-dim)' }}>
+            {ftuxPhase === 'spawn' && 'Welcome, Beastmaster. Spawn your first monster to begin your journey.'}
+            {ftuxPhase === 'equip_send' && `Outfit ${ftuxSendableName} with cards, then send them into battle.`}
+            {ftuxPhase === 'waiting' && `${ftuxInRingName} is in the ring. Fights begin once there are 2 or more monsters.`}
+            {ftuxPhase === 'post_fight' && `${ftuxDeadName} has fallen. Revive them to fight again.`}
           </p>
-          <button className="quick-action-chip" onClick={() => setInputValue('spawn monster')}>
-            spawn monster
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('look at monsters')}>
-            look at monsters
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('send [monster] to the ring')}>
-            send [monster] to the ring
-          </button>
-          <button className="quick-action-chip" onClick={() => setInputValue('look at handbook')}>
-            look at handbook
-          </button>
+          {ftuxPhase === 'spawn' && (
+            <>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('spawn a monster')}>
+                spawn a monster
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('look at player handbook')}>
+                look at player handbook
+              </button>
+            </>
+          )}
+          {ftuxPhase === 'equip_send' && (
+            <>
+              <button className="quick-action-chip" onClick={() => handleQuickAction(`equip ${ftuxSendableName}`)}>
+                equip {ftuxSendableName}
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction(`send ${ftuxSendableName} to the ring`)}>
+                send {ftuxSendableName} to the ring
+              </button>
+              <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
+                look at ring
+              </button>
+            </>
+          )}
+          {ftuxPhase === 'waiting' && (
+            <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
+              look at ring
+            </button>
+          )}
+          {ftuxPhase === 'post_fight' && (
+            <button className="quick-action-chip" onClick={() => handleQuickAction(`revive ${ftuxDeadName}`)}>
+              revive {ftuxDeadName}
+            </button>
+          )}
         </section>
       )}
 

--- a/docs/local-testing-guidelines.md
+++ b/docs/local-testing-guidelines.md
@@ -1,0 +1,58 @@
+# Local testing guidelines (env-driven sessions)
+
+This guide captures repeatable local-testing principles for sessions where required env vars are already set externally.
+
+## Core principles
+
+- Keep secrets out of docs, logs, commits, and screenshots. Only document variable names.
+- Verify env var presence early, then fail fast if required values are missing.
+- Run `pnpm build` before tests/manual flows on fresh checkouts so downstream packages see fresh `@deck-monsters/engine` `dist/` output.
+- Start API and web servers in separate long-lived terminal/tmux sessions so logs remain available while testing.
+- Prefer minimal, high-signal checks first (`/health`, auth flow, room list) before long manual scenarios.
+- Record evidence during successful runs only (video/screenshot/log snippets from passing behavior).
+
+## Environment setup checklist (no secret values)
+
+- Required vars should be injected by the shell/session manager, not hardcoded in files.
+- Quick presence check:
+  - `for v in TEST_USERNAME TEST_PASSWORD VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_KEY SUPABASE_URL SUPABASE_SECRET_KEY DATABASE_URL; do [ -n "${!v:-}" ] && echo "$v=SET" || echo "$v=MISSING"; done`
+- Keep URL-style vars normalized when needed by issuer checks (`no trailing slash`), for example:
+  - `SUPABASE_URL="${SUPABASE_URL%/}"`
+
+## Service startup pattern
+
+1. Build once:
+   - `pnpm build`
+2. Start API server:
+   - `pnpm --filter @deck-monsters/server dev`
+3. Start web server:
+   - `pnpm --filter @deck-monsters/web dev -- --host 0.0.0.0 --port 5173`
+4. Confirm API readiness:
+   - `curl -sS http://localhost:3000/health`
+
+## Manual testing heuristics
+
+- Validate auth + room load before gameplay checks.
+- For command parsing checks, use exact supported command strings (for example, `spawn a monster`).
+- For cross-room checks, keep two room tabs open simultaneously and switch frequently while watching both console histories.
+- For autocomplete checks:
+  - Trigger with at least two characters.
+  - Verify context-aware substitutions (e.g., concrete monster names in `send [monster] to the ring` suggestions).
+  - Re-check after state-changing actions (send/revive/fight outcomes) without reloading.
+- For boss pacing/scaling checks:
+  - Use beginner-level monsters in a fresh or low-progress room.
+  - Observe multiple encounter cycles before concluding.
+  - Capture timing/strength notes from ring feed, not memory.
+
+## Reusable rooms from this session
+
+These rooms were created during local manual testing and can be reused in future sessions.
+
+- `Test Room A`
+  - `roomId`: `70cb10d2-4faa-4300-9c20-8befe121a3d1`
+  - `inviteCode`: `717305BE`
+- `Test Room B`
+  - `roomId`: `227ba78e-bca5-4bd4-a59c-9793fac508bd`
+  - `inviteCode`: `328F58D2`
+
+If either room becomes noisy or drifts too far from beginner state, create a fresh room for pacing/scaling verification and add its metadata here.

--- a/packages/server/src/trpc/context.test.ts
+++ b/packages/server/src/trpc/context.test.ts
@@ -111,6 +111,15 @@ describe('trpc/context.ts', () => {
 			expect(ctx.userId).to.equal('user-abc');
 		});
 
+		it('extracts userId when SUPABASE_URL has trailing slash', async () => {
+			process.env['SUPABASE_URL'] = 'https://test.supabase.co/';
+			const token = await signJwt('user-trailing-slash');
+			const ctx = await createContext(
+				makeCtxOpts(makeReq({ authorization: `Bearer ${token}` }))
+			);
+			expect(ctx.userId).to.equal('user-trailing-slash');
+		});
+
 		it('extracts userId from ?token= query param (WebSocket fallback via req.query)', async () => {
 			const token = await signJwt('user-ws');
 			const ctx = await createContext(

--- a/packages/server/src/trpc/context.ts
+++ b/packages/server/src/trpc/context.ts
@@ -14,11 +14,17 @@ let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 let cachedUrl: string | null = null;
 let jwksOverride: ReturnType<typeof createRemoteJWKSet> | null = null;
 
-function getJWKS(): ReturnType<typeof createRemoteJWKSet> | null {
+function normalizeSupabaseUrl(raw: string | undefined): string | null {
+	if (!raw) return null;
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+	return trimmed.replace(/\/+$/, '');
+}
+
+function getJWKS(supabaseUrl: string | null): ReturnType<typeof createRemoteJWKSet> | null {
 	if (jwksOverride !== null) return jwksOverride;
-	const supabaseUrl = process.env['SUPABASE_URL'];
 	if (!supabaseUrl) return null;
-	const url = new URL('/auth/v1/.well-known/jwks.json', supabaseUrl).toString();
+	const url = new URL('/auth/v1/.well-known/jwks.json', `${supabaseUrl}/`).toString();
 	if (url !== cachedUrl) {
 		jwks = createRemoteJWKSet(new URL(url));
 		cachedUrl = url;
@@ -79,8 +85,9 @@ export async function createContext({ req }: CreateFastifyContextOptions): Promi
 	log.debug('verifying JWT', { source: tokenSource });
 
 	try {
-		const keySet = getJWKS();
-		if (!keySet) {
+		const supabaseUrl = normalizeSupabaseUrl(process.env['SUPABASE_URL']);
+		const keySet = getJWKS(supabaseUrl);
+		if (!keySet || !supabaseUrl) {
 			log.debug('SUPABASE_URL not configured — skipping JWT verification');
 			throw new Error('SUPABASE_URL is not configured');
 		}
@@ -90,7 +97,7 @@ export async function createContext({ req }: CreateFastifyContextOptions): Promi
 			// audience verification when the aud claim is present.
 			audience: 'authenticated',
 			// Verify the issuer so tokens from other Supabase projects are rejected.
-			issuer: `${process.env['SUPABASE_URL']}/auth/v1`,
+			issuer: `${supabaseUrl}/auth/v1`,
 			// Allow minor clock skew between API host and auth provider.
 			clockTolerance: 60,
 		});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `docs/local-testing-guidelines.md` with general principles for env-driven local testing sessions
- document a reusable startup/testing flow that avoids embedding secret values and relies on env vars
- record reusable room metadata created during manual testing (`Test Room A` and `Test Room B`) for faster follow-up sessions
- harden server JWT auth context by normalizing `SUPABASE_URL` so trailing slashes do not break issuer verification
- align web console FTUX with the staged guidance approach from PR #327, with command compatibility fixes for current parser behavior

## Details
- includes a safe env presence check command (variable names only)
- includes URL normalization guidance for `SUPABASE_URL` issuer consistency
- includes practical heuristics for auth, cross-room isolation, autocomplete, and boss pacing checks
- includes room IDs and invite codes only (no credentials or secret key values)
- updates `packages/server/src/trpc/context.ts` to trim and remove trailing slashes before building JWKS URL and issuer
- adds a regression test in `packages/server/src/trpc/context.test.ts` proving JWT verification works when `SUPABASE_URL` is set with a trailing slash
- updates `apps/web/src/components/ConsolePane.tsx` FTUX to use phased guidance (`spawn`, `equip_send`, `waiting`, `post_fight`) with dismiss support and monster-aware chip commands
- uses parser-compatible FTUX commands (`spawn a monster`, `look at player handbook`) to avoid command-not-recognized regressions

## Validation
- `pnpm --filter @deck-monsters/server test -- src/trpc/context.test.ts`
- `pnpm --filter @deck-monsters/server build`
- `pnpm --filter @deck-monsters/web test`
- `pnpm --filter @deck-monsters/web build`
- reviewed doc content to ensure no secret values are present
- confirmed listed room metadata by querying the configured database from local env

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0aa3726-be03-43b9-af91-6c58e0391d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0aa3726-be03-43b9-af91-6c58e0391d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

