### PR TITLE
Fix cross-room ring announcement bleed between active rooms

### DIFF
--- a/packages/engine/src/announcements/index.ts
+++ b/packages/engine/src/announcements/index.ts
@@ -75,23 +75,29 @@ function createRoomScopedEventGuard(game: RoomScopedGame): (...args: any[]) => b
 		if (value === game || value === game.ring || value === game.exploration) return true;
 
 		const characters = Object.values(game.characters ?? {});
-		for (const character of characters) {
+		for (const character of characters as Array<RoomScopedCharacter | undefined>) {
 			if (value === character) return true;
 
-			const monsters = Array.isArray(character?.monsters) ? character.monsters : [];
+			const monsters: unknown[] = Array.isArray(character?.monsters) ? character.monsters : [];
 			if (monsters.includes(value)) return true;
 
-			const charItems = Array.isArray(character?.items) ? character.items : [];
+			const charItems: unknown[] = Array.isArray(character?.items) ? character.items : [];
 			if (charItems.includes(value)) return true;
 
-			const deck = Array.isArray(character?.deck) ? character.deck : [];
+			const deck: unknown[] = Array.isArray(character?.deck) ? character.deck : [];
 			if (deck.includes(value)) return true;
 
 			for (const monster of monsters) {
-				const cards = Array.isArray(monster?.cards) ? monster.cards : [];
+				const cards: unknown[] =
+					monster && typeof monster === 'object' && Array.isArray((monster as any).cards)
+						? (monster as any).cards
+						: [];
 				if (cards.includes(value)) return true;
 
-				const items = Array.isArray(monster?.items) ? monster.items : [];
+				const items: unknown[] =
+					monster && typeof monster === 'object' && Array.isArray((monster as any).items)
+						? (monster as any).items
+						: [];
 				if (items.includes(value)) return true;
 			}
 		}

--- a/packages/engine/src/announcements/index.ts
+++ b/packages/engine/src/announcements/index.ts
@@ -49,12 +49,32 @@ import { announceXPGain } from './xpGain.js';
 import { announceLevelUp } from './level-up.js';
 import type { RoomEventBus } from '../events/index.js';
 
-function createRoomScopedEventGuard(game: any): (...args: any[]) => boolean {
+const MAX_OWNERSHIP_WALK_DEPTH = 3;
+
+type RoomScopedCharacter = {
+	monsters?: unknown[];
+	items?: unknown[];
+	deck?: unknown[];
+};
+
+type RoomScopedGame = {
+	eventBus: RoomEventBus;
+	ring: {
+		on: (event: string, listener: (...args: any[]) => void) => (...args: any[]) => void;
+		off: (event: string, listener: (...args: any[]) => void) => void;
+	};
+	exploration: unknown;
+	characters?: Record<string, RoomScopedCharacter | undefined>;
+	on: (event: string, listener: (...args: any[]) => void) => (...args: any[]) => void;
+	off: (event: string, listener: (...args: any[]) => void) => void;
+};
+
+function createRoomScopedEventGuard(game: RoomScopedGame): (...args: any[]) => boolean {
 	const ownsDirectly = (value: unknown): boolean => {
 		if (!value || typeof value !== 'object') return false;
 		if (value === game || value === game.ring || value === game.exploration) return true;
 
-		const characters = Object.values((game.characters ?? {}) as Record<string, any>);
+		const characters = Object.values(game.characters ?? {});
 		for (const character of characters) {
 			if (value === character) return true;
 
@@ -80,11 +100,14 @@ function createRoomScopedEventGuard(game: any): (...args: any[]) => boolean {
 	};
 
 	return (...args: any[]): boolean => {
+		// Hot path: the emitting instance is almost always a top-level argument.
+		if (args.some((arg) => ownsDirectly(arg))) return true;
+
 		const visited = new WeakSet<object>();
 
 		const walk = (value: unknown, depth: number): boolean => {
 			if (ownsDirectly(value)) return true;
-			if (depth >= 3 || !value || typeof value !== 'object') return false;
+			if (depth >= MAX_OWNERSHIP_WALK_DEPTH || !value || typeof value !== 'object') return false;
 
 			if (visited.has(value)) return false;
 			visited.add(value);
@@ -104,7 +127,7 @@ function createRoomScopedEventGuard(game: any): (...args: any[]) => boolean {
 	};
 }
 
-export function initialize(game: any): () => void {
+export function initialize(game: RoomScopedGame): () => void {
 	const eb: RoomEventBus = game.eventBus;
 	const isRoomScopedEvent = createRoomScopedEventGuard(game);
 
@@ -140,8 +163,10 @@ export function initialize(game: any): () => void {
 		{ event: 'potion.used', listener: wrapGameEvent(announceItemUsed) },
 		{
 			event: 'creature.levelUp',
-			listener: (_className: string, _instance: any, { monster, level }: { monster: any; level: number }) =>
-				announceLevelUp(eb, monster, level),
+			listener: wrapGameEvent(
+				(_eb, _className: string, _instance: any, { monster, level }: { monster: any; level: number }) =>
+					announceLevelUp(_eb, monster, level)
+			),
 		},
 		{ event: 'scroll.narration', listener: wrapGameEvent(announceNarration) },
 		{ event: 'scroll.used', listener: wrapGameEvent(announceItemUsed) },

--- a/packages/engine/src/announcements/index.ts
+++ b/packages/engine/src/announcements/index.ts
@@ -49,53 +49,118 @@ import { announceXPGain } from './xpGain.js';
 import { announceLevelUp } from './level-up.js';
 import type { RoomEventBus } from '../events/index.js';
 
+function createRoomScopedEventGuard(game: any): (...args: any[]) => boolean {
+	const ownsDirectly = (value: unknown): boolean => {
+		if (!value || typeof value !== 'object') return false;
+		if (value === game || value === game.ring || value === game.exploration) return true;
+
+		const characters = Object.values((game.characters ?? {}) as Record<string, any>);
+		for (const character of characters) {
+			if (value === character) return true;
+
+			const monsters = Array.isArray(character?.monsters) ? character.monsters : [];
+			if (monsters.includes(value)) return true;
+
+			const charItems = Array.isArray(character?.items) ? character.items : [];
+			if (charItems.includes(value)) return true;
+
+			const deck = Array.isArray(character?.deck) ? character.deck : [];
+			if (deck.includes(value)) return true;
+
+			for (const monster of monsters) {
+				const cards = Array.isArray(monster?.cards) ? monster.cards : [];
+				if (cards.includes(value)) return true;
+
+				const items = Array.isArray(monster?.items) ? monster.items : [];
+				if (items.includes(value)) return true;
+			}
+		}
+
+		return false;
+	};
+
+	return (...args: any[]): boolean => {
+		const visited = new WeakSet<object>();
+
+		const walk = (value: unknown, depth: number): boolean => {
+			if (ownsDirectly(value)) return true;
+			if (depth >= 3 || !value || typeof value !== 'object') return false;
+
+			if (visited.has(value)) return false;
+			visited.add(value);
+
+			if (Array.isArray(value)) {
+				return value.some((entry) => walk(entry, depth + 1));
+			}
+
+			for (const nestedValue of Object.values(value as Record<string, unknown>)) {
+				if (walk(nestedValue, depth + 1)) return true;
+			}
+
+			return false;
+		};
+
+		return args.some((arg) => walk(arg, 0));
+	};
+}
+
 export function initialize(game: any): () => void {
 	const eb: RoomEventBus = game.eventBus;
+	const isRoomScopedEvent = createRoomScopedEventGuard(game);
 
-	const wrap = (fn: (eb: RoomEventBus, ...args: any[]) => void) =>
+	// game.on(...) listeners are wired to the process-wide semaphore, so we must
+	// explicitly gate events to entities owned by this specific room/game.
+	const wrapGameEvent = (fn: (eb: RoomEventBus, ...args: any[]) => void) =>
+		(...args: any[]) => {
+			if (!isRoomScopedEvent(...args)) return;
+			fn(eb, ...args);
+		};
+
+	// ring.on(...) listeners are already instance-scoped and do not need guarding.
+	const wrapRingEvent = (fn: (eb: RoomEventBus, ...args: any[]) => void) =>
 		(...args: any[]) => fn(eb, ...args);
 
 	const gameEvents: Array<{ event: string; listener: (...args: any[]) => void }> = [
-		{ event: 'card.effect', listener: wrap(announceEffect) },
-		{ event: 'card.miss', listener: wrap(announceMiss) },
-		{ event: 'card.narration', listener: wrap(announceNarration) },
-		{ event: 'card.played', listener: wrap(announceCardPlayed) },
-		{ event: 'card.rolled', listener: wrap(announceRolled) },
-		{ event: 'card.stay', listener: wrap(announceStay) },
-		{ event: 'cardDrop', listener: wrap(announceCardDrop) },
-		{ event: 'creature.die', listener: wrap(announceDeath) },
-		{ event: 'creature.hit', listener: wrap(announceHit) },
-		{ event: 'creature.leave', listener: wrap(announceLeave) },
-		{ event: 'creature.modifier', listener: wrap(announceModifier) },
-		{ event: 'creature.narration', listener: wrap(announceNarration) },
-		{ event: 'gainedXP', listener: wrap(announceXPGain) },
-		{ event: 'item.narration', listener: wrap(announceNarration) },
-		{ event: 'item.used', listener: wrap(announceItemUsed) },
-		{ event: 'potion.narration', listener: wrap(announceNarration) },
-		{ event: 'potion.used', listener: wrap(announceItemUsed) },
+		{ event: 'card.effect', listener: wrapGameEvent(announceEffect) },
+		{ event: 'card.miss', listener: wrapGameEvent(announceMiss) },
+		{ event: 'card.narration', listener: wrapGameEvent(announceNarration) },
+		{ event: 'card.played', listener: wrapGameEvent(announceCardPlayed) },
+		{ event: 'card.rolled', listener: wrapGameEvent(announceRolled) },
+		{ event: 'card.stay', listener: wrapGameEvent(announceStay) },
+		{ event: 'cardDrop', listener: wrapGameEvent(announceCardDrop) },
+		{ event: 'creature.die', listener: wrapGameEvent(announceDeath) },
+		{ event: 'creature.hit', listener: wrapGameEvent(announceHit) },
+		{ event: 'creature.leave', listener: wrapGameEvent(announceLeave) },
+		{ event: 'creature.modifier', listener: wrapGameEvent(announceModifier) },
+		{ event: 'creature.narration', listener: wrapGameEvent(announceNarration) },
+		{ event: 'gainedXP', listener: wrapGameEvent(announceXPGain) },
+		{ event: 'item.narration', listener: wrapGameEvent(announceNarration) },
+		{ event: 'item.used', listener: wrapGameEvent(announceItemUsed) },
+		{ event: 'potion.narration', listener: wrapGameEvent(announceNarration) },
+		{ event: 'potion.used', listener: wrapGameEvent(announceItemUsed) },
 		{
 			event: 'creature.levelUp',
 			listener: (_className: string, _instance: any, { monster, level }: { monster: any; level: number }) =>
 				announceLevelUp(eb, monster, level),
 		},
-		{ event: 'scroll.narration', listener: wrap(announceNarration) },
-		{ event: 'scroll.used', listener: wrap(announceItemUsed) },
+		{ event: 'scroll.narration', listener: wrapGameEvent(announceNarration) },
+		{ event: 'scroll.used', listener: wrapGameEvent(announceItemUsed) },
 	];
 
 	// Ring events must be bound to this room's ring instance (not game/global),
 	// otherwise the global emitter path can mirror ring announcements across rooms.
 	const ringEvents: Array<{ event: string; listener: (...args: any[]) => void }> = [
-		{ event: 'add', listener: wrap(announceContestant) },
-		{ event: 'bossWillSpawn', listener: wrap(announceBossWillSpawn) },
-		{ event: 'endOfDeck', listener: wrap(announceEndOfDeck) },
-		{ event: 'fight', listener: wrap(announceFight) },
-		{ event: 'fightConcludes', listener: wrap(announceFightConcludes) },
-		{ event: 'gainedXP', listener: wrap(announceXPGain) },
-		{ event: 'narration', listener: wrap(announceNarration) },
-		{ event: 'remove', listener: wrap(announceContestantLeave) },
-		{ event: 'roundComplete', listener: wrap(announceNextRound) },
-		{ event: 'startTurn', listener: wrap(announceNextTurn) },
-		{ event: 'playerTurnBegin', listener: wrap(announceTurnBegin) },
+		{ event: 'add', listener: wrapRingEvent(announceContestant) },
+		{ event: 'bossWillSpawn', listener: wrapRingEvent(announceBossWillSpawn) },
+		{ event: 'endOfDeck', listener: wrapRingEvent(announceEndOfDeck) },
+		{ event: 'fight', listener: wrapRingEvent(announceFight) },
+		{ event: 'fightConcludes', listener: wrapRingEvent(announceFightConcludes) },
+		{ event: 'gainedXP', listener: wrapRingEvent(announceXPGain) },
+		{ event: 'narration', listener: wrapRingEvent(announceNarration) },
+		{ event: 'remove', listener: wrapRingEvent(announceContestantLeave) },
+		{ event: 'roundComplete', listener: wrapRingEvent(announceNextRound) },
+		{ event: 'startTurn', listener: wrapRingEvent(announceNextTurn) },
+		{ event: 'playerTurnBegin', listener: wrapRingEvent(announceTurnBegin) },
 	];
 
 	// Collect bound listeners so they can be removed on dispose
@@ -113,6 +178,7 @@ export function initialize(game: any): () => void {
 
 	// heal is special: ring is passed as an extra argument before the standard args
 	const healListener = (...args: any[]) => {
+		if (!isRoomScopedEvent(...args)) return;
 		(announceHeal as (...a: any[]) => void)(eb, game.ring, ...args);
 	};
 	const boundHeal = game.on('creature.heal', healListener);

--- a/packages/engine/src/game.test.ts
+++ b/packages/engine/src/game.test.ts
@@ -56,6 +56,42 @@ describe('game.ts', () => {
 		}
 	});
 
+	it('does not mirror card-play announcements across active rooms', async () => {
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+		const roomAEvents: Array<{ type: string }> = [];
+		const roomBEvents: Array<{ type: string }> = [];
+
+		roomA.eventBus.subscribe('room-a-card-spy', {
+			deliver: (event) => roomAEvents.push({ type: event.type }),
+		});
+		roomB.eventBus.subscribe('room-b-card-spy', {
+			deliver: (event) => roomBEvents.push({ type: event.type }),
+		});
+
+		try {
+			const { HitCard } = await import('./cards/hit.js');
+			const Basilisk = (await import('./monsters/basilisk.js')).default;
+			const Beastmaster = (await import('./characters/beastmaster.js')).default;
+
+			const card = new HitCard();
+			const monster = new Basilisk({ name: 'Room A Monster' });
+			monster.cards = [card];
+
+			const character = new Beastmaster({ name: 'Room A Trainer' });
+			character.addMonster(monster);
+			roomA.characters['room-a-user'] = character;
+
+			card.emit('played', { player: monster });
+
+			expect(roomAEvents.some((event) => event.type === 'card.played')).to.equal(true);
+			expect(roomBEvents.some((event) => event.type === 'card.played')).to.equal(false);
+		} finally {
+			roomA.dispose();
+			roomB.dispose();
+		}
+	});
+
 	it('can look at the ring', () => {
 		const game = new Game();
 		const lookStub = sinon.stub(game.ring, 'look');

--- a/packages/engine/src/game.test.ts
+++ b/packages/engine/src/game.test.ts
@@ -8,6 +8,7 @@ import { BaseCard } from './cards/base.js';
 import Ring from './ring/index.js';
 import { RoomEventBus } from './events/index.js';
 import { engineReady } from './helpers/engine-ready.js';
+import { globalSemaphore } from './helpers/semaphore.js';
 
 describe('game.ts', () => {
 	afterEach(() => {
@@ -80,9 +81,9 @@ describe('game.ts', () => {
 
 			const character = new Beastmaster({ name: 'Room A Trainer' });
 			character.addMonster(monster);
-			roomA.characters['room-a-user'] = character;
+			roomA.characters = { ...roomA.characters, 'room-a-user': character };
 
-			card.emit('played', { player: monster });
+			globalSemaphore.emit('card.played', card.name, card, { player: monster });
 
 			expect(roomAEvents.some((event) => event.type === 'card.played')).to.equal(true);
 			expect(roomBEvents.some((event) => event.type === 'card.played')).to.equal(false);

--- a/packages/engine/src/game.test.ts
+++ b/packages/engine/src/game.test.ts
@@ -60,14 +60,14 @@ describe('game.ts', () => {
 	it('does not mirror card-play announcements across active rooms', async () => {
 		const roomA = new Game({ roomId: 'room-a' });
 		const roomB = new Game({ roomId: 'room-b' });
-		const roomAEvents: Array<{ type: string }> = [];
-		const roomBEvents: Array<{ type: string }> = [];
+		const roomAEvents: Array<{ type: string; text: string }> = [];
+		const roomBEvents: Array<{ type: string; text: string }> = [];
 
 		roomA.eventBus.subscribe('room-a-card-spy', {
-			deliver: (event) => roomAEvents.push({ type: event.type }),
+			deliver: (event) => roomAEvents.push({ type: event.type, text: event.text ?? '' }),
 		});
 		roomB.eventBus.subscribe('room-b-card-spy', {
-			deliver: (event) => roomBEvents.push({ type: event.type }),
+			deliver: (event) => roomBEvents.push({ type: event.type, text: event.text ?? '' }),
 		});
 
 		try {
@@ -87,6 +87,71 @@ describe('game.ts', () => {
 
 			expect(roomAEvents.some((event) => event.type === 'card.played')).to.equal(true);
 			expect(roomBEvents.some((event) => event.type === 'card.played')).to.equal(false);
+		} finally {
+			roomA.dispose();
+			roomB.dispose();
+		}
+	});
+
+	it('does not mirror level-up announcements across active rooms', async () => {
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+		const roomAEvents: Array<{ type: string; text: string }> = [];
+		const roomBEvents: Array<{ type: string; text: string }> = [];
+
+		roomA.eventBus.subscribe('room-a-levelup-spy', {
+			deliver: (event) => roomAEvents.push({ type: event.type, text: event.text ?? '' }),
+		});
+		roomB.eventBus.subscribe('room-b-levelup-spy', {
+			deliver: (event) => roomBEvents.push({ type: event.type, text: event.text ?? '' }),
+		});
+
+		try {
+			const Basilisk = (await import('./monsters/basilisk.js')).default;
+			const Beastmaster = (await import('./characters/beastmaster.js')).default;
+
+			const monster = new Basilisk({ name: 'Room A Leveler' });
+			const character = new Beastmaster({ name: 'Room A Trainer' });
+			character.addMonster(monster);
+			roomA.characters = { ...roomA.characters, 'room-a-user': character };
+
+			globalSemaphore.emit('creature.levelUp', monster.name, monster, { monster, level: 2 });
+
+			expect(roomAEvents.some((event) => event.text.includes('has reached level 2'))).to.equal(true);
+			expect(roomBEvents.some((event) => event.text.includes('has reached level 2'))).to.equal(false);
+		} finally {
+			roomA.dispose();
+			roomB.dispose();
+		}
+	});
+
+	it('does not mirror heal announcements across active rooms', async () => {
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+		const roomAEvents: Array<{ type: string; text: string }> = [];
+		const roomBEvents: Array<{ type: string; text: string }> = [];
+
+		roomA.eventBus.subscribe('room-a-heal-spy', {
+			deliver: (event) => roomAEvents.push({ type: event.type, text: event.text ?? '' }),
+		});
+		roomB.eventBus.subscribe('room-b-heal-spy', {
+			deliver: (event) => roomBEvents.push({ type: event.type, text: event.text ?? '' }),
+		});
+
+		try {
+			const Basilisk = (await import('./monsters/basilisk.js')).default;
+			const Beastmaster = (await import('./characters/beastmaster.js')).default;
+
+			const monster = new Basilisk({ name: 'Room A Healer' });
+			const character = new Beastmaster({ name: 'Room A Trainer' });
+			character.addMonster(monster);
+			roomA.characters = { ...roomA.characters, 'room-a-user': character };
+			roomA.ring.contestants = [{ monster, character, userId: 'room-a-user' }] as any;
+
+			globalSemaphore.emit('creature.heal', monster.name, monster, { amount: 2 });
+
+			expect(roomAEvents.some((event) => event.text.includes('healed 2 hp'))).to.equal(true);
+			expect(roomBEvents.some((event) => event.text.includes('healed 2 hp'))).to.equal(false);
 		} finally {
 			roomA.dispose();
 			roomB.dispose();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- guard `creature.levelUp` via `wrapGameEvent` so level-up announcements cannot leak across active rooms
- tighten the ownership guard with a typed `RoomScopedGame` shape, top-level fast-path checks, and a named max depth constant
- keep the previous card-play coverage and add explicit regressions for level-up and heal leakage across two concurrent rooms
- fix strict TypeScript typing in guard traversal to keep the engine build clean

## Testing
- `pnpm --filter @deck-monsters/engine build`
- `pnpm --filter @deck-monsters/engine exec mocha src/game.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ded0135-c63c-4b01-ab99-3ff3c2b4870b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ded0135-c63c-4b01-ab99-3ff3c2b4870b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

