### PR TITLE
feat(engine): weighted boss level distribution by room monster levels

### DIFF
--- a/packages/engine/src/announcements/rolled.test.ts
+++ b/packages/engine/src/announcements/rolled.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import { announceRolled } from './rolled.js';
+import type { RoomEventBus } from '../events/index.js';
+
+function makeEb(onPublish: (text: string) => void): RoomEventBus {
+	return {
+		publish: ({ text }: { text: string }) => {
+			onPublish(text);
+			return { id: '1', roomId: 'test', timestamp: 0, type: 'announce', scope: 'public', text, payload: {} };
+		},
+	} as unknown as RoomEventBus;
+}
+
+describe('./announcements/rolled.ts', () => {
+	it('announces a partial roll payload without crashing', () => {
+		let publishedText = '';
+		const eb = makeEb((text) => {
+			publishedText = text;
+		});
+
+		announceRolled(eb, '', {}, {
+			reason: 'to determine how much to drink.',
+			roll: { result: 5 },
+			who: { givenName: 'Player' },
+			outcome: 'Player grows stronger...',
+		});
+
+		expect(publishedText).to.include('Player rolled _5_ to determine how much to drink.');
+		expect(publishedText).to.not.include('undefined');
+		expect(publishedText).to.include('🎲 *5*');
+	});
+});

--- a/packages/engine/src/announcements/rolled.ts
+++ b/packages/engine/src/announcements/rolled.ts
@@ -2,22 +2,27 @@ import { signedNumber } from '../helpers/signed-number.js';
 import type { RoomEventBus } from '../events/index.js';
 
 interface RollResult {
-	naturalRoll: { result: number };
-	bonusResult: number;
-	modifier: number;
+	naturalRoll?: { result?: number };
+	bonusResult?: number;
+	modifier?: number;
 	primaryDice?: string;
 	strokeOfLuck?: boolean;
 	curseOfLoki?: boolean;
-	result: number | string;
+	result?: number | string;
 }
 
 interface RolledOpts {
 	outcome?: string;
 	reason: string;
-	roll: RollResult;
+	roll?: RollResult;
 	vs?: number | string;
 	who: any;
 }
