### PR TITLE
fix: reduce FTUX frequency and simplify mobile guidance

### DIFF
--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -48,6 +48,7 @@ interface MonsterAutocompleteRow {
   name: string;
   dead: boolean;
   inRing: boolean;
+  battlesTotal: number;
 }
 
 const EMPTY_MONSTERS: MonsterAutocompleteRow[] = [];
@@ -91,9 +92,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const [reconnecting, setReconnecting] = useState(false);
   const [quickActions, setQuickActions] = useState<QuickAction[]>([]);
   const [suggestionIndex, setSuggestionIndex] = useState(-1);
-  const [ftuxComplete, setFtuxComplete] = useState(
-    () => typeof localStorage !== 'undefined' && localStorage.getItem('ftuxComplete') === 'true'
-  );
+  const [ftuxComplete, setFtuxComplete] = useState(false);
   const [hasFoughtFirstFight, setHasFoughtFirstFight] = useState(false);
 
   // Resume cursor for reconnects. Updated only on errors so we don't restart
@@ -104,6 +103,17 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const seenRef = useRef(new Set<string>());
   const latestTrackedEventIdRef = useRef<string | undefined>(undefined);
   const historyApplied = useRef(false);
+  const ftuxStorageKey = useMemo(
+    () => (user?.id ? `ftuxComplete:${user.id}` : 'ftuxComplete'),
+    [user?.id]
+  );
+
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    if (localStorage.getItem(ftuxStorageKey) === 'true') {
+      setFtuxComplete(true);
+    }
+  }, [ftuxStorageKey]);
 
   // Register command-insert function so external callers (CommandReference, etc.) can populate the input
   useEffect(() => {
@@ -207,6 +217,18 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const hasMonsters = monsterRows.length > 0;
   const hasMonsterInRing = monsterRows.some((m) => m.inRing);
   const hasDeadMonster = monsterRows.some((m) => m.dead);
+  const hasBattleExperiencedMonsters = monsterRows.some((m) => m.battlesTotal > 0);
+  const hasRingOutcomeHistory = useMemo(
+    () => (history ?? []).some((ev) => MONSTER_REFRESH_EVENT_TYPES.has(ev.type)),
+    [history]
+  );
+  const isEstablishedRoomState = hasBattleExperiencedMonsters || hasRingOutcomeHistory || monsterRows.length > 1;
+
+  useEffect(() => {
+    if (ftuxComplete || !isEstablishedRoomState || typeof localStorage === 'undefined') return;
+    setFtuxComplete(true);
+    localStorage.setItem(ftuxStorageKey, 'true');
+  }, [ftuxComplete, ftuxStorageKey, isEstablishedRoomState]);
 
   type FtuxPhase = 'spawn' | 'equip_send' | 'waiting' | 'post_fight' | 'hidden';
   const ftuxPhase = useMemo((): FtuxPhase => {
@@ -222,6 +244,24 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const ftuxSendableName = sendableMonsterNames[0] ?? monsterNames.find((n) => !deadMonsterNames.includes(n)) ?? '';
   const ftuxInRingName = monsterRows.find((m) => m.inRing)?.name ?? '';
   const ftuxDeadName = deadMonsterNames[0] ?? '';
+  const ftuxAction = useMemo((): { label: string; command: string } | null => {
+    switch (ftuxPhase) {
+      case 'spawn':
+        return { label: 'spawn a monster', command: 'spawn a monster' };
+      case 'equip_send':
+        return ftuxSendableName
+          ? { label: `equip ${ftuxSendableName}`, command: `equip ${ftuxSendableName}` }
+          : { label: 'look at monsters', command: 'look at monsters' };
+      case 'waiting':
+        return { label: 'look at ring', command: 'look at ring' };
+      case 'post_fight':
+        return ftuxDeadName
+          ? { label: `revive ${ftuxDeadName}`, command: `revive ${ftuxDeadName}` }
+          : { label: 'look at monsters', command: 'look at monsters' };
+      default:
+        return null;
+    }
+  }, [ftuxDeadName, ftuxPhase, ftuxSendableName]);
 
   const sendCommand = trpc.game.command.useMutation();
   const respondToPrompt = trpc.game.respondToPrompt.useMutation();
@@ -585,7 +625,9 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
 
   function dismissFtux() {
     setFtuxComplete(true);
-    localStorage.setItem('ftuxComplete', 'true');
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(ftuxStorageKey, 'true');
+    }
   }
 
   const placeholder = activePromptId
@@ -702,9 +744,8 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
 
       {ftuxPhase !== 'hidden' && (
         <section
-          className="quick-actions"
+          className="ftux-guide"
           aria-label="Getting started guide"
-          style={{ marginBottom: '0.75rem', position: 'relative' }}
         >
           <button
             onClick={dismissFtux}
@@ -725,44 +766,38 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
           >
             ✕
           </button>
-          <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.85rem', color: 'var(--color-fg-dim)' }}>
+          <p className="ftux-guide-copy">
             {ftuxPhase === 'spawn' && 'Welcome, Beastmaster. Spawn your first monster to begin your journey.'}
             {ftuxPhase === 'equip_send' && `Outfit ${ftuxSendableName} with cards, then send them into battle.`}
             {ftuxPhase === 'waiting' && `${ftuxInRingName} is in the ring. Fights begin once there are 2 or more monsters.`}
             {ftuxPhase === 'post_fight' && `${ftuxDeadName} has fallen. Revive them to fight again.`}
           </p>
-          {ftuxPhase === 'spawn' && (
-            <>
-              <button className="quick-action-chip" onClick={() => handleQuickAction('spawn a monster')}>
-                spawn a monster
+          {ftuxAction && (
+            <div className="ftux-guide-actions">
+              <button className="quick-action-chip" onClick={() => handleQuickAction(ftuxAction.command)}>
+                {ftuxAction.label}
               </button>
-              <button className="quick-action-chip" onClick={() => handleQuickAction('look at player handbook')}>
-                look at player handbook
-              </button>
-            </>
+            </div>
           )}
           {ftuxPhase === 'equip_send' && (
-            <>
-              <button className="quick-action-chip" onClick={() => handleQuickAction(`equip ${ftuxSendableName}`)}>
-                equip {ftuxSendableName}
-              </button>
-              <button className="quick-action-chip" onClick={() => handleQuickAction(`send ${ftuxSendableName} to the ring`)}>
-                send {ftuxSendableName} to the ring
-              </button>
-              <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
-                look at ring
-              </button>
-            </>
-          )}
-          {ftuxPhase === 'waiting' && (
-            <button className="quick-action-chip" onClick={() => handleQuickAction('look at ring')}>
-              look at ring
-            </button>
+            <p className="ftux-guide-hint">
+              Once equipped, run <code>send {ftuxSendableName || '[monster]'} to the ring</code>.
+            </p>
           )}
           {ftuxPhase === 'post_fight' && (
-            <button className="quick-action-chip" onClick={() => handleQuickAction(`revive ${ftuxDeadName}`)}>
-              revive {ftuxDeadName}
-            </button>
+            <p className="ftux-guide-hint">
+              Dead monsters can still be inspected with <code>look at monsters</code>.
+            </p>
+          )}
+          {ftuxPhase === 'waiting' && (
+            <p className="ftux-guide-hint">
+              Add another monster to start fights faster.
+            </p>
+          )}
+          {ftuxPhase === 'spawn' && (
+            <p className="ftux-guide-hint">
+              Need help first? Try <code>look at player handbook</code>.
+            </p>
           )}
         </section>
       )}

--- a/apps/web/src/styles/terminal.css
+++ b/apps/web/src/styles/terminal.css
@@ -242,6 +242,44 @@
   color: var(--color-fg);
 }
 
+.ftux-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.6rem var(--pane-padding);
+  border-top: 1px solid var(--color-border);
+  flex-shrink: 0;
+  position: relative;
+}
+
+.ftux-guide-copy {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-fg-dim);
+}
+
+.ftux-guide-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.ftux-guide .quick-action-chip {
+  width: 100%;
+  text-align: left;
+  white-space: normal;
+}
+
+.ftux-guide-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-fg-dim);
+}
+
+.ftux-guide-hint code {
+  color: var(--color-fg);
+}
+
 /* Command input dock */
 .command-dock {
   border-top: 1px solid var(--color-border);

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -433,10 +433,14 @@ export function createRouter(roomManager: RoomManager) {
 				);
 
 				return monsters
-					.map((monster: { givenName?: unknown; dead?: unknown }) => ({
+					.map((monster: { givenName?: unknown; dead?: unknown; battles?: { total?: unknown } }) => ({
 						name: String(monster?.givenName ?? '').trim(),
 						dead: Boolean(monster?.dead),
 						inRing: inRing.has(monster),
+						battlesTotal:
+							typeof monster?.battles?.total === 'number' && Number.isFinite(monster.battles.total)
+								? monster.battles.total
+								: 0,
 					}))
 					.filter((monster: { name: string }) => monster.name.length > 0);
 			}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- prevent FTUX from resurfacing for established players/rooms with prior battles
- simplify FTUX to a single next-step action instead of multi-chip horizontal suggestions
- make FTUX guidance panel mobile-friendly with stacked copy/actions

## What changed
- `packages/server/src/trpc/router.ts`
  - extend `myMonsters` response with `battlesTotal` derived from monster battle history
- `apps/web/src/components/ConsolePane.tsx`
  - add established-room detection (`battlesTotal`, ring outcome history, multi-monster state) and auto-complete FTUX state persistence
  - keep FTUX completion stored per user key in localStorage
  - render one primary "do this next" action per FTUX phase
  - keep guidance copy as hints instead of presenting multiple side-by-side choices
- `apps/web/src/styles/terminal.css`
  - add dedicated `.ftux-guide*` styles for stacked layout and full-width action chips

## Validation
- `pnpm --filter @deck-monsters/web test`
- `pnpm --filter @deck-monsters/web build`
- `pnpm --filter @deck-monsters/server build`

## Notes
- manual browser verification via `computerUse` is currently blocked in this agent session by provider media-limit errors (`maximum of 100 images/documents`). Automated checks above pass for this patch set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0aa3726-be03-43b9-af91-6c58e0391d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0aa3726-be03-43b9-af91-6c58e0391d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