+
+const toNumber = (value: unknown, fallback = 0): number => {
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : fallback;
+};
 
 export function announceRolled(
 	eb: RoomEventBus,
@@ -25,19 +30,32 @@ export function announceRolled(
 	monster: any,
 	{ outcome, reason, roll, vs, who }: RolledOpts,
 ): void {
-	let rollDesc = `${roll.naturalRoll.result}${signedNumber(roll.bonusResult)}${signedNumber(roll.modifier)}`;
-	if (roll.primaryDice) rollDesc = `${rollDesc} on ${roll.primaryDice}`;
+	const naturalRoll = toNumber(roll?.naturalRoll?.result);
+	const bonusResult = toNumber(roll?.bonusResult);
+	const modifier = toNumber(roll?.modifier);
+	const fallbackResult = naturalRoll + bonusResult + modifier;
+	const result = roll?.result ?? fallbackResult;
+	const hasDetailedRollDescription = roll?.naturalRoll?.result !== undefined ||
+		roll?.bonusResult !== undefined ||
+		roll?.modifier !== undefined ||
+		!!roll?.primaryDice;
 
-	const text = `${who.givenName} rolled _${rollDesc}_ ${reason}`;
+	let rollDesc = hasDetailedRollDescription
+		? `${naturalRoll}${signedNumber(bonusResult)}${signedNumber(modifier)}`
+		: `${result}`;
+	if (roll?.primaryDice) rollDesc = `${rollDesc} on ${roll.primaryDice}`;
+
+	const whoName = who?.givenName ?? 'Someone';
+	const text = `${whoName} rolled _${rollDesc}_ ${reason}`;
 
 	const vsMsg = vs ? ` v ${vs}` : '';
-	let rollResult: string = roll.strokeOfLuck ? 'Nat 20!' : String(roll.result);
-	if (roll.curseOfLoki) rollResult = 'Crit Fail!';
+	let rollResult: string = roll?.strokeOfLuck ? 'Nat 20!' : String(result);
+	if (roll?.curseOfLoki) rollResult = 'Crit Fail!';
 
 	eb.publish({
 		type: 'announce',
 		scope: 'public',
 		text: `${text}\n🎲 *${rollResult}${vsMsg}*${outcome ? `\n    ${outcome}` : ''}\n `,
-		payload: { roll, who, outcome },
+		payload: { roll: roll ?? { result }, who, outcome },
 	});
 }

--- a/packages/engine/src/announcements/rolled.ts
+++ b/packages/engine/src/announcements/rolled.ts
@@ -1,15 +1,27 @@
 import { signedNumber } from '../helpers/signed-number.js';
 import type { RoomEventBus } from '../events/index.js';
 
-interface RollResult {
-	naturalRoll?: { result?: number };
-	bonusResult?: number;
-	modifier?: number;
+type RollFlags = {
 	primaryDice?: string;
 	strokeOfLuck?: boolean;
 	curseOfLoki?: boolean;
+};
+
+type RollWithParts = RollFlags & {
+	naturalRoll: { result: number };
+	bonusResult: number;
+	modifier: number;
 	result?: number | string;
-}
+};
+
+type RollWithResultOnly = RollFlags & {
+	result: number | string;
+	naturalRoll?: { result?: number };
+	bonusResult?: number;
+	modifier?: number;
+};
+
+type RollResult = RollWithParts | RollWithResultOnly;
 
 interface RolledOpts {
 	outcome?: string;

--- a/packages/engine/src/game.ts
+++ b/packages/engine/src/game.ts
@@ -75,7 +75,10 @@ export class Game extends BaseClass {
 
 		this.ring = new Ring(
 			this._eventBus,
-			{ spawnBosses: (this.options as any).spawnBosses },
+			{
+				spawnBosses: (this.options as any).spawnBosses,
+				getRoomMonsterLevels: () => this.getRoomMonsterLevels(),
+			},
 			this.log
 		);
 		this.exploration = new Exploration(this._eventBus as any, {}, this.log);
@@ -168,6 +171,15 @@ export class Game extends BaseClass {
 
 	set characters(characters: Record<string, any>) {
 		this.setOptions({ characters } as any);
+	}
+
+	private getRoomMonsterLevels(): number[] {
+		return Object.values(this.characters)
+			.flatMap((character: any) =>
+				Array.isArray(character?.monsters) ? character.monsters : []
+			)
+			.map((monster: any) => Number(monster?.level ?? 0))
+			.filter((level: number) => Number.isFinite(level) && level >= 0);
 	}
 
 	get saveState(): () => void {

--- a/packages/engine/src/game.ts
+++ b/packages/engine/src/game.ts
@@ -178,6 +178,7 @@ export class Game extends BaseClass {
 			.flatMap((character: any) =>
 				Array.isArray(character?.monsters) ? character.monsters : []
 			)
+			.filter((monster: any) => monster && !monster.dead && !monster.destroyed)
 			.map((monster: any) => Number(monster?.level ?? 0))
 			.filter((level: number) => Number.isFinite(level) && level >= 0);
 	}

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -133,54 +133,49 @@ describe('ring/index.ts', () => {
 			expect(contestant).to.be.undefined;
 		});
 
-		it('spawns lower-level bosses when only beginner monsters are present', () => {
+		it('uses weighted cap bands from room monster levels', () => {
 			const game = new Game();
 			const ring = game.getRing();
-			const beginnerA = randomContestant({
-				isBoss: false,
-				battles: { total: 0, wins: 0, losses: 0 },
-			});
-			const beginnerB = randomContestant({
-				isBoss: false,
-				battles: { total: 0, wins: 0, losses: 0 },
-			});
+			const determineBossLevelCap = (ring as any).determineBossLevelCap.bind(ring);
 
-			ring.addMonster(beginnerA);
-			ring.addMonster(beginnerB);
-
-			const boss = ring.spawnBoss();
-			expect(boss).to.not.be.undefined;
-			expect(boss!.monster.level).to.be.at.most(2);
+			// 20%: keep full random distribution (no cap).
+			expect(determineBossLevelCap([0, 1, 2], 1)).to.equal(undefined);
+			expect(determineBossLevelCap([0, 1, 2], 20)).to.equal(undefined);
+			// 30%: cap at highest level + 1.
+			expect(determineBossLevelCap([0, 1, 2], 21)).to.equal(3);
+			expect(determineBossLevelCap([0, 1, 2], 50)).to.equal(3);
+			// 50%: cap at floor(average level).
+			expect(determineBossLevelCap([0, 1, 2], 51)).to.equal(1);
+			expect(determineBossLevelCap([0, 1, 2], 100)).to.equal(1);
 		});
 
-		it('does not spawn high-level bosses on an empty beginner ring (timer-driven case)', () => {
+		it('treats empty-room capped bands as level 0', () => {
 			const game = new Game();
 			const ring = game.getRing();
+			const determineBossLevelCap = (ring as any).determineBossLevelCap.bind(ring);
 
-			const boss = ring.spawnBoss();
-			expect(boss).to.not.be.undefined;
-			expect(boss!.monster.level).to.be.at.most(2);
+			expect(determineBossLevelCap([], 20)).to.equal(undefined);
+			expect(determineBossLevelCap([], 21)).to.equal(0);
+			expect(determineBossLevelCap([], 100)).to.equal(0);
 		});
 
-		it('caps beginner-room boss XP when average player XP is high within beginner levels', () => {
+		it('caps spawned boss level when cap strategy applies', () => {
 			const game = new Game();
 			const ring = game.getRing();
-			// Level 2 monsters (XP 100–149): 14 wins => 140 XP each; average 140 => unscaled band would reach ~180 XP (level 3+).
-			const beginnerA = randomContestant({
-				isBoss: false,
-				battles: { total: 20, wins: 14, losses: 6 },
-			});
-			const beginnerB = randomContestant({
-				isBoss: false,
-				battles: { total: 20, wins: 14, losses: 6 },
-			});
 
-			ring.addMonster(beginnerA);
-			ring.addMonster(beginnerB);
+			const capOneStub = sinon.stub(ring as any, 'getBossLevelCap').returns(1);
+			const lowBoss = ring.spawnBoss();
+			expect(lowBoss).to.not.be.undefined;
+			expect(lowBoss!.monster.level).to.be.at.most(1);
+			capOneStub.restore();
 
-			const boss = ring.spawnBoss();
-			expect(boss).to.not.be.undefined;
-			expect(boss!.monster.level).to.be.at.most(2);
+			ring.clearRing();
+
+			const capThreeStub = sinon.stub(ring as any, 'getBossLevelCap').returns(3);
+			const midBoss = ring.spawnBoss();
+			expect(midBoss).to.not.be.undefined;
+			expect(midBoss!.monster.level).to.be.at.most(3);
+			capThreeStub.restore();
 		});
 	});
 

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -133,7 +133,7 @@ describe('ring/index.ts', () => {
 			expect(contestant).to.be.undefined;
 		});
 
-		it('uses weighted cap bands from room monster levels', () => {
+		it('uses weighted cap bands from selected level source', () => {
 			const game = new Game();
 			const ring = game.getRing();
 			const determineBossLevelCap = (ring as any).determineBossLevelCap.bind(ring);
@@ -147,6 +147,60 @@ describe('ring/index.ts', () => {
 			// 50%: cap at floor(average level).
 			expect(determineBossLevelCap([0, 1, 2], 51)).to.equal(1);
 			expect(determineBossLevelCap([0, 1, 2], 100)).to.equal(1);
+		});
+
+		it('falls back to room monster levels when no player monsters are in the ring', () => {
+			const game = new Game();
+			const ring = game.getRing();
+			const roomMonsterA = randomContestant({
+				isBoss: false,
+				battles: { total: 30, wins: 26, losses: 4 },
+			});
+			const roomMonsterB = randomContestant({
+				isBoss: false,
+				battles: { total: 20, wins: 14, losses: 6 },
+			});
+			game.characters = {
+				roomA: roomMonsterA.character,
+				roomB: roomMonsterB.character,
+			} as any;
+
+			const determineStub = sinon.stub(ring as any, 'determineBossLevelCap').returns(0);
+			(ring as any).getBossLevelCap();
+
+			const selectedLevels = [...(determineStub.firstCall.args[0] as number[])].sort((a, b) => a - b);
+			const roomLevels = [roomMonsterA.monster.level, roomMonsterB.monster.level].sort((a, b) => a - b);
+			expect(selectedLevels).to.deep.equal(roomLevels);
+		});
+
+		it('prefers ring monster levels over room levels when ring has players', () => {
+			const game = new Game();
+			const ring = game.getRing();
+			const highRoomMonster = randomContestant({
+				isBoss: false,
+				battles: { total: 60, wins: 55, losses: 5 },
+			});
+			game.characters = {
+				highRoom: highRoomMonster.character,
+			} as any;
+
+			const ringMonsterA = randomContestant({
+				isBoss: false,
+				battles: { total: 2, wins: 1, losses: 1 },
+			});
+			const ringMonsterB = randomContestant({
+				isBoss: false,
+				battles: { total: 0, wins: 0, losses: 0 },
+			});
+			ring.addMonster(ringMonsterA);
+			ring.addMonster(ringMonsterB);
+
+			const determineStub = sinon.stub(ring as any, 'determineBossLevelCap').returns(0);
+			(ring as any).getBossLevelCap();
+
+			const selectedLevels = [...(determineStub.firstCall.args[0] as number[])].sort((a, b) => a - b);
+			const ringLevels = [ringMonsterA.monster.level, ringMonsterB.monster.level].sort((a, b) => a - b);
+			expect(selectedLevels).to.deep.equal(ringLevels);
 		});
 
 		it('treats empty-room capped bands as level 0', () => {

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -203,6 +203,56 @@ describe('ring/index.ts', () => {
 			expect(selectedLevels).to.deep.equal(ringLevels);
 		});
 
+		it('uses ring-only levels for boss spawn timing context', () => {
+			const game = new Game();
+			const ring = game.getRing();
+			const highRoomMonster = randomContestant({
+				isBoss: false,
+				battles: { total: 80, wins: 75, losses: 5 },
+			});
+			game.characters = { highRoom: highRoomMonster.character } as any;
+
+			// Ring is empty, so timing remains beginner-paced regardless of room roster.
+			expect((ring as any).isBeginnerBossTimingContext()).to.equal(true);
+
+			const highRingMonster = randomContestant({
+				isBoss: false,
+				battles: { total: 80, wins: 75, losses: 5 },
+			});
+			ring.addMonster(highRingMonster);
+			expect((ring as any).isBeginnerBossTimingContext()).to.equal(false);
+		});
+
+		it('ignores dead and destroyed room monsters in fallback level selection', () => {
+			const game = new Game();
+			const ring = game.getRing();
+			const aliveRoomMonster = randomContestant({
+				isBoss: false,
+				battles: { total: 0, wins: 0, losses: 0 },
+			});
+			const deadRoomMonster = randomContestant({
+				isBoss: false,
+				battles: { total: 60, wins: 55, losses: 5 },
+			});
+			const destroyedRoomMonster = randomContestant({
+				isBoss: false,
+				battles: { total: 90, wins: 85, losses: 5 },
+			});
+			deadRoomMonster.monster.hp = 0;
+			destroyedRoomMonster.monster.hp = -999;
+			game.characters = {
+				aliveRoom: aliveRoomMonster.character,
+				deadRoom: deadRoomMonster.character,
+				destroyedRoom: destroyedRoomMonster.character,
+			} as any;
+
+			const determineStub = sinon.stub(ring as any, 'determineBossLevelCap').returns(0);
+			(ring as any).getBossLevelCap();
+
+			const selectedLevels = determineStub.firstCall.args[0] as number[];
+			expect(selectedLevels).to.deep.equal([aliveRoomMonster.monster.level]);
+		});
+
 		it('treats empty-room capped bands as level 0', () => {
 			const game = new Game();
 			const ring = game.getRing();

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -223,6 +223,34 @@ describe('ring/index.ts', () => {
 			expect((ring as any).isBeginnerBossTimingContext()).to.equal(false);
 		});
 
+		it('maps level caps to expected XP boundaries', () => {
+			const game = new Game();
+			const ring = game.getRing();
+			const getXpCapForLevel = (ring as any).constructor
+				.toString()
+				.includes('getXpCapForLevel');
+			expect(getXpCapForLevel).to.equal(true);
+
+			// spot-check known level boundaries from getLevel progression
+			const xpCapForLevel = (ring as any).getSpawnedBossContestant
+				? (level: number) => {
+					const helper = (ring as any).constructor as any;
+					// Reach private helper through spawned-boss path deterministically:
+					// with cap N, max boss XP should never exceed the cap boundary.
+					const capStub = sinon.stub(ring as any, 'getBossLevelCap').returns(level);
+					const boss = ring.spawnBoss()!;
+					capStub.restore();
+					ring.clearRing();
+					return boss.monster.xp;
+				}
+				: () => 0;
+
+			expect(xpCapForLevel(0)).to.be.at.most(49);
+			expect(xpCapForLevel(1)).to.be.at.most(99);
+			expect(xpCapForLevel(2)).to.be.at.most(149);
+			expect(xpCapForLevel(3)).to.be.at.most(249);
+		});
+
 		it('ignores dead and destroyed room monsters in fallback level selection', () => {
 			const game = new Game();
 			const ring = game.getRing();

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -30,11 +30,26 @@ const BOSS_HIGHEST_PLUS_ONE_WEIGHT_PERCENT = 30;
  */
 const getXpCapForLevel = (targetLevel: number): number => {
 	const normalizedLevel = Math.max(0, Math.floor(targetLevel));
-	let xp = 0;
-	while (getLevel(xp + 1) <= normalizedLevel) {
-		xp += 1;
+	let lower = 0;
+	let upper = 1;
+
+	// Expand the search window until it strictly exceeds the target level.
+	while (getLevel(upper) <= normalizedLevel) {
+		lower = upper;
+		upper *= 2;
 	}
-	return xp;
+
+	// Binary search for the highest XP whose computed level is still <= target.
+	while (lower + 1 < upper) {
+		const mid = Math.floor((lower + upper) / 2);
+		if (getLevel(mid) <= normalizedLevel) {
+			lower = mid;
+		} else {
+			upper = mid;
+		}
+	}
+
+	return lower;
 };
 
 export interface Contestant {

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -74,6 +74,7 @@ export class Ring extends BaseClass {
 	log: (err: unknown) => void;
 	spawnBosses: boolean;
 	eventBus: RoomEventBus;
+	private readonly roomMonsterLevelsProvider?: () => number[];
 	inEncounter: boolean = false;
 	encounter?: Record<string, any>;
 	fightTimer?: ReturnType<typeof setTimeout>;
@@ -95,7 +96,11 @@ export class Ring extends BaseClass {
 
 	constructor(
 		eventBus: RoomEventBus,
-		{ spawnBosses = true, ...options }: Record<string, any> = {},
+		{
+			spawnBosses = true,
+			getRoomMonsterLevels,
+			...options
+		}: { spawnBosses?: boolean; getRoomMonsterLevels?: () => number[]; [key: string]: unknown } = {},
 		log: (err: unknown) => void = () => {}
 	) {
 		super(options);
@@ -103,6 +108,7 @@ export class Ring extends BaseClass {
 		this.log = log;
 		this.spawnBosses = spawnBosses;
 		this.eventBus = eventBus;
+		this.roomMonsterLevelsProvider = getRoomMonsterLevels;
 		if (!Array.isArray((this.options as any).battles)) {
 			this.setOptions({ battles: [] } as any);
 		}
@@ -930,8 +936,21 @@ export class Ring extends BaseClass {
 			.filter(level => Number.isFinite(level) && level >= 0);
 	}
 
+	private getRoomMonsterLevels(): number[] {
+		const levels = this.roomMonsterLevelsProvider?.() ?? [];
+		return levels
+			.map(level => Number(level))
+			.filter(level => Number.isFinite(level) && level >= 0);
+	}
+
+	private getPreferredBossScalingLevels(): number[] {
+		const ringLevels = this.getPlayerMonsterLevels();
+		if (ringLevels.length > 0) return ringLevels;
+		return this.getRoomMonsterLevels();
+	}
+
 	private hasOnlyBeginnerPlayers(): boolean {
-		const levels = this.getPlayerMonsterLevels();
+		const levels = this.getPreferredBossScalingLevels();
 		return levels.length > 0 && levels.every(level => level <= BEGINNER_LEVEL_THRESHOLD);
 	}
 
@@ -940,7 +959,7 @@ export class Ring extends BaseClass {
 	 * no player monsters in the ring yet (empty ring still uses beginner boss pacing — not full random).
 	 */
 	private isBeginnerBossContext(): boolean {
-		return this.hasOnlyBeginnerPlayers() || this.getPlayerMonsterLevels().length === 0;
+		return this.hasOnlyBeginnerPlayers() || this.getPreferredBossScalingLevels().length === 0;
 	}
 
 	private getBossSpawnOuterDelayMs(): number {
@@ -969,7 +988,7 @@ export class Ring extends BaseClass {
 	}
 
 	private getBossLevelCap(): number | undefined {
-		return this.determineBossLevelCap(this.getPlayerMonsterLevels(), random(1, 100));
+		return this.determineBossLevelCap(this.getPreferredBossScalingLevels(), random(1, 100));
 	}
 
 	private getSpawnedBossContestant(): Contestant {

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -20,8 +20,30 @@ const BOSS_SPAWN_MAX_DELAY_MS = 2_100_000; // 35 min
 const BOSS_SPAWN_BEGINNER_MIN_DELAY_MS = 720_000; // 12 min
 const BOSS_SPAWN_BEGINNER_MAX_DELAY_MS = 1_320_000; // 22 min
 const BEGINNER_LEVEL_THRESHOLD = 2;
-/** Max XP for bosses in beginner rooms — keeps boss level aligned with `BEGINNER_LEVEL_THRESHOLD` (level 2 caps at 149 XP). */
-const BEGINNER_BOSS_MAX_XP = 149;
+const BOSS_FULL_RANDOM_WEIGHT_PERCENT = 20;
+const BOSS_HIGHEST_PLUS_ONE_WEIGHT_PERCENT = 30;
+
+/**
+ * Calculates the max XP that still maps to `targetLevel` via `getLevel()`.
+ * Level 0 cap is 49, level 1 cap is 99, level 2 cap is 149, etc.
+ */
+const getXpCapForLevel = (targetLevel: number): number => {
+	if (targetLevel <= 0) return 49;
+
+	let prevPrevThreshold = 0;
+	let prevThreshold = 50;
+	let level = 0;
+	while (level <= targetLevel) {
+		const threshold = prevPrevThreshold + prevThreshold;
+		if (level === targetLevel) return threshold - 1;
+
+		prevPrevThreshold = prevThreshold;
+		prevThreshold = threshold;
+		level += 1;
+	}
+
+	return 49;
+};
 
 export interface Contestant {
 	monster: any;
@@ -928,28 +950,36 @@ export class Ring extends BaseClass {
 		return random(BOSS_SPAWN_MIN_DELAY_MS, BOSS_SPAWN_MAX_DELAY_MS);
 	}
 
+	private determineBossLevelCap(playerLevels: number[], roll: number): number | undefined {
+		if (roll <= BOSS_FULL_RANDOM_WEIGHT_PERCENT) {
+			return undefined;
+		}
+
+		if (playerLevels.length <= 0) {
+			return 0;
+		}
+
+		const highestLevel = Math.max(...playerLevels);
+		if (roll <= BOSS_FULL_RANDOM_WEIGHT_PERCENT + BOSS_HIGHEST_PLUS_ONE_WEIGHT_PERCENT) {
+			return Math.max(0, highestLevel + 1);
+		}
+
+		const averageLevel = playerLevels.reduce((sum, level) => sum + level, 0) / playerLevels.length;
+		return Math.max(0, Math.floor(averageLevel));
+	}
+
+	private getBossLevelCap(): number | undefined {
+		return this.determineBossLevelCap(this.getPlayerMonsterLevels(), random(1, 100));
+	}
+
 	private getSpawnedBossContestant(): Contestant {
-		const playerContestants = this.contestants.filter(contestant => !contestant.isBoss);
-		if (!this.isBeginnerBossContext()) {
+		const levelCap = this.getBossLevelCap();
+		if (levelCap === undefined) {
 			return randomContestant();
 		}
 
-		if (playerContestants.length === 0) {
-			// Same band as avg XP 0 when players are present: roughly level 0–1 bosses.
-			return randomContestant({ xp: random(0, 40) });
-		}
-
-		const averagePlayerXp = Math.round(
-			playerContestants.reduce(
-				(sum, contestant) => sum + Number(contestant.monster?.xp ?? 0),
-				0
-			) / playerContestants.length
-		);
-		const minBossXp = Math.max(0, averagePlayerXp - 20);
-		const maxBossXp = Math.max(minBossXp, averagePlayerXp + 40);
-		const scaledBossXp = Math.min(random(minBossXp, maxBossXp), BEGINNER_BOSS_MAX_XP);
-
-		return randomContestant({ xp: scaledBossXp });
+		const maxXp = getXpCapForLevel(levelCap);
+		return randomContestant({ xp: random(0, maxXp) });
 	}
 
 	startBossTimer(): void {

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -4,6 +4,7 @@ import { actionCard, monsterCard } from '../helpers/card.js';
 import { calculateXP } from '../helpers/experience.js';
 import { getTarget } from '../helpers/targeting-strategies.js';
 import { randomContestant } from '../helpers/bosses.js';
+import { getLevel } from '../helpers/levels.js';
 import { sortCardsAlphabetically } from '../cards/helpers/sort.js';
 import { shortDelay, veryShortDelay } from '../helpers/delay-times.js';
 import { uniqueCards } from '../cards/helpers/unique-cards.js';
@@ -28,21 +29,12 @@ const BOSS_HIGHEST_PLUS_ONE_WEIGHT_PERCENT = 30;
  * Level 0 cap is 49, level 1 cap is 99, level 2 cap is 149, etc.
  */
 const getXpCapForLevel = (targetLevel: number): number => {
-	if (targetLevel <= 0) return 49;
-
-	let prevPrevThreshold = 0;
-	let prevThreshold = 50;
-	let level = 0;
-	while (level <= targetLevel) {
-		const threshold = prevPrevThreshold + prevThreshold;
-		if (level === targetLevel) return threshold - 1;
-
-		prevPrevThreshold = prevThreshold;
-		prevThreshold = threshold;
-		level += 1;
+	const normalizedLevel = Math.max(0, Math.floor(targetLevel));
+	let xp = 0;
+	while (getLevel(xp + 1) <= normalizedLevel) {
+		xp += 1;
 	}
-
-	return 49;
+	return xp;
 };
 
 export interface Contestant {
@@ -949,21 +941,17 @@ export class Ring extends BaseClass {
 		return this.getRoomMonsterLevels();
 	}
 
-	private hasOnlyBeginnerPlayers(): boolean {
-		const levels = this.getPreferredBossScalingLevels();
-		return levels.length > 0 && levels.every(level => level <= BEGINNER_LEVEL_THRESHOLD);
-	}
-
 	/**
-	 * Beginner *room* timing and boss scaling: all player monsters are beginner-level, or there are
-	 * no player monsters in the ring yet (empty ring still uses beginner boss pacing — not full random).
+	 * Boss timing remains ring-focused so room-level fallback only changes boss level
+	 * selection, not spawn cadence. If the ring is empty we keep beginner pacing.
 	 */
-	private isBeginnerBossContext(): boolean {
-		return this.hasOnlyBeginnerPlayers() || this.getPreferredBossScalingLevels().length === 0;
+	private isBeginnerBossTimingContext(): boolean {
+		const ringLevels = this.getPlayerMonsterLevels();
+		return ringLevels.length === 0 || ringLevels.every(level => level <= BEGINNER_LEVEL_THRESHOLD);
 	}
 
 	private getBossSpawnOuterDelayMs(): number {
-		if (this.isBeginnerBossContext()) {
+		if (this.isBeginnerBossTimingContext()) {
 			return random(BOSS_SPAWN_BEGINNER_MIN_DELAY_MS, BOSS_SPAWN_BEGINNER_MAX_DELAY_MS);
 		}
 		return random(BOSS_SPAWN_MIN_DELAY_MS, BOSS_SPAWN_MAX_DELAY_MS);
@@ -975,6 +963,7 @@ export class Ring extends BaseClass {
 		}
 
 		if (playerLevels.length <= 0) {
+			// When no ring/room monsters are known, capped branches collapse to beginner cap.
 			return 0;
 		}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement weighted boss-level selection for ring boss spawns:
  - 20% keep the current fully random boss level distribution
  - 30% cap boss level at highest player monster level in ring + 1
  - 50% cap boss level at floor(average player monster level in ring)
- prioritize in-ring player monster levels for boss scaling; when ring has no player monsters, fall back to all player monster levels in the room
- keep boss spawn timing ring-focused (empty ring still uses beginner pacing), so room fallback affects level selection but not spawn cadence
- optimize level→XP cap lookup with exponential+binary search while still delegating level math to `getLevel()`
- ignore dead/destroyed room monsters in fallback level sourcing
- tighten roll announcement typing and behavior for partial roll payloads
- add tests for weighted boundaries, ring-priority/room-fallback source selection, ring-only timing context, dead/destroyed fallback filtering, partial roll announcements, and XP-cap boundary behavior

## Validation
- `pnpm --filter @deck-monsters/engine build && pnpm --filter @deck-monsters/engine test`
- `pnpm --filter @deck-monsters/engine test -- src/ring/index.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a089943d-7732-454d-a855-eb4e538f860f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a089943d-7732-454d-a855-eb4e538f860f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

