### PR TITLE
Implement card management engine and server foundations

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import RoomSettingsView from './views/RoomSettingsView.js';
 import AccountView from './views/AccountView.js';
 import LeaderboardView from './views/LeaderboardView.js';
 import FightLogView from './views/FightLogView.js';
+import WorkshopView from './views/WorkshopView.js';
 import { trpc } from './lib/trpc.js';
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
@@ -203,6 +204,15 @@ export default function App() {
         element={
           <RequireAuth>
             <FightLogView />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/room/:roomId/workshop"
+        element={
+          <RequireAuth>
+            <WorkshopView />
           </RequireAuth>
         }
       />

--- a/apps/web/src/__tests__/cards-utils.test.ts
+++ b/apps/web/src/__tests__/cards-utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { abbreviateCardName } from '../utils/cards.js';
+
+describe('abbreviateCardName', () => {
+	it('returns short names unchanged', () => {
+		expect(abbreviateCardName('Hit')).toBe('Hit');
+	});
+
+	it('shortens multi-word card names', () => {
+		expect(abbreviateCardName('Adrenaline Rush')).toBe('AdrR');
+		expect(abbreviateCardName('Battle Focus')).toBe('BatF');
+	});
+});

--- a/apps/web/src/__tests__/cards-utils.test.ts
+++ b/apps/web/src/__tests__/cards-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { abbreviateCardName } from '../utils/cards.js';
+import { abbreviateCardName, getCardClass } from '../utils/cards.js';
 
 describe('abbreviateCardName', () => {
 	it('returns short names unchanged', () => {
@@ -10,5 +10,17 @@ describe('abbreviateCardName', () => {
 	it('shortens multi-word card names', () => {
 		expect(abbreviateCardName('Adrenaline Rush')).toBe('AdrR');
 		expect(abbreviateCardName('Battle Focus')).toBe('BatF');
+	});
+});
+
+describe('getCardClass', () => {
+	it('matches keyword groups case-insensitively', () => {
+		expect(getCardClass('Whiskey Shot')).toBe('heal');
+		expect(getCardClass('HIT')).toBe('melee');
+		expect(getCardClass('Blink')).toBe('magic');
+	});
+
+	it('falls back to utility for unmatched names', () => {
+		expect(getCardClass('Mystery Card')).toBe('utility');
 	});
 });

--- a/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
+++ b/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MonsterWorkshopPanel from '../components/MonsterWorkshopPanel.js';
+
+const baseMonster = {
+  name: 'Stonefang',
+  type: 'Basilisk',
+  level: 3,
+  inRing: true,
+  inEncounter: false,
+  cardSlots: 1,
+  cards: [null] as Array<string | null>,
+  presets: {},
+};
+
+describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
+  it('allows dropping into monster slots while in ring but not in encounter', async () => {
+    const onDropCard = vi.fn(async () => undefined);
+    render(
+      <MonsterWorkshopPanel
+        monster={{
+          ...baseMonster,
+          cards: [],
+        }}
+        selectedMonsterName={null}
+        selectedCard={null}
+        onDropCard={onDropCard}
+        onTapSlot={() => undefined}
+        onSelectCard={() => undefined}
+        onSavePreset={() => undefined}
+        onLoadPreset={() => undefined}
+        onDeletePreset={() => undefined}
+      />,
+    );
+
+    const targetSlot = screen.getByRole('button', { name: 'Empty slot' });
+    expect(targetSlot).not.toHaveAttribute('disabled');
+
+    const dataTransfer = {
+      store: {} as Record<string, string>,
+      setData(type: string, value: string) {
+        this.store[type] = value;
+      },
+      getData(type: string) {
+        return this.store[type] ?? '';
+      },
+      effectAllowed: 'none',
+    };
+    dataTransfer.setData(
+      'application/x-deck-monsters-card',
+      JSON.stringify({ location: { kind: 'inventory' }, cardName: 'Hit' }),
+    );
+
+    fireEvent.dragOver(targetSlot, { dataTransfer });
+    fireEvent.drop(targetSlot, { dataTransfer });
+
+    expect(onDropCard).toHaveBeenCalledTimes(1);
+    expect(onDropCard).toHaveBeenCalledWith({ kind: 'inventory' }, 'Hit');
+  });
+
+  it('keeps monster slots locked during an encounter', () => {
+    const onDropCard = vi.fn(async () => undefined);
+    render(
+      <MonsterWorkshopPanel
+        monster={{
+          ...baseMonster,
+          inRing: true,
+          inEncounter: true,
+          cards: [],
+        }}
+        selectedMonsterName={null}
+        selectedCard={null}
+        onDropCard={onDropCard}
+        onTapSlot={() => undefined}
+        onSelectCard={() => undefined}
+        onSavePreset={() => undefined}
+        onLoadPreset={() => undefined}
+        onDeletePreset={() => undefined}
+      />,
+    );
+
+    const targetSlot = screen.getByRole('button', { name: 'Empty slot' });
+    expect(targetSlot).toHaveAttribute('disabled');
+  });
+});

--- a/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
+++ b/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
@@ -9,7 +9,7 @@ const baseMonster = {
   inRing: true,
   inEncounter: false,
   cardSlots: 1,
-  cards: [null] as Array<string | null>,
+  cards: [] as string[],
   presets: {},
 };
 
@@ -22,7 +22,7 @@ describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
           ...baseMonster,
           cards: [],
         }}
-        selectedMonsterName={null}
+        showSelectionHint={false}
         selectedCard={null}
         onDropCard={onDropCard}
         onTapSlot={() => undefined}
@@ -68,7 +68,7 @@ describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
           inEncounter: true,
           cards: [],
         }}
-        selectedMonsterName={null}
+        showSelectionHint={false}
         selectedCard={null}
         onDropCard={onDropCard}
         onTapSlot={() => undefined}
@@ -81,5 +81,30 @@ describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
 
     const targetSlot = screen.getByRole('button', { name: 'Empty slot' });
     expect(targetSlot).toHaveAttribute('disabled');
+  });
+
+  it('treats occupied slot taps as destination taps when a card is selected', () => {
+    const onTapSlot = vi.fn();
+    const onSelectCard = vi.fn();
+    render(
+      <MonsterWorkshopPanel
+        monster={{
+          ...baseMonster,
+          cards: ['Hit'],
+        }}
+        showSelectionHint
+        selectedCard={{ location: { kind: 'inventory' }, cardName: 'Heal' }}
+        onDropCard={() => undefined}
+        onTapSlot={onTapSlot}
+        onSelectCard={onSelectCard}
+        onSavePreset={() => undefined}
+        onLoadPreset={() => undefined}
+        onDeletePreset={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hit' }));
+    expect(onTapSlot).toHaveBeenCalledWith({ kind: 'monster', monsterName: 'Stonefang' });
+    expect(onSelectCard).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/__tests__/useDeckWorkshop.test.ts
+++ b/apps/web/src/__tests__/useDeckWorkshop.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('useDeckWorkshop cache helpers', () => {
+	it('placeholder sanity test for workshop hook module', () => {
+		expect(true).toBe(true);
+	});
+});

--- a/apps/web/src/__tests__/useDeckWorkshop.test.ts
+++ b/apps/web/src/__tests__/useDeckWorkshop.test.ts
@@ -1,7 +1,102 @@
-import { describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('useDeckWorkshop cache helpers', () => {
-	it('placeholder sanity test for workshop hook module', () => {
-		expect(true).toBe(true);
-	});
+const mocks = vi.hoisted(() => {
+  const inventoryInvalidate = vi.fn(async () => undefined);
+  const monstersInvalidate = vi.fn(async () => undefined);
+  const roomInfoUseQuery = vi.fn();
+  const myInventoryUseQuery = vi.fn();
+  const defaultMutation = vi.fn((options?: { onSuccess?: () => Promise<void> }) => ({
+    isPending: false,
+    error: null,
+    mutateAsync: vi.fn(async () => {
+      await options?.onSuccess?.();
+      return { equippedCount: 1, requestedCount: 1, skippedCards: [] };
+    }),
+  }));
+
+  return {
+    inventoryInvalidate,
+    monstersInvalidate,
+    roomInfoUseQuery,
+    myInventoryUseQuery,
+    unequipCardUseMutation: vi.fn(defaultMutation),
+    unequipAllUseMutation: vi.fn(defaultMutation),
+    equipCardsUseMutation: vi.fn(defaultMutation),
+    moveCardUseMutation: vi.fn(defaultMutation),
+    savePresetUseMutation: vi.fn(defaultMutation),
+    loadPresetUseMutation: vi.fn(defaultMutation),
+    deletePresetUseMutation: vi.fn(defaultMutation),
+  };
+});
+
+vi.mock('../lib/trpc.js', () => ({
+  trpc: {
+    useUtils: () => ({
+      game: {
+        myInventory: { invalidate: mocks.inventoryInvalidate },
+        myMonsters: { invalidate: mocks.monstersInvalidate },
+      },
+    }),
+    room: {
+      info: {
+        useQuery: mocks.roomInfoUseQuery,
+      },
+    },
+    game: {
+      myInventory: {
+        useQuery: mocks.myInventoryUseQuery,
+      },
+      unequipCard: { useMutation: mocks.unequipCardUseMutation },
+      unequipAll: { useMutation: mocks.unequipAllUseMutation },
+      equipCards: { useMutation: mocks.equipCardsUseMutation },
+      moveCard: { useMutation: mocks.moveCardUseMutation },
+      savePreset: { useMutation: mocks.savePresetUseMutation },
+      loadPreset: { useMutation: mocks.loadPresetUseMutation },
+      deletePreset: { useMutation: mocks.deletePresetUseMutation },
+    },
+  },
+}));
+
+import { useDeckWorkshop } from '../hooks/useDeckWorkshop.js';
+
+describe('useDeckWorkshop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.roomInfoUseQuery.mockReturnValue({
+      data: { name: 'Test Room' },
+      isLoading: false,
+    });
+    mocks.myInventoryUseQuery.mockReturnValue({
+      data: { monsters: [], unequippedDeck: [], items: { character: [], monsters: [] } },
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('invalidates inventory and monster queries after successful mutation', async () => {
+    const { result } = renderHook(() => useDeckWorkshop('room-123'));
+
+    await act(async () => {
+      await result.current.equipCards({
+        monsterName: 'Stonefang',
+        cardNames: ['Hit'],
+      });
+    });
+
+    expect(mocks.inventoryInvalidate).toHaveBeenCalledWith({ roomId: 'room-123' });
+    expect(mocks.monstersInvalidate).toHaveBeenCalledWith({ roomId: 'room-123' });
+  });
+
+  it('throws when room is missing for mutation calls', async () => {
+    const { result } = renderHook(() => useDeckWorkshop(undefined));
+
+    await expect(
+      result.current.equipCards({
+        monsterName: 'Stonefang',
+        cardNames: ['Hit'],
+      }),
+    ).rejects.toThrow('Room not selected');
+  });
 });

--- a/apps/web/src/__tests__/useDeckWorkshop.test.ts
+++ b/apps/web/src/__tests__/useDeckWorkshop.test.ts
@@ -92,11 +92,11 @@ describe('useDeckWorkshop', () => {
   it('throws when room is missing for mutation calls', async () => {
     const { result } = renderHook(() => useDeckWorkshop(undefined));
 
-    await expect(
+    expect(() =>
       result.current.equipCards({
         monsterName: 'Stonefang',
         cardNames: ['Hit'],
       }),
-    ).rejects.toThrow('Room not selected');
+    ).toThrow('Room not selected');
   });
 });

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -105,6 +105,11 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
             Leaderboard
           </Link>
           {roomId && (
+            <Link to={`/room/${roomId}/workshop`} className="btn" style={{ fontSize: '0.8rem' }}>
+              Workshop
+            </Link>
+          )}
+          {roomId && (
             <Link to={`/room/${roomId}/fights`} className="btn" style={{ fontSize: '0.8rem' }}>
               Fight log
             </Link>
@@ -179,6 +184,11 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
             >
               Leaderboard
             </Link>
+            {roomId && (
+              <Link to={`/room/${roomId}/workshop`} className="btn" onClick={() => setMenuOpen(false)}>
+                Workshop
+              </Link>
+            )}
             {roomId && (
               <Link to={`/room/${roomId}/fights`} className="btn" onClick={() => setMenuOpen(false)}>
                 Fight log

--- a/apps/web/src/components/CardSlot.tsx
+++ b/apps/web/src/components/CardSlot.tsx
@@ -1,4 +1,4 @@
-import { abbreviateCardName, classifyCard, getCardEmoji } from '../utils/cards.js';
+import { abbreviateCardName, getCardClass, getCardEmoji } from '../utils/cards.js';
 
 export type WorkshopCardLocation =
   | { kind: 'inventory' }
@@ -25,7 +25,7 @@ export default function CardSlot({
   onDropCard,
   onTapSlot,
 }: CardSlotProps) {
-  const cardClass = cardName ? classifyCard(cardName) : 'utility';
+  const cardClass = cardName ? getCardClass(cardName) : 'utility';
 
   async function handleDrop(event: React.DragEvent<HTMLButtonElement>) {
     if (disabled) return;
@@ -67,7 +67,7 @@ export default function CardSlot({
     <button
       type="button"
       className={[
-        'card-slot',
+        'workshop-card-slot',
         cardName ? `class-${cardClass}` : 'empty',
         isDropActive ? 'drop-over' : '',
         selected ? 'selected' : '',
@@ -86,9 +86,9 @@ export default function CardSlot({
     >
       {cardName ? (
         <>
-          <span className="card-slot-icon">{getCardEmoji(cardName)}</span>
-          <span className="card-slot-name">{abbreviateCardName(cardName)}</span>
-          <span className="card-slot-class">{cardClass}</span>
+          <span className="workshop-card-icon">{getCardEmoji(cardName)}</span>
+          <span className="workshop-card-name">{abbreviateCardName(cardName)}</span>
+          <span className="workshop-card-class">{cardClass}</span>
         </>
       ) : (
         <span>[+]</span>

--- a/apps/web/src/components/CardSlot.tsx
+++ b/apps/web/src/components/CardSlot.tsx
@@ -1,0 +1,98 @@
+import { abbreviateCardName, classifyCard, getCardEmoji } from '../utils/cards.js';
+
+export type WorkshopCardLocation =
+  | { kind: 'inventory' }
+  | { kind: 'monster'; monsterName: string };
+
+interface CardSlotProps {
+  location: WorkshopCardLocation;
+  cardName: string | null;
+  isDropActive?: boolean;
+  disabled?: boolean;
+  selected?: boolean;
+  onSelectCard?: (location: WorkshopCardLocation, cardName: string) => void;
+  onDropCard?: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
+  onTapSlot?: (target: WorkshopCardLocation) => Promise<void> | void;
+}
+
+export default function CardSlot({
+  location,
+  cardName,
+  isDropActive = false,
+  disabled = false,
+  selected = false,
+  onSelectCard,
+  onDropCard,
+  onTapSlot,
+}: CardSlotProps) {
+  const cardClass = cardName ? classifyCard(cardName) : 'utility';
+
+  async function handleDrop(event: React.DragEvent<HTMLButtonElement>) {
+    if (disabled) return;
+    const payload = event.dataTransfer.getData('application/x-deck-monsters-card');
+    if (!payload) return;
+    event.preventDefault();
+    try {
+      const parsed = JSON.parse(payload) as { location: WorkshopCardLocation; cardName: string };
+      await onDropCard?.(parsed.location, parsed.cardName);
+    } catch {
+      // Ignore malformed payloads.
+    }
+  }
+
+  function handleDragOver(event: React.DragEvent<HTMLButtonElement>) {
+    if (disabled) return;
+    event.preventDefault();
+  }
+
+  function handleDragStart(event: React.DragEvent<HTMLButtonElement>) {
+    if (!cardName || disabled) return;
+    event.dataTransfer.setData(
+      'application/x-deck-monsters-card',
+      JSON.stringify({ location, cardName }),
+    );
+    event.dataTransfer.effectAllowed = 'move';
+  }
+
+  async function handleClick() {
+    if (disabled) return;
+    if (cardName) {
+      onSelectCard?.(location, cardName);
+      return;
+    }
+    await onTapSlot?.(location);
+  }
+
+  return (
+    <button
+      type="button"
+      className={[
+        'card-slot',
+        cardName ? `class-${cardClass}` : 'empty',
+        isDropActive ? 'drop-over' : '',
+        selected ? 'selected' : '',
+        disabled ? 'disabled' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      disabled={disabled}
+      draggable={Boolean(cardName && !disabled)}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDrop={(event) => void handleDrop(event)}
+      onClick={() => void handleClick()}
+      title={cardName ?? 'Empty slot'}
+      aria-label={cardName ?? 'Empty slot'}
+    >
+      {cardName ? (
+        <>
+          <span className="card-slot-icon">{getCardEmoji(cardName)}</span>
+          <span className="card-slot-name">{abbreviateCardName(cardName)}</span>
+          <span className="card-slot-class">{cardClass}</span>
+        </>
+      ) : (
+        <span>[+]</span>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/CardSlot.tsx
+++ b/apps/web/src/components/CardSlot.tsx
@@ -10,6 +10,7 @@ interface CardSlotProps {
   isDropActive?: boolean;
   disabled?: boolean;
   selected?: boolean;
+  hasActiveSelection?: boolean;
   onSelectCard?: (location: WorkshopCardLocation, cardName: string) => void;
   onDropCard?: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
   onTapSlot?: (target: WorkshopCardLocation) => Promise<void> | void;
@@ -21,6 +22,7 @@ export default function CardSlot({
   isDropActive = false,
   disabled = false,
   selected = false,
+  hasActiveSelection = false,
   onSelectCard,
   onDropCard,
   onTapSlot,
@@ -56,7 +58,7 @@ export default function CardSlot({
 
   async function handleClick() {
     if (disabled) return;
-    if (cardName) {
+    if (cardName && !hasActiveSelection) {
       onSelectCard?.(location, cardName);
       return;
     }

--- a/apps/web/src/components/InventoryPanel.tsx
+++ b/apps/web/src/components/InventoryPanel.tsx
@@ -40,6 +40,8 @@ export default function InventoryPanel({
                 selectedCard?.location.kind === 'inventory' &&
                 selectedCard.cardName === cardName
               }
+              hasActiveSelection={Boolean(selectedCard)}
+              onTapSlot={() => onTapSlot()}
               onSelectCard={onSelectCard}
             />
           ))}

--- a/apps/web/src/components/InventoryPanel.tsx
+++ b/apps/web/src/components/InventoryPanel.tsx
@@ -1,0 +1,79 @@
+import CardSlot, { type WorkshopCardLocation } from './CardSlot.js';
+
+interface InventoryPanelProps {
+  cards: string[];
+  selectedCard: {
+    location: WorkshopCardLocation;
+    cardName: string;
+  } | null;
+  onDropCard: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
+  onTapSlot: () => Promise<void> | void;
+  onSelectCard: (location: WorkshopCardLocation, cardName: string) => void;
+}
+
+export default function InventoryPanel({
+  cards,
+  selectedCard,
+  onDropCard,
+  onTapSlot,
+  onSelectCard,
+}: InventoryPanelProps) {
+  const location: WorkshopCardLocation = { kind: 'inventory' };
+
+  return (
+    <section className="workshop-inventory">
+      <header className="workshop-section-header">
+        <h2>Your Inventory</h2>
+        <span>{cards.length} unequipped cards</span>
+      </header>
+
+      {cards.length < 1 ? (
+        <div className="workshop-empty-state">No unequipped cards.</div>
+      ) : (
+        <div className="workshop-card-grid inventory-grid">
+          {cards.map((cardName, index) => (
+            <CardSlot
+              key={`${cardName}-${index}`}
+              location={location}
+              cardName={cardName}
+              selected={
+                selectedCard?.location.kind === 'inventory' &&
+                selectedCard.cardName === cardName
+              }
+              onSelectCard={onSelectCard}
+            />
+          ))}
+        </div>
+      )}
+
+      <div
+        className="workshop-drop-zone"
+        onDrop={(event) => {
+          event.preventDefault();
+          const payload = event.dataTransfer.getData('application/x-deck-monsters-card');
+          if (!payload) return;
+          try {
+            const parsed = JSON.parse(payload) as { location: WorkshopCardLocation; cardName: string };
+            void onDropCard(parsed.location, parsed.cardName);
+          } catch {
+            // Ignore malformed payloads.
+          }
+        }}
+        onDragOver={(event) => event.preventDefault()}
+        onClick={() => {
+          void onTapSlot();
+        }}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            void onTapSlot();
+          }
+        }}
+      >
+        Drop here to unequip from monster
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/MonsterWorkshopPanel.tsx
+++ b/apps/web/src/components/MonsterWorkshopPanel.tsx
@@ -13,7 +13,7 @@ type MonsterPanelProps = {
     cards: string[];
     presets: Record<string, string[]>;
   };
-  selectedMonsterName: string | null;
+  showSelectionHint: boolean;
   selectedCard: { location: WorkshopCardLocation; cardName: string } | null;
   onDropCard: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
   onTapSlot: (target: WorkshopCardLocation) => void;
@@ -25,7 +25,7 @@ type MonsterPanelProps = {
 
 export default function MonsterWorkshopPanel({
   monster,
-  selectedMonsterName,
+  showSelectionHint,
   selectedCard,
   onDropCard,
   onTapSlot,
@@ -80,6 +80,7 @@ export default function MonsterWorkshopPanel({
                 selectedCard.location.monsterName === monster.name &&
                 selectedCard.cardName === cardName
               }
+              hasActiveSelection={Boolean(selectedCard)}
               disabled={locked}
               onSelectCard={onSelectCard}
               onTapSlot={onTapSlot}
@@ -91,13 +92,14 @@ export default function MonsterWorkshopPanel({
 
       <PresetControl
         presets={monster.presets ?? {}}
+        monsterName={monster.name}
         onLoad={onLoadPreset}
         onSave={onSavePreset}
         onDelete={onDeletePreset}
         disabled={locked}
       />
 
-      {selectedMonsterName === monster.name && (
+      {showSelectionHint && (
         <div className="workshop-mobile-hint">
           Tap destination slot or inventory to move selected card.
         </div>

--- a/apps/web/src/components/MonsterWorkshopPanel.tsx
+++ b/apps/web/src/components/MonsterWorkshopPanel.tsx
@@ -34,7 +34,7 @@ export default function MonsterWorkshopPanel({
   onLoadPreset,
   onDeletePreset,
 }: MonsterPanelProps) {
-  const locked = monster.inRing || monster.inEncounter;
+  const locked = monster.inEncounter;
   const slots = useMemo(() => {
     const total = Math.max(monster.cardSlots, 1);
     return Array.from({ length: total }, (_, idx) => monster.cards[idx] ?? null);

--- a/apps/web/src/components/MonsterWorkshopPanel.tsx
+++ b/apps/web/src/components/MonsterWorkshopPanel.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import CardSlot, { type WorkshopCardLocation } from './CardSlot.js';
+import PresetControl from './PresetControl.js';
+
+type MonsterPanelProps = {
+  monster: {
+    name: string;
+    type: string;
+    level: number;
+    inRing: boolean;
+    inEncounter: boolean;
+    cardSlots: number;
+    cards: string[];
+    presets: Record<string, string[]>;
+  };
+  selectedMonsterName: string | null;
+  selectedCard: { location: WorkshopCardLocation; cardName: string } | null;
+  onDropCard: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
+  onTapSlot: (target: WorkshopCardLocation) => void;
+  onSelectCard: (location: WorkshopCardLocation, cardName: string) => void;
+  onSavePreset: (presetName: string) => void;
+  onLoadPreset: (presetName: string) => void;
+  onDeletePreset: (presetName: string) => void;
+};
+
+export default function MonsterWorkshopPanel({
+  monster,
+  selectedMonsterName,
+  selectedCard,
+  onDropCard,
+  onTapSlot,
+  onSelectCard,
+  onSavePreset,
+  onLoadPreset,
+  onDeletePreset,
+}: MonsterPanelProps) {
+  const locked = monster.inRing || monster.inEncounter;
+  const slots = useMemo(() => {
+    const total = Math.max(monster.cardSlots, 1);
+    return Array.from({ length: total }, (_, idx) => monster.cards[idx] ?? null);
+  }, [monster.cardSlots, monster.cards]);
+  const usagePct = Math.min(100, Math.round((monster.cards.length / Math.max(monster.cardSlots, 1)) * 100));
+
+  return (
+    <section className={`workshop-monster-panel${monster.inRing ? ' in-ring' : ''}${locked ? ' locked' : ''}`}>
+      <div className="workshop-monster-header">
+        <div>
+          <h3>{monster.name}</h3>
+          <p>
+            {monster.type}, L{monster.level}
+          </p>
+        </div>
+        <div className="workshop-slot-meter" aria-label={`${monster.cards.length} of ${monster.cardSlots} slots used`}>
+          <div style={{ width: `${usagePct}%` }} />
+          <span>{monster.cards.length}/{monster.cardSlots} slots</span>
+        </div>
+      </div>
+
+      {locked && (
+        <p className="workshop-warning">
+          {monster.name} is currently fighting. Changes apply after they return.
+        </p>
+      )}
+
+      <div className="workshop-slot-grid">
+        {slots.map((cardName, idx) => {
+          const location: WorkshopCardLocation = {
+            kind: 'monster',
+            monsterName: monster.name,
+          };
+          return (
+            <CardSlot
+              key={`${monster.name}-${idx}`}
+              cardName={cardName}
+              location={location}
+              isDropActive={false}
+              selected={
+                !!selectedCard &&
+                selectedCard.location.kind === 'monster' &&
+                selectedCard.location.monsterName === monster.name &&
+                selectedCard.cardName === cardName
+              }
+              disabled={locked}
+              onSelectCard={onSelectCard}
+              onTapSlot={onTapSlot}
+              onDropCard={onDropCard}
+            />
+          );
+        })}
+      </div>
+
+      <PresetControl
+        presets={monster.presets ?? {}}
+        onLoad={onLoadPreset}
+        onSave={onSavePreset}
+        onDelete={onDeletePreset}
+        disabled={locked}
+      />
+
+      {selectedMonsterName === monster.name && (
+        <div className="workshop-mobile-hint">
+          Tap destination slot or inventory to move selected card.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/PresetControl.tsx
+++ b/apps/web/src/components/PresetControl.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+
+interface PresetControlProps {
+  presets: Record<string, string[]>;
+  onLoad: (presetName: string) => Promise<void> | void;
+  onSave: (presetName: string) => Promise<void> | void;
+  onDelete: (presetName: string) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+export default function PresetControl({
+  presets,
+  onLoad,
+  onSave,
+  onDelete,
+  disabled = false,
+}: PresetControlProps) {
+  const [selectedPreset, setSelectedPreset] = useState('');
+  const [newPresetName, setNewPresetName] = useState('');
+
+  const presetNames = Object.keys(presets).sort((a, b) => a.localeCompare(b));
+
+  return (
+    <div className="workshop-presets">
+      <label className="workshop-subheading" htmlFor="preset-select">
+        Presets
+      </label>
+      <div className="workshop-preset-row">
+        <select
+          id="preset-select"
+          className="workshop-select"
+          value={selectedPreset}
+          disabled={disabled}
+          onChange={(event) => setSelectedPreset(event.target.value)}
+        >
+          <option value="">Select preset</option>
+          {presetNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="btn"
+          disabled={disabled || !selectedPreset}
+          onClick={() => void onLoad(selectedPreset)}
+        >
+          Load
+        </button>
+        <button
+          type="button"
+          className="btn"
+          disabled={disabled || !selectedPreset}
+          onClick={() => void onDelete(selectedPreset)}
+        >
+          Delete
+        </button>
+      </div>
+      <div className="workshop-preset-row">
+        <input
+          type="text"
+          className="workshop-input"
+          placeholder="Save as..."
+          value={newPresetName}
+          disabled={disabled}
+          onChange={(event) => setNewPresetName(event.target.value)}
+        />
+        <button
+          type="button"
+          className="btn"
+          disabled={disabled || newPresetName.trim().length < 1}
+          onClick={async () => {
+            const name = newPresetName.trim();
+            if (!name) return;
+            await onSave(name);
+            setNewPresetName('');
+            setSelectedPreset(name);
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PresetControl.tsx
+++ b/apps/web/src/components/PresetControl.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 interface PresetControlProps {
+  monsterName: string;
   presets: Record<string, string[]>;
   onLoad: (presetName: string) => Promise<void> | void;
   onSave: (presetName: string) => Promise<void> | void;
@@ -9,12 +10,15 @@ interface PresetControlProps {
 }
 
 export default function PresetControl({
+  monsterName,
   presets,
   onLoad,
   onSave,
   onDelete,
   disabled = false,
 }: PresetControlProps) {
+  const baseId = useId();
+  const selectId = `${baseId}-${monsterName.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'monster'}-preset-select`;
   const [selectedPreset, setSelectedPreset] = useState('');
   const [newPresetName, setNewPresetName] = useState('');
 
@@ -22,12 +26,12 @@ export default function PresetControl({
 
   return (
     <div className="workshop-presets">
-      <label className="workshop-subheading" htmlFor="preset-select">
+      <label className="workshop-subheading" htmlFor={selectId}>
         Presets
       </label>
       <div className="workshop-preset-row">
         <select
-          id="preset-select"
+          id={selectId}
           className="workshop-select"
           value={selectedPreset}
           disabled={disabled}

--- a/apps/web/src/hooks/useDeckWorkshop.ts
+++ b/apps/web/src/hooks/useDeckWorkshop.ts
@@ -1,0 +1,141 @@
+import { useMemo } from 'react';
+import { trpc } from '../lib/trpc.js';
+
+type WorkshopMonster = {
+  name: string;
+  type: string;
+  level: number;
+  inRing: boolean;
+  inEncounter: boolean;
+  cardSlots: number;
+  cards: string[];
+  presets: Record<string, string[]>;
+};
+
+type WorkshopInventory = {
+  monsters: WorkshopMonster[];
+  unequippedDeck: string[];
+  items: {
+    character: string[];
+    monsters: Array<{ monsterName: string; items: string[] }>;
+  };
+};
+
+const EMPTY_INVENTORY: WorkshopInventory = {
+  monsters: [],
+  unequippedDeck: [],
+  items: {
+    character: [],
+    monsters: [],
+  },
+};
+
+export function useDeckWorkshop(roomId?: string) {
+  const validRoomId = roomId ?? '';
+  const utils = trpc.useUtils();
+
+  const roomQuery = trpc.room.info.useQuery(
+    { roomId: validRoomId },
+    { enabled: !!roomId },
+  );
+  const inventoryQuery = trpc.game.myInventory.useQuery(
+    { roomId: validRoomId },
+    {
+      enabled: !!roomId,
+      refetchInterval: 30_000,
+    },
+  );
+
+  const invalidateWorkshop = async () => {
+    if (!roomId) return;
+    await utils.game.myInventory.invalidate({ roomId });
+    await utils.game.myMonsters.invalidate({ roomId });
+  };
+
+  const mutationOptions = { onSuccess: invalidateWorkshop } as const;
+  const unequipCardMutation = trpc.game.unequipCard.useMutation(mutationOptions);
+  const unequipAllMutation = trpc.game.unequipAll.useMutation(mutationOptions);
+  const equipCardsMutation = trpc.game.equipCards.useMutation(mutationOptions);
+  const moveCardMutation = trpc.game.moveCard.useMutation(mutationOptions);
+  const savePresetMutation = trpc.game.savePreset.useMutation(mutationOptions);
+  const loadPresetMutation = trpc.game.loadPreset.useMutation(mutationOptions);
+  const deletePresetMutation = trpc.game.deletePreset.useMutation(mutationOptions);
+
+  const inventory = (inventoryQuery.data ?? EMPTY_INVENTORY) as WorkshopInventory;
+  const monsters = inventory.monsters ?? [];
+  const unequippedDeck = inventory.unequippedDeck ?? [];
+
+  const loading = roomQuery.isLoading || inventoryQuery.isLoading;
+  const busy = useMemo(
+    () =>
+      inventoryQuery.isFetching ||
+      unequipCardMutation.isPending ||
+      unequipAllMutation.isPending ||
+      equipCardsMutation.isPending ||
+      moveCardMutation.isPending ||
+      savePresetMutation.isPending ||
+      loadPresetMutation.isPending ||
+      deletePresetMutation.isPending,
+    [
+      deletePresetMutation.isPending,
+      equipCardsMutation.isPending,
+      inventoryQuery.isFetching,
+      loadPresetMutation.isPending,
+      moveCardMutation.isPending,
+      savePresetMutation.isPending,
+      unequipAllMutation.isPending,
+      unequipCardMutation.isPending,
+    ],
+  );
+
+  return {
+    roomName: roomQuery.data?.name,
+    inventory,
+    monsters,
+    unequippedDeck,
+    loading,
+    busy,
+    latestError:
+      unequipCardMutation.error?.message ??
+      unequipAllMutation.error?.message ??
+      equipCardsMutation.error?.message ??
+      moveCardMutation.error?.message ??
+      savePresetMutation.error?.message ??
+      loadPresetMutation.error?.message ??
+      deletePresetMutation.error?.message,
+    refresh: () => inventoryQuery.refetch(),
+    equipCards: (input: { monsterName: string; cardNames: string[]; replaceAll?: boolean }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return equipCardsMutation.mutateAsync({ roomId, ...input });
+    },
+    unequipCard: (input: { monsterName: string; cardName: string; count?: number }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return unequipCardMutation.mutateAsync({ roomId, ...input });
+    },
+    unequipAll: (input: { monsterName: string }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return unequipAllMutation.mutateAsync({ roomId, ...input });
+    },
+    moveCard: (input: {
+      cardName: string;
+      fromMonsterName: string;
+      toMonsterName: string;
+      count?: number;
+    }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return moveCardMutation.mutateAsync({ roomId, ...input });
+    },
+    savePreset: (input: { monsterName: string; presetName: string }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return savePresetMutation.mutateAsync({ roomId, ...input });
+    },
+    loadPreset: (input: { monsterName: string; presetName: string }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return loadPresetMutation.mutateAsync({ roomId, ...input });
+    },
+    deletePreset: (input: { monsterName: string; presetName: string }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return deletePresetMutation.mutateAsync({ roomId, ...input });
+    },
+  };
+}

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -347,6 +347,31 @@ button {
   cursor: pointer;
 }
 
+.workshop-card-slot.drop-over {
+  border-color: var(--color-accent);
+}
+
+.workshop-card-slot.selected {
+  box-shadow: inset 0 0 0 1px var(--color-accent);
+}
+
+.workshop-card-slot.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.workshop-card-slot.class-melee {
+  border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
+}
+
+.workshop-card-slot.class-heal {
+  border-color: color-mix(in srgb, var(--color-success) 55%, var(--color-border));
+}
+
+.workshop-card-slot.class-magic {
+  border-color: color-mix(in srgb, var(--color-fg-bright) 45%, var(--color-border));
+}
+
 .workshop-card-icon {
   font-size: 1rem;
   line-height: 1;

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -214,6 +214,233 @@ button {
 /* Header nav/hamburger visibility */
 .header-hamburger { display: none; }
 
+.workshop-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.workshop-header h1 {
+  font-size: 1.2rem;
+  color: var(--color-fg-bright);
+}
+
+.workshop-monster-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.85rem;
+}
+
+.workshop-monster-panel {
+  border: 1px solid var(--color-border);
+  padding: 0.75rem;
+  background: var(--color-input-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.workshop-monster-panel.locked {
+  opacity: 0.72;
+}
+
+.workshop-monster-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.workshop-monster-header h3 {
+  font-size: 0.95rem;
+  color: var(--color-fg-bright);
+}
+
+.workshop-monster-header p {
+  color: var(--color-fg-dim);
+  font-size: 0.72rem;
+}
+
+.workshop-slot-meter {
+  min-width: 98px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  position: relative;
+  height: 14px;
+}
+
+.workshop-slot-meter > div {
+  background: var(--color-accent);
+  height: 100%;
+}
+
+.workshop-slot-meter > span {
+  position: absolute;
+  inset: 0;
+  text-align: center;
+  font-size: 0.62rem;
+  line-height: 14px;
+  color: var(--color-fg-bright);
+}
+
+.workshop-slot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(70px, 1fr));
+  gap: 0.4rem;
+}
+
+.workshop-inventory {
+  border: 1px solid var(--color-border);
+  padding: 0.75rem;
+  background: var(--color-input-bg);
+}
+
+.workshop-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.workshop-section-header h2 {
+  font-size: 0.9rem;
+  color: var(--color-fg-bright);
+}
+
+.workshop-section-header span {
+  font-size: 0.75rem;
+  color: var(--color-fg-dim);
+}
+
+.workshop-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 0.4rem;
+}
+
+.workshop-drop-zone {
+  margin-top: 0.6rem;
+  border: 1px dashed var(--color-border);
+  padding: 0.5rem;
+  color: var(--color-fg-dim);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+.workshop-drop-zone.drop-active {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.workshop-card-slot {
+  width: 100%;
+  min-height: 92px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  padding: 0.3rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.workshop-card-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.workshop-card-name {
+  text-align: center;
+  font-size: 0.7rem;
+  line-height: 1.15;
+}
+
+.workshop-card-class {
+  text-align: center;
+  font-size: 0.62rem;
+  color: var(--color-fg-dim);
+  text-transform: uppercase;
+}
+
+.workshop-presets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.workshop-subheading {
+  font-size: 0.72rem;
+  color: var(--color-fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.workshop-preset-row {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.workshop-select,
+.workshop-input {
+  flex: 1;
+  min-width: 120px;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  padding: 0.2rem 0.35rem;
+  font-family: var(--font-family);
+  font-size: 0.75rem;
+}
+
+.workshop-panel-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.workshop-mobile-hint {
+  font-size: 0.7rem;
+  color: var(--color-fg-dim);
+}
+
+.workshop-empty-state {
+  color: var(--color-fg-dim);
+  padding: 1rem 0;
+  text-align: center;
+  font-size: 0.8rem;
+}
+
+.monster-workshop-panel.in-ring,
+.workshop-monster-panel.in-ring {
+  border-color: var(--color-accent);
+}
+
+.workshop-warning {
+  border: 1px solid var(--color-accent);
+  color: var(--color-accent);
+  padding: 0.45rem 0.55rem;
+  font-size: 0.78rem;
+}
+
+.workshop-flash-error {
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
+  padding: 0.45rem 0.55rem;
+  font-size: 0.78rem;
+}
+
+@media (max-width: 700px) {
+  .workshop-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .workshop-panel-actions {
+    flex-direction: column;
+  }
+}
+
 /* Mobile layout — narrow screens */
 @media (max-width: 600px) {
   .header-nav { display: none !important; }

--- a/apps/web/src/utils/cards.ts
+++ b/apps/web/src/utils/cards.ts
@@ -1,0 +1,63 @@
+const HEAL_KEYWORDS = ['heal', 'scotch', 'whiskey', 'potion', 'pokecen', 'spin up'];
+const MELEE_KEYWORDS = ['hit', 'berserk', 'gore', 'spear', 'knife', 'swipe', 'battle', 'rampage'];
+const MAGIC_KEYWORDS = ['blink', 'blast', 'mesmer', 'sandstorm', 'curse', 'coil', 'focus', 'drain', 'cloak', 'entrance'];
+
+export type CardClass = 'melee' | 'magic' | 'heal' | 'utility';
+
+export function abbreviateCardName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return '';
+  if (trimmed.length <= 8) return trimmed;
+
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return `${parts[0].slice(0, 7)}…`;
+  if (parts.length === 2) {
+    return `${parts[0].slice(0, 3)}${parts[1][0] ?? ''}`;
+  }
+  return parts
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('')
+    .slice(0, 5);
+}
+
+export function getCardClass(name: string): CardClass {
+  const lower = name.toLowerCase();
+  if (HEAL_KEYWORDS.some((keyword) => lower.includes(keyword))) return 'heal';
+  if (MELEE_KEYWORDS.some((keyword) => lower.includes(keyword))) return 'melee';
+  if (MAGIC_KEYWORDS.some((keyword) => lower.includes(keyword))) return 'magic';
+  return 'utility';
+}
+
+export function classifyCard(name: string): CardClass {
+  return getCardClass(name);
+}
+
+export function getCardClassColorVar(cardClass: CardClass): string {
+  switch (cardClass) {
+    case 'melee':
+      return '--workshop-card-melee';
+    case 'magic':
+      return '--workshop-card-magic';
+    case 'heal':
+      return '--workshop-card-heal';
+    default:
+      return '--color-border';
+  }
+}
+
+export function getCardIcon(cardClass: CardClass): string {
+  switch (cardClass) {
+    case 'melee':
+      return '⚔';
+    case 'magic':
+      return '✦';
+    case 'heal':
+      return '✚';
+    default:
+      return '◇';
+  }
+}
+
+export function getCardEmoji(name: string): string {
+  return getCardIcon(getCardClass(name));
+}

--- a/apps/web/src/utils/cards.ts
+++ b/apps/web/src/utils/cards.ts
@@ -28,23 +28,6 @@ export function getCardClass(name: string): CardClass {
   return 'utility';
 }
 
-export function classifyCard(name: string): CardClass {
-  return getCardClass(name);
-}
-
-export function getCardClassColorVar(cardClass: CardClass): string {
-  switch (cardClass) {
-    case 'melee':
-      return '--workshop-card-melee';
-    case 'magic':
-      return '--workshop-card-magic';
-    case 'heal':
-      return '--workshop-card-heal';
-    default:
-      return '--color-border';
-  }
-}
-
 export function getCardIcon(cardClass: CardClass): string {
   switch (cardClass) {
     case 'melee':

--- a/apps/web/src/views/WorkshopView.tsx
+++ b/apps/web/src/views/WorkshopView.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import AppShell from '../components/AppShell.js';
+import InventoryPanel from '../components/InventoryPanel.js';
+import MonsterWorkshopPanel from '../components/MonsterWorkshopPanel.js';
+import type { WorkshopCardLocation } from '../components/CardSlot.js';
+import { useDeckWorkshop } from '../hooks/useDeckWorkshop.js';
+
+type SelectionState = {
+  location: WorkshopCardLocation;
+  cardName: string;
+} | null;
+
+export default function WorkshopView() {
+  const { roomId } = useParams<{ roomId: string }>();
+  const [selected, setSelected] = useState<SelectionState>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    roomName,
+    monsters,
+    unequippedDeck,
+    loading,
+    busy,
+    latestError,
+    equipCards,
+    unequipCard,
+    moveCard,
+    savePreset,
+    loadPreset,
+    deletePreset,
+    refresh,
+  } = useDeckWorkshop(roomId);
+
+  useEffect(() => {
+    if (!message) return;
+    const timer = setTimeout(() => setMessage(null), 3500);
+    return () => clearTimeout(timer);
+  }, [message]);
+
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(() => setError(null), 5000);
+    return () => clearTimeout(timer);
+  }, [error]);
+
+  useEffect(() => {
+    if (!latestError) return;
+    setError(latestError);
+  }, [latestError]);
+
+  const selectedMonsterName = useMemo(() => {
+    if (!selected || selected.location.kind !== 'monster') return null;
+    return selected.location.monsterName;
+  }, [selected]);
+
+  async function handleDrop(
+    source: WorkshopCardLocation,
+    target: WorkshopCardLocation,
+    cardName: string,
+  ) {
+    if (!roomId) return;
+    if (source.kind === 'monster' && target.kind === 'monster' && source.monsterName === target.monsterName) {
+      return;
+    }
+
+    try {
+      setError(null);
+      if (source.kind === 'inventory' && target.kind === 'monster') {
+        await equipCards({
+          monsterName: target.monsterName,
+          cardNames: [cardName],
+          replaceAll: false,
+        });
+        setMessage(`Equipped ${cardName} on ${target.monsterName}.`);
+        return;
+      }
+
+      if (source.kind === 'monster' && target.kind === 'inventory') {
+        await unequipCard({
+          monsterName: source.monsterName,
+          cardName,
+          count: 1,
+        });
+        setMessage(`Unequipped ${cardName} from ${source.monsterName}.`);
+        return;
+      }
+
+      if (source.kind === 'monster' && target.kind === 'monster') {
+        await moveCard({
+          cardName,
+          fromMonsterName: source.monsterName,
+          toMonsterName: target.monsterName,
+          count: 1,
+        });
+        setMessage(`Moved ${cardName} to ${target.monsterName}.`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed');
+    }
+  }
+
+  async function handleSlotClick(target: WorkshopCardLocation) {
+    if (!selected || !roomId) return;
+    const payload = selected;
+    setSelected(null);
+    await handleDrop(payload.location, target, payload.cardName);
+  }
+
+  function handleSelect(location: WorkshopCardLocation, cardName: string) {
+    setSelected({ location, cardName });
+  }
+
+  async function handleSavePreset(monsterName: string, presetName: string) {
+    if (!roomId) return;
+    try {
+      setError(null);
+      await savePreset({ monsterName, presetName });
+      setMessage(`Saved preset "${presetName}" for ${monsterName}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save preset');
+    }
+  }
+
+  async function handleLoadPreset(monsterName: string, presetName: string) {
+    if (!roomId) return;
+    try {
+      setError(null);
+      const result = await loadPreset({ monsterName, presetName });
+      const skipped = result.skippedCards.length > 0 ? ` Skipped: ${result.skippedCards.join(', ')}.` : '';
+      setMessage(
+        `Loaded "${presetName}" on ${monsterName} (${result.equippedCount}/${result.requestedCount}).${skipped}`,
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load preset');
+    }
+  }
+
+  async function handleDeletePreset(monsterName: string, presetName: string) {
+    if (!roomId) return;
+    try {
+      setError(null);
+      await deletePreset({ monsterName, presetName });
+      setMessage(`Deleted preset "${presetName}" from ${monsterName}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not delete preset');
+    }
+  }
+
+  return (
+    <AppShell roomName={roomName} roomId={roomId}>
+      <div className="workshop-view">
+        <div className="workshop-header">
+          <div>
+            <h1>Deck Workshop</h1>
+            <p>Manage equipped and unequipped cards in one view.</p>
+          </div>
+          <button className="btn" onClick={() => void refresh()} disabled={!roomId || loading || busy}>
+            Refresh
+          </button>
+        </div>
+
+        {message && <div className="success-msg">{message}</div>}
+        {error && <div className="error-msg">{error}</div>}
+        {busy && <div className="workshop-banner">Applying changes…</div>}
+
+        <div className="workshop-monster-row">
+          {monsters.map((monster) => (
+            <MonsterWorkshopPanel
+              key={monster.name}
+              monster={monster}
+              selectedCard={selected}
+              selectedMonsterName={selectedMonsterName}
+              onDropCard={(source, cardName) =>
+                handleDrop(source, { kind: 'monster', monsterName: monster.name }, cardName)
+              }
+              onTapSlot={(target) => {
+                void handleSlotClick(target);
+              }}
+              onSelectCard={(location, cardName) => handleSelect(location, cardName)}
+              onSavePreset={(presetName) => {
+                void handleSavePreset(monster.name, presetName);
+              }}
+              onLoadPreset={(presetName) => {
+                void handleLoadPreset(monster.name, presetName);
+              }}
+              onDeletePreset={(presetName) => {
+                void handleDeletePreset(monster.name, presetName);
+              }}
+            />
+          ))}
+        </div>
+
+        <InventoryPanel
+          cards={unequippedDeck}
+          selectedCard={selected}
+          onDropCard={(source, cardName) => handleDrop(source, { kind: 'inventory' }, cardName)}
+          onTapSlot={() => {
+            void handleSlotClick({ kind: 'inventory' });
+          }}
+          onSelectCard={(location, cardName) => handleSelect(location, cardName)}
+        />
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/views/WorkshopView.tsx
+++ b/apps/web/src/views/WorkshopView.tsx
@@ -167,6 +167,11 @@ export default function WorkshopView() {
         {message && <div className="success-msg">{message}</div>}
         {error && <div className="error-msg">{error}</div>}
         {busy && <div className="workshop-banner">Applying changes…</div>}
+        {selected?.location.kind === 'inventory' && (
+          <div className="workshop-mobile-hint">
+            {selected.cardName} selected. Tap a monster slot to equip, or tap inventory to cancel.
+          </div>
+        )}
 
         <div className="workshop-monster-row">
           {monsters.map((monster) => (
@@ -174,7 +179,7 @@ export default function WorkshopView() {
               key={monster.name}
               monster={monster}
               selectedCard={selected}
-              selectedMonsterName={selectedMonsterName}
+              showSelectionHint={Boolean(selected) && selectedMonsterName === monster.name}
               onDropCard={(source, cardName) =>
                 handleDrop(source, { kind: 'monster', monsterName: monster.name }, cardName)
               }

--- a/apps/web/src/views/WorkshopView.tsx
+++ b/apps/web/src/views/WorkshopView.tsx
@@ -68,12 +68,15 @@ export default function WorkshopView() {
     try {
       setError(null);
       if (source.kind === 'inventory' && target.kind === 'monster') {
-        await equipCards({
+        const result = await equipCards({
           monsterName: target.monsterName,
           cardNames: [cardName],
           replaceAll: false,
         });
-        setMessage(`Equipped ${cardName} on ${target.monsterName}.`);
+        const skipped = result.skippedCards.length > 0 ? ` Skipped: ${result.skippedCards.join(', ')}.` : '';
+        setMessage(
+          `Equipped ${target.monsterName} (${result.equippedCount}/${result.requestedCount}).${skipped}`,
+        );
         return;
       }
 

--- a/packages/engine/src/characters/beastmaster.test.ts
+++ b/packages/engine/src/characters/beastmaster.test.ts
@@ -5,6 +5,22 @@ import Beastmaster from './beastmaster.js';
 describe('characters/beastmaster', () => {
 	let channelStub: sinon.SinonStub;
 
+	const makeCard = (cardType: string) => ({ cardType, name: cardType });
+	const makeMonster = (name: string, cards: any[] = []) => ({
+		givenName: name,
+		creatureType: 'Basilisk',
+		level: 4,
+		cardSlots: 9,
+		inEncounter: false,
+		items: [],
+		cards: [...cards],
+		options: {},
+		canHoldCard: () => true,
+		setOptions(update: Record<string, unknown>) {
+			this.options = { ...this.options, ...update };
+		},
+	});
+
 	beforeEach(() => {
 		channelStub = sinon.stub().resolves(undefined);
 	});
@@ -63,5 +79,114 @@ describe('characters/beastmaster', () => {
 		expect(beastmaster.ownsMonster('Ragnar')).to.equal(true);
 		expect(beastmaster.ownsMonster('ragnar')).to.equal(true);
 		expect(beastmaster.ownsMonster('Unknown')).to.equal(false);
+	});
+
+	it('formats a combined card inventory with equipped and unequipped cards', async () => {
+		const beastmaster = new Beastmaster();
+		beastmaster.monsters = [makeMonster('Stonefang', [makeCard('Hit'), makeCard('Heal')]) as any];
+		beastmaster.deck = [makeCard('Blink'), makeCard('Hit')];
+
+		await beastmaster.lookAtCardInventory(channelStub);
+
+		expect(channelStub.called).to.equal(true);
+		const announce = channelStub.firstCall.args[0].announce as string;
+		expect(announce).to.include('Your Card Inventory');
+		expect(announce).to.include('Stonefang');
+		expect(announce).to.include('Unequipped (2 cards)');
+		expect(announce).to.include('Blink');
+	});
+
+	it('unequips cards from a monster and returns them to deck', async () => {
+		const beastmaster = new Beastmaster();
+		const monster = makeMonster('Stonefang', [makeCard('Hit'), makeCard('Hit'), makeCard('Heal')]);
+		beastmaster.monsters = [monster as any];
+		beastmaster.deck = [];
+		const hitsBefore = beastmaster.deck.filter(card => card.cardType === 'Hit').length;
+
+		const result = await beastmaster.unequipCard({
+			channel: channelStub,
+			cardName: 'Hit',
+			count: 2,
+			monsterName: 'Stonefang',
+		});
+
+		expect(result.removedCount).to.equal(2);
+		expect(monster.cards.map(card => card.cardType)).to.deep.equal(['Heal']);
+		const hitsAfter = beastmaster.deck.filter(card => card.cardType === 'Hit').length;
+		expect(hitsAfter).to.equal(hitsBefore + 2);
+	});
+
+	it('moves cards between monsters directly', async () => {
+		const beastmaster = new Beastmaster();
+		const fromMonster = makeMonster('Stonefang', [makeCard('Hit'), makeCard('Heal')]);
+		const toMonster = makeMonster('Mirebell', [makeCard('Blink')]);
+		beastmaster.monsters = [fromMonster as any, toMonster as any];
+
+		const result = await beastmaster.moveCard({
+			channel: channelStub,
+			cardName: 'Hit',
+			fromMonsterName: 'Stonefang',
+			toMonsterName: 'Mirebell',
+		});
+
+		expect(result.movedCount).to.equal(1);
+		expect(fromMonster.cards.map(card => card.cardType)).to.deep.equal(['Heal']);
+		expect(toMonster.cards.map(card => card.cardType)).to.deep.equal(['Blink', 'Hit']);
+	});
+
+	it('saves, loads, and deletes presets', async () => {
+		const beastmaster = new Beastmaster();
+		const monster = makeMonster('Stonefang', [makeCard('Hit'), makeCard('Heal')]);
+		beastmaster.monsters = [monster as any];
+		beastmaster.deck = [makeCard('Blink')];
+
+		const saveResult = await beastmaster.savePreset({
+			channel: channelStub,
+			presetName: 'aggro',
+			monsterName: 'Stonefang',
+		});
+		expect(saveResult.presetName).to.equal('aggro');
+
+		monster.cards = [makeCard('Blink')];
+		beastmaster.deck = [makeCard('Hit'), makeCard('Heal')];
+		const loadResult = await beastmaster.loadPreset({
+			channel: channelStub,
+			presetName: 'aggro',
+			monsterName: 'Stonefang',
+		});
+		expect(loadResult.equipped).to.equal(2);
+		expect(monster.cards.map(card => card.cardType)).to.deep.equal(['Hit', 'Heal']);
+
+		const deleteResult = await beastmaster.deletePreset({
+			channel: channelStub,
+			presetName: 'aggro',
+			monsterName: 'Stonefang',
+		});
+		expect(deleteResult.presetName).to.equal('aggro');
+		expect(beastmaster.getPresets('Stonefang')).to.deep.equal({});
+	});
+
+	it('returns skipped cards when loading an incomplete preset', async () => {
+		const beastmaster = new Beastmaster();
+		const monster = makeMonster('Stonefang', [makeCard('Hit'), makeCard('Heal')]);
+		beastmaster.monsters = [monster as any];
+
+		await beastmaster.savePreset({
+			channel: channelStub,
+			presetName: 'starter',
+			monsterName: 'Stonefang',
+		});
+
+		monster.cards = [];
+		beastmaster.deck = [makeCard('Hit')];
+		const loadResult = await beastmaster.loadPreset({
+			channel: channelStub,
+			presetName: 'starter',
+			monsterName: 'Stonefang',
+		});
+
+		expect(loadResult.equipped).to.equal(1);
+		expect(loadResult.requested).to.equal(2);
+		expect(loadResult.skippedCards).to.deep.equal(['Heal']);
 	});
 });

--- a/packages/engine/src/characters/beastmaster.ts
+++ b/packages/engine/src/characters/beastmaster.ts
@@ -40,6 +40,10 @@ const getCardName = (card: CardInstance): string =>
 	(card as any).cardType ?? (card as any).itemType ?? (card as any).name ?? 'Unknown';
 const isSameCardName = (card: CardInstance, cardName: string): boolean =>
 	getCardName(card).toLowerCase() === cardName.toLowerCase();
+const announceAndThrow = async (channel: ChannelFn, announce: string): Promise<never> => {
+	await channel({ announce });
+	throw new Error(announce);
+};
 
 class Beastmaster extends BaseCharacter {
 	constructor(options: Record<string, unknown> = {}) {
@@ -467,11 +471,10 @@ class Beastmaster extends BaseCharacter {
 			)
 			.then((monster) => {
 				if (monster.inEncounter) {
-					return Promise.reject(
-						channel({
-							announce: `You cannot unequip cards from ${monster.givenName} while they are fighting!`,
-						}),
-					) as unknown as { removedCount: number; monsterName: string };
+					return announceAndThrow(
+						channel,
+						`You cannot unequip cards from ${monster.givenName} while they are fighting!`,
+					);
 				}
 
 				const remainingCards = [...monster.cards];
@@ -486,9 +489,7 @@ class Beastmaster extends BaseCharacter {
 				}
 
 				if (removedCards.length < 1) {
-					return Promise.reject(
-						channel({ announce: `${monster.givenName} is not holding ${cardName}.` }),
-					) as unknown as { removedCount: number; monsterName: string };
+					return announceAndThrow(channel, `${monster.givenName} is not holding ${cardName}.`);
 				}
 
 				monster.cards = remainingCards;
@@ -524,17 +525,14 @@ class Beastmaster extends BaseCharacter {
 			)
 			.then((monster) => {
 				if (monster.inEncounter) {
-					return Promise.reject(
-						channel({
-							announce: `You cannot clear ${monster.givenName}'s deck while they are fighting!`,
-						}),
-					) as unknown as { removedCount: number; monsterName: string };
+					return announceAndThrow(
+						channel,
+						`You cannot clear ${monster.givenName}'s deck while they are fighting!`,
+					);
 				}
 
 				if (monster.cards.length < 1) {
-					return Promise.reject(
-						channel({ announce: `${monster.givenName} already has an empty deck.` }),
-					) as unknown as { removedCount: number; monsterName: string };
+					return announceAndThrow(channel, `${monster.givenName} already has an empty deck.`);
 				}
 
 				const previousCards = [...monster.cards];
@@ -571,24 +569,16 @@ class Beastmaster extends BaseCharacter {
 		const toMonster = this.findMonsterByName(toMonsterName);
 
 		if (!fromMonster) {
-			return Promise.reject(
-				channel({ announce: `I can find no monster named ${fromMonsterName}.` }),
-			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+			return announceAndThrow(channel, `I can find no monster named ${fromMonsterName}.`);
 		}
 		if (!toMonster) {
-			return Promise.reject(
-				channel({ announce: `I can find no monster named ${toMonsterName}.` }),
-			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+			return announceAndThrow(channel, `I can find no monster named ${toMonsterName}.`);
 		}
 		if (fromMonster === toMonster) {
-			return Promise.reject(
-				channel({ announce: 'Choose two different monsters for move operations.' }),
-			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+			return announceAndThrow(channel, 'Choose two different monsters for move operations.');
 		}
 		if (fromMonster.inEncounter || toMonster.inEncounter) {
-			return Promise.reject(
-				channel({ announce: 'Cards cannot be moved while a monster is in battle.' }),
-			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+			return announceAndThrow(channel, 'Cards cannot be moved while a monster is in battle.');
 		}
 
 		const sourceCards = [...fromMonster.cards];
@@ -625,11 +615,7 @@ class Beastmaster extends BaseCharacter {
 
 		if (movedCount < 1) {
 			const reason = blockedBy || `${fromMonster.givenName} is not holding ${cardName}.`;
-			return Promise.reject(channel({ announce: reason })) as Promise<{
-				movedCount: number;
-				fromMonsterName: string;
-				toMonsterName: string;
-			}>;
+			return announceAndThrow(channel, reason);
 		}
 
 		fromMonster.cards = sourceCards;
@@ -688,16 +674,10 @@ class Beastmaster extends BaseCharacter {
 			)
 			.then((monster) => {
 				if (monster.inEncounter) {
-					return Promise.reject(
-						channel({
-							announce: `You cannot equip ${monster.givenName} while they are fighting!`,
-						}),
-					) as unknown as {
-						equipped: number;
-						requested: number;
-						skippedCards: string[];
-						monsterName: string;
-					};
+					return announceAndThrow(
+						channel,
+						`You cannot equip ${monster.givenName} while they are fighting!`,
+					);
 				}
 
 				const requested = cardNames.length;
@@ -764,10 +744,7 @@ class Beastmaster extends BaseCharacter {
 	}): Promise<{ presetName: string; monsterName: string }> {
 		const trimmedName = presetName.trim();
 		if (!trimmedName) {
-			return Promise.reject(channel({ announce: 'Preset name is required.' })) as Promise<{
-				presetName: string;
-				monsterName: string;
-			}>;
+			return announceAndThrow(channel, 'Preset name is required.');
 		}
 
 		return Promise.resolve()
@@ -782,11 +759,10 @@ class Beastmaster extends BaseCharacter {
 				const presets = this.getMonsterPresets(monster);
 				const hasPreset = Object.prototype.hasOwnProperty.call(presets, trimmedName);
 				if (!hasPreset && Object.keys(presets).length >= MAX_PRESETS) {
-					return Promise.reject(
-						channel({
-							announce: `${monster.givenName} already has ${MAX_PRESETS} presets. Delete one before saving another.`,
-						}),
-					) as unknown as { presetName: string; monsterName: string };
+					return announceAndThrow(
+						channel,
+						`${monster.givenName} already has ${MAX_PRESETS} presets. Delete one before saving another.`,
+					);
 				}
 
 				const nextPresets = {
@@ -818,13 +794,7 @@ class Beastmaster extends BaseCharacter {
 	}): Promise<{ equipped: number; requested: number; skippedCards: string[]; presetName: string; monsterName: string }> {
 		const trimmedName = presetName.trim();
 		if (!trimmedName) {
-			return Promise.reject(channel({ announce: 'Preset name is required.' })) as Promise<{
-				equipped: number;
-				requested: number;
-				skippedCards: string[];
-				presetName: string;
-				monsterName: string;
-			}>;
+			return announceAndThrow(channel, 'Preset name is required.');
 		}
 
 		return Promise.resolve()
@@ -837,33 +807,19 @@ class Beastmaster extends BaseCharacter {
 			)
 			.then((monster) => {
 				if (monster.inEncounter) {
-					return Promise.reject(
-						channel({
-							announce: `You cannot load presets for ${monster.givenName} while they are fighting!`,
-						}),
-					) as unknown as {
-						equipped: number;
-						requested: number;
-						skippedCards: string[];
-						presetName: string;
-						monsterName: string;
-					};
+					return announceAndThrow(
+						channel,
+						`You cannot load presets for ${monster.givenName} while they are fighting!`,
+					);
 				}
 
 				const presets = this.getMonsterPresets(monster);
 				const requestedCards = presets[trimmedName];
 				if (!requestedCards) {
-					return Promise.reject(
-						channel({
-							announce: `No preset named "${trimmedName}" exists for ${monster.givenName}.`,
-						}),
-					) as unknown as {
-						equipped: number;
-						requested: number;
-						skippedCards: string[];
-						presetName: string;
-						monsterName: string;
-					};
+					return announceAndThrow(
+						channel,
+						`No preset named "${trimmedName}" exists for ${monster.givenName}.`,
+					);
 				}
 
 				const oldCards = [...monster.cards];
@@ -926,10 +882,7 @@ class Beastmaster extends BaseCharacter {
 	}): Promise<{ presetName: string; monsterName: string }> {
 		const trimmedName = presetName.trim();
 		if (!trimmedName) {
-			return Promise.reject(channel({ announce: 'Preset name is required.' })) as Promise<{
-				presetName: string;
-				monsterName: string;
-			}>;
+			return announceAndThrow(channel, 'Preset name is required.');
 		}
 
 		return Promise.resolve()
@@ -943,11 +896,10 @@ class Beastmaster extends BaseCharacter {
 			.then((monster) => {
 				const presets = this.getMonsterPresets(monster);
 				if (!Object.prototype.hasOwnProperty.call(presets, trimmedName)) {
-					return Promise.reject(
-						channel({
-							announce: `No preset named "${trimmedName}" exists for ${monster.givenName}.`,
-						}),
-					) as unknown as { presetName: string; monsterName: string };
+					return announceAndThrow(
+						channel,
+						`No preset named "${trimmedName}" exists for ${monster.givenName}.`,
+					);
 				}
 
 				const nextPresets = { ...presets };

--- a/packages/engine/src/characters/beastmaster.ts
+++ b/packages/engine/src/characters/beastmaster.ts
@@ -401,20 +401,19 @@ class Beastmaster extends BaseCharacter {
 		});
 	}
 
-	lookAtInventory(channel: ChannelWithManager): Promise<void> {
+	async lookAtInventory(channel: ChannelWithManager): Promise<void> {
 		const hasItems =
 			this.items.length > 0 ||
 			this.monsters.some(monster => (monster as any).items?.length > 0);
 
-		return Promise.resolve()
-			.then(() => this.lookAtCardInventory(channel as ChannelFn))
-			.then(() => {
-				if (!hasItems) {
-					return channel({ announce: 'Items:\n  (none)' });
-				}
+		await this.lookAtCardInventory(channel as ChannelFn);
 
-				return this.lookAtItems(channel);
-			});
+		if (!hasItems) {
+			await channel({ announce: 'Items:\n  (none)' });
+			return;
+		}
+
+		await this.lookAtItems(channel);
 	}
 
 	private findMonsterByName(monsterName: string): BaseMonster | undefined {

--- a/packages/engine/src/characters/beastmaster.ts
+++ b/packages/engine/src/characters/beastmaster.ts
@@ -8,8 +8,10 @@ import { spawn, equip } from '../monsters/index.js';
 import TENSE from '../helpers/tense.js';
 import transferItems from '../items/helpers/transfer.js';
 import useItems from '../items/helpers/use.js';
+import { getItemKey } from '../items/helpers/counts.js';
 import { formatRelative } from '../helpers/time.js';
 import { eachSeries } from '../helpers/promise.js';
+import { MAX_PRESETS } from '../constants/card-management.js';
 import type { ChannelFn, ChannelWithManager, CardInstance, ItemInstance } from '../creatures/base.js';
 import type BaseMonster from '../monsters/base.js';
 
@@ -30,6 +32,14 @@ export const beastmasterReady = loadHelpers().catch((err) => {
 });
 
 const DEFAULT_MONSTER_SLOTS = 7;
+
+const MAX_CARD_COPIES_IN_HAND = 4;
+
+const normalize = (value: string): string => value.trim().toLowerCase();
+const getCardName = (card: CardInstance): string =>
+	(card as any).cardType ?? (card as any).itemType ?? (card as any).name ?? 'Unknown';
+const isSameCardName = (card: CardInstance, cardName: string): boolean =>
+	getCardName(card).toLowerCase() === cardName.toLowerCase();
 
 class Beastmaster extends BaseCharacter {
 	constructor(options: Record<string, unknown> = {}) {
@@ -352,6 +362,609 @@ class Beastmaster extends BaseCharacter {
 					).then(() => super.lookAtItems(channel as any, (monster as any).items));
 				}),
 			);
+	}
+
+	lookAtCardInventory(channel: ChannelFn): Promise<void> {
+		const lines: string[] = ['Your Card Inventory', '===================', ''];
+
+		this.monsters.forEach((monster) => {
+			lines.push(
+				`${monster.givenName} [${monster.creatureType}, L${monster.level}]  ${monster.cards.length}/${monster.cardSlots} slots`,
+			);
+
+			if (monster.cards.length < 1) {
+				lines.push('  (empty)');
+			} else {
+				monster.cards.forEach((card, index) => {
+					lines.push(`  ${index + 1}) ${getCardName(card)}`);
+				});
+			}
+
+			lines.push('');
+		});
+
+		const deckCounts = this.deck.reduce<Record<string, number>>((counts, card) => {
+			const key = getItemKey(card);
+			counts[key] = (counts[key] ?? 0) + 1;
+			return counts;
+		}, {});
+
+		const deckList = Object.entries(deckCounts)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([name, count]) => (count > 1 ? `${name} x${count}` : name));
+
+		lines.push(`Unequipped (${this.deck.length} cards)`);
+		lines.push(deckList.length > 0 ? `  ${deckList.join(', ')}` : '  (none)');
+
+		return Promise.resolve().then(() => {
+			channel({ announce: lines.join('\n') });
+		});
+	}
+
+	lookAtInventory(channel: ChannelWithManager): Promise<void> {
+		const hasItems =
+			this.items.length > 0 ||
+			this.monsters.some(monster => (monster as any).items?.length > 0);
+
+		return Promise.resolve()
+			.then(() => this.lookAtCardInventory(channel as ChannelFn))
+			.then(() => {
+				if (!hasItems) {
+					return channel({ announce: 'Items:\n  (none)' });
+				}
+
+				return this.lookAtItems(channel);
+			});
+	}
+
+	private findMonsterByName(monsterName: string): BaseMonster | undefined {
+		return this.monsters.find(monster => normalize(monster.givenName) === normalize(monsterName));
+	}
+
+	private getMonsterPresets(monster: BaseMonster): Record<string, string[]> {
+		const presets = ((monster.options as Record<string, unknown>).presets ??
+			{}) as Record<string, string[]>;
+		return Object.entries(presets).reduce<Record<string, string[]>>((all, [name, cards]) => {
+			if (!Array.isArray(cards)) return all;
+			all[name] = cards.filter(card => typeof card === 'string');
+			return all;
+		}, {});
+	}
+
+	getPresets(monsterName?: string): Record<string, string[]> | Record<string, Record<string, string[]>> {
+		if (monsterName) {
+			const monster = this.findMonsterByName(monsterName);
+			if (!monster) return {};
+			return this.getMonsterPresets(monster);
+		}
+
+		return this.monsters.reduce<Record<string, Record<string, string[]>>>((all, monster) => {
+			all[monster.givenName] = this.getMonsterPresets(monster);
+			return all;
+		}, {});
+	}
+
+	unequipCard({
+		cardName,
+		monsterName,
+		count = 1,
+		channel,
+	}: {
+		cardName: string;
+		monsterName?: string;
+		count?: number;
+		channel: ChannelFn;
+	}): Promise<{ removedCount: number; monsterName: string }> {
+		const removeCount = Math.max(Number(count) || 1, 1);
+
+		return Promise.resolve()
+			.then(() =>
+				this.chooseMonster({
+					channel,
+					monsterName,
+					action: 'unequip from',
+					reason: "you don't appear to have a monster by that name.",
+				}),
+			)
+			.then((monster) => {
+				if (monster.inEncounter) {
+					return Promise.reject(
+						channel({
+							announce: `You cannot unequip cards from ${monster.givenName} while they are fighting!`,
+						}),
+					) as unknown as { removedCount: number; monsterName: string };
+				}
+
+				const remainingCards = [...monster.cards];
+				const removedCards: CardInstance[] = [];
+
+				while (removedCards.length < removeCount) {
+					const cardIndex = remainingCards.findIndex(card =>
+						isSameCardName(card, cardName),
+					);
+					if (cardIndex < 0) break;
+					removedCards.push(remainingCards.splice(cardIndex, 1)[0]);
+				}
+
+				if (removedCards.length < 1) {
+					return Promise.reject(
+						channel({ announce: `${monster.givenName} is not holding ${cardName}.` }),
+					) as unknown as { removedCount: number; monsterName: string };
+				}
+
+				monster.cards = remainingCards;
+				removedCards.forEach(card => this.addCard(card));
+
+				return Promise.resolve(channel({
+					announce: `Unequipped ${removedCards.length} ${cardName}${removedCards.length === 1 ? '' : ' cards'} from ${monster.givenName}.`,
+				})).then(
+					() =>
+						({
+							removedCount: removedCards.length,
+							monsterName: monster.givenName,
+						}) as { removedCount: number; monsterName: string },
+				);
+			});
+	}
+
+	unequipAll({
+		monsterName,
+		channel,
+	}: {
+		monsterName?: string;
+		channel: ChannelFn;
+	}): Promise<{ removedCount: number; monsterName: string }> {
+		return Promise.resolve()
+			.then(() =>
+				this.chooseMonster({
+					channel,
+					monsterName,
+					action: 'clear',
+					reason: "you don't appear to have a monster by that name.",
+				}),
+			)
+			.then((monster) => {
+				if (monster.inEncounter) {
+					return Promise.reject(
+						channel({
+							announce: `You cannot clear ${monster.givenName}'s deck while they are fighting!`,
+						}),
+					) as unknown as { removedCount: number; monsterName: string };
+				}
+
+				if (monster.cards.length < 1) {
+					return Promise.reject(
+						channel({ announce: `${monster.givenName} already has an empty deck.` }),
+					) as unknown as { removedCount: number; monsterName: string };
+				}
+
+				const previousCards = [...monster.cards];
+				monster.cards = [];
+				previousCards.forEach(card => this.addCard(card));
+
+				return Promise.resolve(channel({
+					announce: `${monster.givenName}'s deck has been cleared (${previousCards.length} cards returned).`,
+				})).then(
+					() =>
+						({
+							removedCount: previousCards.length,
+							monsterName: monster.givenName,
+						}) as { removedCount: number; monsterName: string },
+				);
+			});
+	}
+
+	moveCard({
+		cardName,
+		fromMonsterName,
+		toMonsterName,
+		count = 1,
+		channel,
+	}: {
+		cardName: string;
+		fromMonsterName: string;
+		toMonsterName: string;
+		count?: number;
+		channel: ChannelFn;
+	}): Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }> {
+		const moveCount = Math.max(Number(count) || 1, 1);
+		const fromMonster = this.findMonsterByName(fromMonsterName);
+		const toMonster = this.findMonsterByName(toMonsterName);
+
+		if (!fromMonster) {
+			return Promise.reject(
+				channel({ announce: `I can find no monster named ${fromMonsterName}.` }),
+			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+		}
+		if (!toMonster) {
+			return Promise.reject(
+				channel({ announce: `I can find no monster named ${toMonsterName}.` }),
+			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+		}
+		if (fromMonster === toMonster) {
+			return Promise.reject(
+				channel({ announce: 'Choose two different monsters for move operations.' }),
+			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+		}
+		if (fromMonster.inEncounter || toMonster.inEncounter) {
+			return Promise.reject(
+				channel({ announce: 'Cards cannot be moved while a monster is in battle.' }),
+			) as Promise<{ movedCount: number; fromMonsterName: string; toMonsterName: string }>;
+		}
+
+		const sourceCards = [...fromMonster.cards];
+		const targetCards = [...toMonster.cards];
+		let movedCount = 0;
+		let blockedBy = '';
+
+		while (movedCount < moveCount) {
+			const cardIndex = sourceCards.findIndex(card => isSameCardName(card, cardName));
+			if (cardIndex < 0) break;
+
+			const card = sourceCards[cardIndex];
+			const targetCount = targetCards.filter(
+				existing => getItemKey(existing) === getItemKey(card),
+			).length;
+
+			if (targetCards.length >= toMonster.cardSlots) {
+				blockedBy = `${toMonster.givenName} has no free slots.`;
+				break;
+			}
+			if (!toMonster.canHoldCard(card)) {
+				blockedBy = `${toMonster.givenName} cannot hold ${getCardName(card)}.`;
+				break;
+			}
+			if (targetCount >= MAX_CARD_COPIES_IN_HAND) {
+				blockedBy = `${toMonster.givenName} already has ${MAX_CARD_COPIES_IN_HAND} copies of ${getCardName(card)}.`;
+				break;
+			}
+
+			sourceCards.splice(cardIndex, 1);
+			targetCards.push(card);
+			movedCount += 1;
+		}
+
+		if (movedCount < 1) {
+			const reason = blockedBy || `${fromMonster.givenName} is not holding ${cardName}.`;
+			return Promise.reject(channel({ announce: reason })) as Promise<{
+				movedCount: number;
+				fromMonsterName: string;
+				toMonsterName: string;
+			}>;
+		}
+
+		fromMonster.cards = sourceCards;
+		toMonster.cards = targetCards;
+
+		return Promise.resolve(channel({
+			announce: `Moved ${movedCount} ${cardName}${movedCount === 1 ? '' : ' cards'} from ${fromMonster.givenName} to ${toMonster.givenName}.${blockedBy ? ` ${blockedBy}` : ''}`,
+		})).then(() => ({
+			movedCount,
+			fromMonsterName: fromMonster.givenName,
+			toMonsterName: toMonster.givenName,
+		}));
+	}
+
+	moveCards({
+		cardNames,
+		fromMonsterName,
+		toMonsterName,
+		channel,
+	}: {
+		cardNames: string[];
+		fromMonsterName: string;
+		toMonsterName: string;
+		channel: ChannelFn;
+	}): Promise<{ movedCards: string[] }> {
+		const movedCards: string[] = [];
+
+		return eachSeries(cardNames, (cardName: string) =>
+			this.moveCard({ cardName, fromMonsterName, toMonsterName, channel })
+				.then(() => {
+					movedCards.push(cardName);
+				})
+				.catch(() => undefined),
+		).then(() => ({ movedCards }));
+	}
+
+	equipCards({
+		monsterName,
+		cardNames,
+		replaceAll = false,
+		channel,
+	}: {
+		monsterName?: string;
+		cardNames: string[];
+		replaceAll?: boolean;
+		channel: ChannelFn;
+	}): Promise<{ equipped: number; requested: number; skippedCards: string[]; monsterName: string }> {
+		return Promise.resolve()
+			.then(() =>
+				this.chooseMonster({
+					channel,
+					monsterName,
+					action: 'equip',
+					reason: "you don't appear to have a monster by that name.",
+				}),
+			)
+			.then((monster) => {
+				if (monster.inEncounter) {
+					return Promise.reject(
+						channel({
+							announce: `You cannot equip ${monster.givenName} while they are fighting!`,
+						}),
+					) as unknown as {
+						equipped: number;
+						requested: number;
+						skippedCards: string[];
+						monsterName: string;
+					};
+				}
+
+				const requested = cardNames.length;
+				const skippedCards: string[] = [];
+				let deck = [...this.deck];
+				let nextCards = replaceAll ? [] : [...monster.cards];
+
+				if (replaceAll) {
+					monster.cards.forEach(card => this.addCard(card));
+					deck = [...this.deck];
+				}
+
+				cardNames.forEach((cardName) => {
+					if (nextCards.length >= monster.cardSlots) {
+						skippedCards.push(cardName);
+						return;
+					}
+
+					const cardIndex = deck.findIndex(card =>
+						isSameCardName(card, cardName) && monster.canHoldCard(card),
+					);
+					if (cardIndex < 0) {
+						skippedCards.push(cardName);
+						return;
+					}
+
+					const selectedCard = deck[cardIndex];
+					const cardCount = nextCards.filter(
+						card => getItemKey(card) === getItemKey(selectedCard),
+					).length;
+					if (cardCount >= MAX_CARD_COPIES_IN_HAND) {
+						skippedCards.push(cardName);
+						return;
+					}
+
+					nextCards.push(deck.splice(cardIndex, 1)[0]);
+				});
+
+				this.deck = deck;
+				monster.cards = nextCards;
+
+				const equipped = requested - skippedCards.length;
+				const summary = {
+					equipped,
+					requested,
+					skippedCards,
+					monsterName: monster.givenName,
+				};
+
+				return Promise.resolve(channel({
+					announce: `Equipped ${monster.givenName}: ${equipped}/${requested}${skippedCards.length > 0 ? ` (skipped: ${skippedCards.join(', ')})` : ''}.`,
+				})).then(() => summary);
+			});
+	}
+
+	savePreset({
+		presetName,
+		monsterName,
+		channel,
+	}: {
+		presetName: string;
+		monsterName?: string;
+		channel: ChannelFn;
+	}): Promise<{ presetName: string; monsterName: string }> {
+		const trimmedName = presetName.trim();
+		if (!trimmedName) {
+			return Promise.reject(channel({ announce: 'Preset name is required.' })) as Promise<{
+				presetName: string;
+				monsterName: string;
+			}>;
+		}
+
+		return Promise.resolve()
+			.then(() =>
+				this.chooseMonster({
+					channel,
+					monsterName,
+					action: 'save a preset for',
+				}),
+			)
+			.then((monster) => {
+				const presets = this.getMonsterPresets(monster);
+				const hasPreset = Object.prototype.hasOwnProperty.call(presets, trimmedName);
+				if (!hasPreset && Object.keys(presets).length >= MAX_PRESETS) {
+					return Promise.reject(
+						channel({
+							announce: `${monster.givenName} already has ${MAX_PRESETS} presets. Delete one before saving another.`,
+						}),
+					) as unknown as { presetName: string; monsterName: string };
+				}
+
+				const nextPresets = {
+					...presets,
+					[trimmedName]: monster.cards.map(card => getCardName(card)),
+				};
+				monster.setOptions({ presets: nextPresets });
+
+				return Promise.resolve(channel({
+					announce: `Saved preset "${trimmedName}" for ${monster.givenName}.`,
+				})).then(
+					() =>
+						({
+							presetName: trimmedName,
+							monsterName: monster.givenName,
+						}) as { presetName: string; monsterName: string },
+				);
+			});
+	}
+
+	loadPreset({
+		presetName,
+		monsterName,
+		channel,
+	}: {
+		presetName: string;
+		monsterName?: string;
+		channel: ChannelFn;
+	}): Promise<{ equipped: number; requested: number; skippedCards: string[]; presetName: string; monsterName: string }> {
+		const trimmedName = presetName.trim();
+		if (!trimmedName) {
+			return Promise.reject(channel({ announce: 'Preset name is required.' })) as Promise<{
+				equipped: number;
+				requested: number;
+				skippedCards: string[];
+				presetName: string;
+				monsterName: string;
+			}>;
+		}
+
+		return Promise.resolve()
+			.then(() =>
+				this.chooseMonster({
+					channel,
+					monsterName,
+					action: 'load a preset for',
+				}),
+			)
+			.then((monster) => {
+				if (monster.inEncounter) {
+					return Promise.reject(
+						channel({
+							announce: `You cannot load presets for ${monster.givenName} while they are fighting!`,
+						}),
+					) as unknown as {
+						equipped: number;
+						requested: number;
+						skippedCards: string[];
+						presetName: string;
+						monsterName: string;
+					};
+				}
+
+				const presets = this.getMonsterPresets(monster);
+				const requestedCards = presets[trimmedName];
+				if (!requestedCards) {
+					return Promise.reject(
+						channel({
+							announce: `No preset named "${trimmedName}" exists for ${monster.givenName}.`,
+						}),
+					) as unknown as {
+						equipped: number;
+						requested: number;
+						skippedCards: string[];
+						presetName: string;
+						monsterName: string;
+					};
+				}
+
+				const oldCards = [...monster.cards];
+				oldCards.forEach(card => this.addCard(card));
+
+				let deck = [...this.deck];
+				const nextCards: CardInstance[] = [];
+				const skippedCards: string[] = [];
+
+				requestedCards.forEach((requestedCard) => {
+					if (nextCards.length >= monster.cardSlots) {
+						skippedCards.push(requestedCard);
+						return;
+					}
+
+					const selectedCount = nextCards.filter(
+						card => getItemKey(card) === requestedCard,
+					).length;
+					if (selectedCount >= MAX_CARD_COPIES_IN_HAND) {
+						skippedCards.push(requestedCard);
+						return;
+					}
+
+					const cardIndex = deck.findIndex(card =>
+						isSameCardName(card, requestedCard) && monster.canHoldCard(card),
+					);
+					if (cardIndex < 0) {
+						skippedCards.push(requestedCard);
+						return;
+					}
+
+					nextCards.push(deck.splice(cardIndex, 1)[0]);
+				});
+
+				this.deck = deck;
+				monster.cards = nextCards;
+
+				const summary = {
+					equipped: nextCards.length,
+					requested: requestedCards.length,
+					skippedCards,
+					presetName: trimmedName,
+					monsterName: monster.givenName,
+				};
+
+				return Promise.resolve(channel({
+					announce: `Loaded preset "${trimmedName}" on ${monster.givenName}: equipped ${summary.equipped}/${summary.requested}${skippedCards.length > 0 ? ` (skipped: ${skippedCards.join(', ')})` : ''}.`,
+				})).then(() => summary);
+			});
+	}
+
+	deletePreset({
+		presetName,
+		monsterName,
+		channel,
+	}: {
+		presetName: string;
+		monsterName?: string;
+		channel: ChannelFn;
+	}): Promise<{ presetName: string; monsterName: string }> {
+		const trimmedName = presetName.trim();
+		if (!trimmedName) {
+			return Promise.reject(channel({ announce: 'Preset name is required.' })) as Promise<{
+				presetName: string;
+				monsterName: string;
+			}>;
+		}
+
+		return Promise.resolve()
+			.then(() =>
+				this.chooseMonster({
+					channel,
+					monsterName,
+					action: 'delete a preset for',
+				}),
+			)
+			.then((monster) => {
+				const presets = this.getMonsterPresets(monster);
+				if (!Object.prototype.hasOwnProperty.call(presets, trimmedName)) {
+					return Promise.reject(
+						channel({
+							announce: `No preset named "${trimmedName}" exists for ${monster.givenName}.`,
+						}),
+					) as unknown as { presetName: string; monsterName: string };
+				}
+
+				const nextPresets = { ...presets };
+				delete nextPresets[trimmedName];
+				monster.setOptions({ presets: nextPresets });
+
+				return Promise.resolve(channel({
+					announce: `Deleted preset "${trimmedName}" for ${monster.givenName}.`,
+				})).then(
+					() =>
+						({
+							presetName: trimmedName,
+							monsterName: monster.givenName,
+						}) as { presetName: string; monsterName: string },
+				);
+			});
 	}
 
 	callMonsterOutOfTheRing({

--- a/packages/engine/src/commands/card-management.test.ts
+++ b/packages/engine/src/commands/card-management.test.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { listen, loadHandlers } from './index.js';
+
+const USER = { id: 'u1', name: 'Tester' };
+
+describe('commands/card-management', () => {
+	before(() => {
+		loadHandlers();
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	function makeActionOptions(game: any) {
+		return {
+			channel: sinon.stub().resolves(undefined),
+			channelName: 'dm',
+			isDM: true,
+			isAdmin: false,
+			user: USER,
+			game,
+		};
+	}
+
+	function makeCharacter(overrides: Record<string, unknown> = {}) {
+		return {
+			equipMonster: sinon.stub().resolves(undefined),
+			unequipCard: sinon.stub().resolves(undefined),
+			unequipAll: sinon.stub().resolves(undefined),
+			moveCard: sinon.stub().resolves(undefined),
+			savePreset: sinon.stub().resolves(undefined),
+			loadPreset: sinon.stub().resolves(undefined),
+			deletePreset: sinon.stub().resolves(undefined),
+			getPresets: sinon.stub().returns({ aggro: ['hit'] }),
+			lookAtInventory: sinon.stub().resolves(undefined),
+			lookAtCardInventory: sinon.stub().resolves(undefined),
+			...overrides,
+		};
+	}
+
+	it('routes unequip command with optional count', async () => {
+		const character = makeCharacter();
+		const game = {
+			getCharacter: sinon.stub().resolves(character),
+			log: sinon.stub(),
+		};
+		const action = listen({ command: 'unequip 2 Hit from Stonefang', game });
+		expect(action).to.not.equal(null);
+
+		await action!(makeActionOptions(game));
+
+		expect(character.unequipCard.calledOnce).to.equal(true);
+		expect(character.unequipCard.firstCall.args[0]).to.include({
+			cardName: 'hit',
+			count: 2,
+			monsterName: 'stonefang',
+		});
+	});
+
+	it('routes move command with source and destination monsters', async () => {
+		const character = makeCharacter();
+		const game = {
+			getCharacter: sinon.stub().resolves(character),
+			log: sinon.stub(),
+		};
+		const action = listen({ command: 'move Hit from Stonefang to Mirebell', game });
+		expect(action).to.not.equal(null);
+
+		await action!(makeActionOptions(game));
+
+		expect(character.moveCard.calledOnce).to.equal(true);
+		expect(character.moveCard.firstCall.args[0]).to.include({
+			cardName: 'hit',
+			fromMonsterName: 'stonefang',
+			toMonsterName: 'mirebell',
+		});
+	});
+
+	it('routes look at inventory commands', async () => {
+		const character = makeCharacter();
+		const game = {
+			getCharacter: sinon.stub().resolves(character),
+			log: sinon.stub(),
+			lookAt: sinon.stub().resolves(undefined),
+		};
+
+		const inventoryAction = listen({ command: 'look at inventory', game });
+		const cardsAction = listen({ command: 'look at all cards', game });
+		expect(inventoryAction).to.not.equal(null);
+		expect(cardsAction).to.not.equal(null);
+
+		await inventoryAction!(makeActionOptions(game));
+		await cardsAction!(makeActionOptions(game));
+
+		expect(character.lookAtInventory.calledOnce).to.equal(true);
+		expect(character.lookAtCardInventory.calledOnce).to.equal(true);
+	});
+
+	it('routes preset commands', async () => {
+		const privateChannel = sinon.stub().resolves(undefined);
+		const character = makeCharacter({
+			getPresets: sinon.stub().returns({ aggro: ['hit'] }),
+		});
+		const game = {
+			getCharacter: sinon.stub().resolves(character),
+			log: sinon.stub(),
+		};
+
+		const saveAction = listen({ command: 'save preset aggro for Stonefang', game });
+		const loadAction = listen({ command: 'load preset aggro on Stonefang', game });
+		const deleteAction = listen({ command: 'delete preset aggro for Stonefang', game });
+		const listAction = listen({ command: 'look at presets for Stonefang', game });
+
+		await saveAction!({ ...makeActionOptions(game), channel: privateChannel });
+		await loadAction!({ ...makeActionOptions(game), channel: privateChannel });
+		await deleteAction!({ ...makeActionOptions(game), channel: privateChannel });
+		await listAction!({ ...makeActionOptions(game), channel: privateChannel });
+
+		expect(character.savePreset.calledOnce).to.equal(true);
+		expect(character.loadPreset.calledOnce).to.equal(true);
+		expect(character.deletePreset.calledOnce).to.equal(true);
+		expect(character.getPresets.calledOnceWith('stonefang')).to.equal(true);
+		expect(privateChannel.called).to.equal(true);
+	});
+});

--- a/packages/engine/src/commands/catalog.ts
+++ b/packages/engine/src/commands/catalog.ts
@@ -26,9 +26,21 @@ export const COMMAND_CATALOG: CommandEntry[] = [
 
 	// Cards
 	{ command: 'look at cards', description: 'View all cards in your deck', category: 'cards' },
+	{ command: 'look at card inventory', description: 'View equipped and unequipped cards together', category: 'cards' },
+	{ command: 'look at all cards', description: 'Alias for card inventory', category: 'cards' },
+	{ command: 'look at inventory', description: 'View all cards and items across your character and monsters', category: 'cards' },
 	{ command: 'look at [card name]', description: 'View details about a specific card', category: 'cards', example: 'look at Hit' },
 	{ command: 'look at card [card name]', description: 'View details about a specific card', category: 'cards', example: 'look at card Heal' },
 	{ command: 'look at deck', description: 'View your full card deck', category: 'cards' },
+	{ command: 'unequip [card] from [monster]', description: 'Remove a card from a monster back to your deck', category: 'cards', example: 'unequip Hit from Fluffy' },
+	{ command: 'unequip [count] [card] from [monster]', description: 'Remove multiple copies of a card from a monster', category: 'cards', example: 'unequip 2 Hit from Fluffy' },
+	{ command: 'unequip all from [monster]', description: "Clear a monster's full deck back to your inventory", category: 'cards', example: 'unequip all from Fluffy' },
+	{ command: 'move [card] from [monster A] to [monster B]', description: 'Move a card directly between monsters', category: 'cards', example: 'move Hit from Fluffy to Fang' },
+	{ command: 'move [count] [card] from [monster A] to [monster B]', description: 'Move multiple copies directly between monsters', category: 'cards', example: 'move 2 Hit from Fluffy to Fang' },
+	{ command: 'save preset [name] for [monster]', description: "Save a monster's current deck as a preset", category: 'cards', example: 'save preset tank for Fluffy' },
+	{ command: 'load preset [name] on [monster]', description: 'Load a preset onto a monster', category: 'cards', example: 'load preset tank on Fluffy' },
+	{ command: 'look at presets for [monster]', description: 'List saved presets for a monster', category: 'cards', example: 'look at presets for Fluffy' },
+	{ command: 'delete preset [name] for [monster]', description: 'Delete a saved preset', category: 'cards', example: 'delete preset tank for Fluffy' },
 
 	// Items
 	{ command: 'look at items', description: 'View your items', category: 'items' },

--- a/packages/engine/src/commands/index.ts
+++ b/packages/engine/src/commands/index.ts
@@ -3,6 +3,7 @@ import historyHandlers from './history.js';
 import monsterHandlers from './monster.js';
 import characterHandlers from './character.js';
 import storeHandlers from './store.js';
+import presetHandlers from './presets.js';
 import { helpHandler } from './help.js';
 import { commandInputSchema } from '../schemas/command.js';
 
@@ -128,6 +129,7 @@ export function loadHandlers(): void {
 	historyHandlers();
 	lookAtHandlers(registerHandler);
 	monsterHandlers(registerHandler);
+	presetHandlers(registerHandler);
 	characterHandlers(registerHandler);
 	storeHandlers(registerHandler);
 }

--- a/packages/engine/src/commands/look-at.ts
+++ b/packages/engine/src/commands/look-at.ts
@@ -1,7 +1,7 @@
 import type { registerHandler } from './index.js';
 
 const LOOK_AT_REGEX =
-	/look (?:at )?(?:the )?(monster(?:s)? manual|player(?:s)? handbook|(?:dungeon master(?:s)|dm)? guide|monsters in|monsters|monster|character|cards in|cards|card|deck|item|items|ring|dmg)?( .+)?$/i;
+	/look (?:at )?(?:the )?(monster(?:s)? manual|player(?:s)? handbook|(?:dungeon master(?:s)|dm)? guide|monsters in|monsters|monster|character|cards in|card inventory|all cards|inventory|cards|card|deck|item|items|ring|dmg)?( .+)?$/i;
 
 function lookAtAction({ channel, character, game, results }: any): Promise<unknown> {
 	return Promise.resolve()
@@ -13,6 +13,11 @@ function lookAtAction({ channel, character, game, results }: any): Promise<unkno
 				case 'deck':
 				case 'cards':
 					return character.lookAtCards(channel, thing);
+				case 'card inventory':
+				case 'all cards':
+					return character.lookAtCardInventory(channel);
+				case 'inventory':
+					return character.lookAtInventory(channel);
 				case 'ring': {
 					const summary = thing === 'summary';
 					return game.lookAtRing(channel, undefined, true, summary);

--- a/packages/engine/src/commands/monster.ts
+++ b/packages/engine/src/commands/monster.ts
@@ -8,8 +8,25 @@ const cleanArgs = (args: Record<string, any> = {}): Record<string, any> => {
 		delete args.monsterName;
 	}
 
+	if (typeof args.fromMonsterName === 'string') {
+		args.fromMonsterName = args.fromMonsterName.trim().replace(/^monster\s+/i, '');
+	}
+
+	if (typeof args.toMonsterName === 'string') {
+		args.toMonsterName = args.toMonsterName.trim().replace(/^monster\s+/i, '');
+	}
+
 	if (args.cardSelection) {
 		args.cardSelection = getArray(args.cardSelection);
+	}
+
+	if (args.cardName && typeof args.cardName === 'string') {
+		args.cardName = args.cardName.trim();
+	}
+
+	if (args.count !== undefined) {
+		const parsedCount = Number(args.count);
+		args.count = Number.isFinite(parsedCount) ? parsedCount : undefined;
 	}
 
 	if (args.itemSelection) {
@@ -70,7 +87,7 @@ function editMonsterAction({ channel, game, isAdmin, results }: any): Promise<un
 	});
 }
 
-const EQUIP_REGEX = /equip (?:a )?(.+?)(?: with (.+?))?$/i;
+const EQUIP_REGEX = /^equip (?:a )?(.+?)(?: with (.+?))?$/i;
 function equipMonsterAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
 	if (!isDM) {
 		return Promise.reject(new Error('Please talk to me in a direct message'));
@@ -84,6 +101,60 @@ function equipMonsterAction({ channel, character, game, isDM, results }: any): P
 
 		return character
 			.equipMonster({ channel, cardSelection, monsterName })
+			.catch((err: unknown) => game.log(err));
+	});
+}
+
+const UNEQUIP_CARD_REGEX = /unequip (?:(\d+) )?(.+?) from (?:a )?(.+?)$/i;
+function unequipCardAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve().then(() => {
+		const { cardName, count, monsterName } = cleanArgs({
+			count: results[1],
+			cardName: results[2],
+			monsterName: results[3],
+		});
+
+		return character
+			.unequipCard({ channel, cardName, count, monsterName })
+			.catch((err: unknown) => game.log(err));
+	});
+}
+
+const UNEQUIP_ALL_REGEX = /(?:unequip all from|clear deck) (?:a )?(.+?)$/i;
+function unequipAllAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve().then(() => {
+		const { monsterName } = cleanArgs({ monsterName: results[1] });
+
+		return character
+			.unequipAll({ channel, monsterName })
+			.catch((err: unknown) => game.log(err));
+	});
+}
+
+const MOVE_CARD_REGEX = /move (?:(\d+) )?(.+?) from (?:a )?(.+?) to (?:a )?(.+?)$/i;
+function moveCardAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve().then(() => {
+		const { cardName, count, fromMonsterName, toMonsterName } = cleanArgs({
+			count: results[1],
+			cardName: results[2],
+			fromMonsterName: results[3],
+			toMonsterName: results[4],
+		});
+
+		return character
+			.moveCard({ channel, cardName, count, fromMonsterName, toMonsterName })
 			.catch((err: unknown) => game.log(err));
 	});
 }
@@ -243,6 +314,9 @@ export default function monsterHandlers(
 	registerHandlerFn(DISMISS_REGEX, dismissMonsterAction);
 	registerHandlerFn(EDIT_REGEX, editMonsterAction);
 	registerHandlerFn(EQUIP_REGEX, equipMonsterAction);
+	registerHandlerFn(UNEQUIP_CARD_REGEX, unequipCardAction);
+	registerHandlerFn(UNEQUIP_ALL_REGEX, unequipAllAction);
+	registerHandlerFn(MOVE_CARD_REGEX, moveCardAction);
 	registerHandlerFn(GIVE_ITEMS_TO_MONSTER_REGEX, giveItemsToMonsterAction);
 	registerHandlerFn(REVIVE_REGEX, reviveMonsterAction);
 	registerHandlerFn(SEND_MONSTER_EXPLORING_REGEX, sendMonsterExploringAction);

--- a/packages/engine/src/commands/presets.ts
+++ b/packages/engine/src/commands/presets.ts
@@ -1,0 +1,115 @@
+import type { registerHandler } from './index.js';
+
+const cleanMonsterName = (monsterName?: string): string | undefined => {
+	if (!monsterName || monsterName === 'monster') return undefined;
+	return monsterName.trim().replace(/^monster\s+/i, '');
+};
+
+const cleanPresetName = (presetName?: string): string => (presetName ?? '').trim();
+
+const SAVE_PRESET_REGEX = /save preset (.+?) for (?:a )?(.+?)$/i;
+function savePresetAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve()
+		.then(() =>
+			character.savePreset({
+				channel,
+				presetName: cleanPresetName(results[1]),
+				monsterName: cleanMonsterName(results[2]),
+			}),
+		)
+		.catch((err: unknown) => game.log(err));
+}
+
+const LOAD_PRESET_REGEX = /load preset (.+?) on (?:a )?(.+?)$/i;
+function loadPresetAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve()
+		.then(() =>
+			character.loadPreset({
+				channel,
+				presetName: cleanPresetName(results[1]),
+				monsterName: cleanMonsterName(results[2]),
+			}),
+		)
+		.catch((err: unknown) => game.log(err));
+}
+
+const DELETE_PRESET_REGEX = /delete preset (.+?) for (?:a )?(.+?)$/i;
+function deletePresetAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve()
+		.then(() =>
+			character.deletePreset({
+				channel,
+				presetName: cleanPresetName(results[1]),
+				monsterName: cleanMonsterName(results[2]),
+			}),
+		)
+		.catch((err: unknown) => game.log(err));
+}
+
+const LOOK_AT_PRESETS_REGEX = /look at presets(?: for (?:a )?(.+?))?$/i;
+function lookAtPresetsAction({ channel, character, game, isDM, results }: any): Promise<unknown> {
+	if (!isDM) {
+		return Promise.reject(new Error('Please talk to me in a direct message'));
+	}
+
+	return Promise.resolve()
+		.then(() => {
+			const monsterName = cleanMonsterName(results[1]);
+			const presets = character.getPresets(monsterName);
+			const lines: string[] = ['Presets'];
+
+			if (monsterName) {
+				lines.push(`for ${monsterName}:`);
+				const entries = Object.entries(presets as Record<string, string[]>);
+				if (entries.length < 1) {
+					lines.push('  (none)');
+				} else {
+					entries.sort(([a], [b]) => a.localeCompare(b)).forEach(([preset, cards]) => {
+						lines.push(`  ${preset}: ${cards.join(', ') || '(empty)'}`);
+					});
+				}
+				return channel({ announce: lines.join('\n') });
+			}
+
+			const grouped = presets as Record<string, Record<string, string[]>>;
+			const monsters = Object.keys(grouped).sort((a, b) => a.localeCompare(b));
+			if (monsters.length < 1) {
+				lines.push('(none)');
+				return channel({ announce: lines.join('\n') });
+			}
+
+			monsters.forEach((monster) => {
+				lines.push('');
+				lines.push(`${monster}:`);
+				const entries = Object.entries(grouped[monster] ?? {});
+				if (entries.length < 1) {
+					lines.push('  (none)');
+					return;
+				}
+				entries.sort(([a], [b]) => a.localeCompare(b)).forEach(([preset, cards]) => {
+					lines.push(`  ${preset}: ${cards.join(', ') || '(empty)'}`);
+				});
+			});
+			return channel({ announce: lines.join('\n') });
+		})
+		.catch((err: unknown) => game.log(err));
+}
+
+export default function presetHandlers(registerHandlerFn: typeof registerHandler): void {
+	registerHandlerFn(SAVE_PRESET_REGEX, savePresetAction);
+	registerHandlerFn(LOAD_PRESET_REGEX, loadPresetAction);
+	registerHandlerFn(DELETE_PRESET_REGEX, deletePresetAction);
+	registerHandlerFn(LOOK_AT_PRESETS_REGEX, lookAtPresetsAction);
+}

--- a/packages/engine/src/constants/card-management.ts
+++ b/packages/engine/src/constants/card-management.ts
@@ -1,0 +1,1 @@
+export const MAX_PRESETS = 10;

--- a/packages/engine/src/constants/index.ts
+++ b/packages/engine/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './card-classes.js';
+export * from './card-management.js';
 export * from './coins.js';
 export * from './creature-classes.js';
 export * from './creature-types.js';

--- a/packages/engine/src/events/types.ts
+++ b/packages/engine/src/events/types.ts
@@ -14,6 +14,8 @@ export type EventType =
 	| 'ring.cardDrop'
 	| 'ring.state'
 	| 'card.played'
+	| 'card.equipped'
+	| 'card.presetLoaded'
 	| 'announce'
 	| 'prompt.request'
 	| 'prompt.timeout'

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -50,3 +50,100 @@ describe('trpc/router respondToPrompt', () => {
 		expect((err as TRPCError).code).to.equal('PRECONDITION_FAILED');
 	});
 });
+
+describe('trpc/router card management procedures', () => {
+	it('returns inventory summary for game.myInventory', async () => {
+		const targetMonster = {
+			givenName: 'Stonefang',
+			creatureType: 'Basilisk',
+			level: 4,
+			inEncounter: false,
+			cardSlots: 9,
+			cards: [{ cardType: 'Hit' }],
+			items: [{ itemType: 'Potion' }],
+			options: { presets: { aggro: ['Hit'] } },
+		};
+		const game = {
+			characters: {
+				[USER_ID]: {
+					monsters: [targetMonster],
+					deck: [{ cardType: 'Blink' }],
+					items: [{ itemType: 'Scroll' }],
+				},
+			},
+			ring: { contestants: [{ userId: USER_ID, isBoss: false, monster: targetMonster }] },
+		};
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => game,
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const result = await caller.game.myInventory({ roomId: ROOM_ID });
+
+		expect(result.monsters).to.have.length(1);
+		expect(result.monsters[0]).to.include({
+			name: 'Stonefang',
+			type: 'Basilisk',
+			inRing: true,
+		});
+		expect(result.unequippedDeck).to.deep.equal(['Blink']);
+		expect(result.items.character).to.deep.equal(['Scroll']);
+	});
+
+	it('runs game.unequipCard via serialized engine work', async () => {
+		const unequipCard = async () => ({ removedCount: 1, monsterName: 'Stonefang' });
+		const publish = () => undefined;
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => ({
+				characters: { [USER_ID]: { unequipCard } },
+			}),
+			getEventBus: async () => ({ publish }),
+			runSerializedEngineWork: async (_roomId: string, fn: () => Promise<unknown>) => fn(),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const result = await caller.game.unequipCard({
+			roomId: ROOM_ID,
+			monsterName: 'Stonefang',
+			cardName: 'Hit',
+		});
+
+		expect(result).to.deep.equal({ removedCount: 1, monsterName: 'Stonefang' });
+	});
+
+	it('returns transformed loadPreset result', async () => {
+		const loadPreset = async () => ({
+			equipped: 2,
+			requested: 3,
+			skippedCards: ['Heal'],
+			presetName: 'aggro',
+			monsterName: 'Stonefang',
+		});
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => ({
+				characters: { [USER_ID]: { loadPreset } },
+			}),
+			getEventBus: async () => ({ publish: () => undefined }),
+			runSerializedEngineWork: async (_roomId: string, fn: () => Promise<unknown>) => fn(),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const result = await caller.game.loadPreset({
+			roomId: ROOM_ID,
+			monsterName: 'Stonefang',
+			presetName: 'aggro',
+		});
+
+		expect(result).to.deep.equal({
+			equippedCount: 2,
+			requestedCount: 3,
+			skippedCards: ['Heal'],
+		});
+	});
+});

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -146,4 +146,44 @@ describe('trpc/router card management procedures', () => {
 			skippedCards: ['Heal'],
 		});
 	});
+
+	it('routes game.equipCards through character.equipCards and returns summary', async () => {
+		let receivedInput: Record<string, unknown> | null = null;
+		const equipCards = async (input: Record<string, unknown>) => {
+			receivedInput = input;
+			return {
+				equipped: 1,
+				requested: 2,
+				skippedCards: ['Heal'],
+				monsterName: 'Stonefang',
+			};
+		};
+
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => ({
+				characters: { [USER_ID]: { equipCards } },
+			}),
+			getEventBus: async () => ({ publish: () => undefined }),
+			runSerializedEngineWork: async (_roomId: string, fn: () => Promise<unknown>) => fn(),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const result = await caller.game.equipCards({
+			roomId: ROOM_ID,
+			monsterName: 'Stonefang',
+			cardNames: ['Hit', 'Heal'],
+		});
+
+		expect(receivedInput).to.not.equal(null);
+		expect(receivedInput?.monsterName).to.equal('Stonefang');
+		expect(receivedInput?.cardNames).to.deep.equal(['Hit', 'Heal']);
+		expect(receivedInput?.replaceAll).to.equal(false);
+		expect(result).to.deep.equal({
+			equippedCount: 1,
+			requestedCount: 2,
+			skippedCards: ['Heal'],
+		});
+	});
 });

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -148,7 +148,7 @@ describe('trpc/router card management procedures', () => {
 	});
 
 	it('routes game.equipCards through character.equipCards and returns summary', async () => {
-		let receivedInput: Record<string, unknown> | null = null;
+		let receivedInput: Record<string, unknown> | undefined;
 		const equipCards = async (input: Record<string, unknown>) => {
 			receivedInput = input;
 			return {
@@ -176,10 +176,12 @@ describe('trpc/router card management procedures', () => {
 			cardNames: ['Hit', 'Heal'],
 		});
 
-		expect(receivedInput).to.not.equal(null);
-		expect(receivedInput?.monsterName).to.equal('Stonefang');
-		expect(receivedInput?.cardNames).to.deep.equal(['Hit', 'Heal']);
-		expect(receivedInput?.replaceAll).to.equal(false);
+		expect(receivedInput).to.not.equal(undefined);
+		if (!receivedInput) throw new Error('Expected equipCards to be called');
+		const callInput = receivedInput;
+		expect(callInput.monsterName).to.equal('Stonefang');
+		expect(callInput.cardNames).to.deep.equal(['Hit', 'Heal']);
+		expect(callInput.replaceAll).to.equal(false);
 		expect(result).to.deep.equal({
 			equippedCount: 1,
 			requestedCount: 2,

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -115,6 +115,31 @@ describe('trpc/router card management procedures', () => {
 		expect(result).to.deep.equal({ removedCount: 1, monsterName: 'Stonefang' });
 	});
 
+	it('maps engine mutation failures to BAD_REQUEST errors with message', async () => {
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => ({
+				characters: { [USER_ID]: { unequipCard: async () => ({}) } },
+			}),
+			getEventBus: async () => ({ publish: () => undefined }),
+			runSerializedEngineWork: async () => {
+				throw new Error('Cannot unequip while in encounter');
+			},
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const err = await caller.game.unequipCard({
+			roomId: ROOM_ID,
+			monsterName: 'Stonefang',
+			cardName: 'Hit',
+		}).catch((e: unknown) => e);
+
+		expect(err).to.be.instanceOf(TRPCError);
+		expect((err as TRPCError).code).to.equal('BAD_REQUEST');
+		expect((err as TRPCError).message).to.equal('Cannot unequip while in encounter');
+	});
+
 	it('returns transformed loadPreset result', async () => {
 		const loadPreset = async () => ({
 			equipped: 2,

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -246,6 +246,18 @@ function createSilentChannel({
 }
 
 export function createRouter(roomManager: RoomManager) {
+	const runSerializedMutation = async <T>(roomId: string, fn: () => Promise<T>): Promise<T> => {
+		try {
+			return await roomManager.runSerializedEngineWork(roomId, fn);
+		} catch (err) {
+			if (err instanceof TRPCError) throw err;
+			throw new TRPCError({
+				code: 'BAD_REQUEST',
+				message: err instanceof Error ? err.message : 'Operation failed',
+			});
+		}
+	};
+
 	const leaderboardRouter = t.router({
 		roomPlayers: protectedProcedure
 			.input(
@@ -686,7 +698,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.unequipCard({
 						channel,
 						cardName: input.cardName,
@@ -747,7 +759,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.unequipAll({
 						channel,
 						monsterName: input.monsterName,
@@ -808,7 +820,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.equipCards({
 						channel,
 						monsterName: input.monsterName,
@@ -883,7 +895,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.moveCard({
 						channel,
 						cardName: input.cardName,
@@ -959,7 +971,7 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.savePreset({
 						channel,
 						monsterName: input.monsterName,
@@ -989,7 +1001,7 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.loadPreset({
 						channel,
 						monsterName: input.monsterName,
@@ -1043,7 +1055,7 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, () =>
 					character.deletePreset({
 						channel,
 						monsterName: input.monsterName,

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -802,33 +802,20 @@ export function createRouter(roomManager: RoomManager) {
 					roomManager.getEventBus(input.roomId),
 				]);
 				const character = game.characters?.[ctx.userId];
-				if (!character || typeof character.equipMonster !== 'function') {
+				if (!character || typeof character.equipCards !== 'function') {
 					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
 				}
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await roomManager.runSerializedEngineWork(input.roomId, async () => {
-					if (input.replaceAll && typeof character.unequipAll === 'function') {
-						await character.unequipAll({
-							channel,
-							monsterName: input.monsterName,
-						});
-					}
-
-					await character.equipMonster({
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.equipCards({
 						channel,
 						monsterName: input.monsterName,
-						cardSelection: input.cardNames,
-					});
-					return {
-						monsterName: input.monsterName,
-						cards: getMonsterCardsByName({
-							character: character as Record<string, unknown>,
-							monsterName: input.monsterName,
-						}),
-					};
-				}) as { monsterName: string; cards: string[] };
+						cardNames: input.cardNames,
+						replaceAll: input.replaceAll ?? false,
+					}),
+				) as { equipped: number; requested: number; skippedCards: string[]; monsterName: string };
 				eventBus.publish({
 					type: 'card.equipped' as EventType,
 					scope: 'private',
@@ -836,15 +823,21 @@ export function createRouter(roomManager: RoomManager) {
 					text: '',
 					payload: {
 						operation: 'equipCards',
-						monsterName: input.monsterName,
+						monsterName: result.monsterName,
 						cardNames: input.cardNames,
+						equippedCount: result.equipped,
+						requestedCount: result.requested,
+						skippedCards: result.skippedCards,
 					},
 				});
 
+				const skippedText = result.skippedCards.length > 0
+					? ` Skipped: ${result.skippedCards.join(', ')}.`
+					: '';
 				publishPrivateAnnouncement({
 					eventBus,
 					userId: ctx.userId,
-					text: `Equipped ${input.monsterName} with ${input.cardNames.join(', ')}.`,
+					text: `Equipped ${result.monsterName}: ${result.equipped}/${result.requested}.${skippedText}`,
 					operation: 'equipCards',
 				});
 				eventBus.publish({
@@ -854,10 +847,17 @@ export function createRouter(roomManager: RoomManager) {
 					text: '',
 					payload: {
 						monsterName: result.monsterName,
-						cards: result.cards,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: result.monsterName,
+						}),
 					},
 				});
-				return { ok: true };
+				return {
+					equippedCount: result.equipped,
+					requestedCount: result.requested,
+					skippedCards: result.skippedCards,
+				};
 			}),
 
 		moveCard: protectedProcedure

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -54,6 +54,18 @@ type InventorySummary = {
 	};
 };
 
+type PublishableEvent = {
+	type: EventType;
+	scope: EventScope;
+	text: string;
+	payload: Record<string, unknown>;
+	targetUserId?: string;
+};
+
+type EventBusPublisher = {
+	publish: (event: PublishableEvent) => unknown;
+};
+
 const getDisplayName = (entity: unknown): string => {
 	if (!entity || typeof entity !== 'object') return 'Unknown';
 	const entry = entity as Record<string, unknown>;
@@ -161,7 +173,7 @@ const publishPrivateAnnouncement = ({
 	text,
 	operation,
 }: {
-	eventBus: { publish: (event: GameEvent) => GameEvent } | { publish: (event: any) => any };
+	eventBus: EventBusPublisher;
 	userId: string;
 	text: string;
 	operation: string;
@@ -207,7 +219,7 @@ function createSilentChannel({
 	userId,
 	commandId,
 }: {
-	eventBus: { publish: (event: GameEvent) => unknown };
+	eventBus: EventBusPublisher;
 	userId: string;
 	commandId: string;
 }) {
@@ -681,13 +693,17 @@ export function createRouter(roomManager: RoomManager) {
 						monsterName: input.monsterName,
 						count: input.count,
 					}),
-				);
+				) as { removedCount: number; monsterName: string };
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
-					payload: { operation: 'unequipCard', ...result },
+					payload: {
+						operation: 'unequipCard',
+						removedCount: result.removedCount,
+						monsterName: result.monsterName,
+					},
 				});
 				publishPrivateAnnouncement({
 					eventBus,
@@ -696,7 +712,7 @@ export function createRouter(roomManager: RoomManager) {
 					operation: 'unequipCard',
 				});
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
@@ -736,13 +752,17 @@ export function createRouter(roomManager: RoomManager) {
 						channel,
 						monsterName: input.monsterName,
 					}),
-				);
+				) as { removedCount: number; monsterName: string };
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
-					payload: { operation: 'unequipAll', ...result },
+					payload: {
+						operation: 'unequipAll',
+						removedCount: result.removedCount,
+						monsterName: result.monsterName,
+					},
 				});
 				publishPrivateAnnouncement({
 					eventBus,
@@ -751,7 +771,7 @@ export function createRouter(roomManager: RoomManager) {
 					operation: 'unequipAll',
 				});
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
@@ -788,7 +808,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				await roomManager.runSerializedEngineWork(input.roomId, async () => {
+				const result = await roomManager.runSerializedEngineWork(input.roomId, async () => {
 					if (input.replaceAll && typeof character.unequipAll === 'function') {
 						await character.unequipAll({
 							channel,
@@ -801,9 +821,16 @@ export function createRouter(roomManager: RoomManager) {
 						monsterName: input.monsterName,
 						cardSelection: input.cardNames,
 					});
-				});
+					return {
+						monsterName: input.monsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: input.monsterName,
+						}),
+					};
+				}) as { monsterName: string; cards: string[] };
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
@@ -821,16 +848,13 @@ export function createRouter(roomManager: RoomManager) {
 					operation: 'equipCards',
 				});
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
 					payload: {
-						monsterName: input.monsterName,
-						cards: getMonsterCardsByName({
-							character: character as Record<string, unknown>,
-							monsterName: input.monsterName,
-						}),
+						monsterName: result.monsterName,
+						cards: result.cards,
 					},
 				});
 				return { ok: true };
@@ -867,13 +891,18 @@ export function createRouter(roomManager: RoomManager) {
 						toMonsterName: input.toMonsterName,
 						count: input.count,
 					}),
-				);
+				) as { movedCount: number; fromMonsterName: string; toMonsterName: string };
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
-					payload: { operation: 'moveCard', ...result },
+					payload: {
+						operation: 'moveCard',
+						movedCount: result.movedCount,
+						fromMonsterName: result.fromMonsterName,
+						toMonsterName: result.toMonsterName,
+					},
 				});
 				publishPrivateAnnouncement({
 					eventBus,
@@ -882,7 +911,7 @@ export function createRouter(roomManager: RoomManager) {
 					operation: 'moveCard',
 				});
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
@@ -895,7 +924,7 @@ export function createRouter(roomManager: RoomManager) {
 					},
 				});
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
@@ -966,16 +995,16 @@ export function createRouter(roomManager: RoomManager) {
 						monsterName: input.monsterName,
 						presetName: input.presetName,
 					}),
-				);
+				) as { equipped: number; requested: number; skippedCards: string[] };
 				eventBus.publish({
-					type: 'card.presetLoaded',
+					type: 'card.presetLoaded' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',
 					payload: result,
 				});
 				eventBus.publish({
-					type: 'card.equipped',
+					type: 'card.equipped' as EventType,
 					scope: 'private',
 					targetUserId: ctx.userId,
 					text: '',

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -34,6 +34,150 @@ import {
 	type LeaderboardSort,
 } from '../analytics-queries.js';
 
+type InventoryMonsterSummary = {
+	name: string;
+	type: string;
+	level: number;
+	inRing: boolean;
+	inEncounter: boolean;
+	cardSlots: number;
+	cards: string[];
+	presets: Record<string, string[]>;
+};
+
+type InventorySummary = {
+	monsters: InventoryMonsterSummary[];
+	unequippedDeck: string[];
+	items: {
+		character: string[];
+		monsters: Array<{ monsterName: string; items: string[] }>;
+	};
+};
+
+const getDisplayName = (entity: unknown): string => {
+	if (!entity || typeof entity !== 'object') return 'Unknown';
+	const entry = entity as Record<string, unknown>;
+	const byItemType = typeof entry.itemType === 'string' ? entry.itemType : undefined;
+	const byCardType = typeof entry.cardType === 'string' ? entry.cardType : undefined;
+	const byName = typeof entry.name === 'string' ? entry.name : undefined;
+	return byItemType ?? byCardType ?? byName ?? 'Unknown';
+};
+
+const summarizeInventory = ({
+	character,
+	inRing,
+}: {
+	character: Record<string, unknown>;
+	inRing: Set<unknown>;
+}): InventorySummary => {
+	const monsters = Array.isArray(character.monsters) ? character.monsters : [];
+	const deck = Array.isArray(character.deck) ? character.deck : [];
+	const items = Array.isArray(character.items) ? character.items : [];
+
+	const monsterSummaries = monsters
+		.map((monster) => {
+			const record = (monster ?? {}) as Record<string, unknown>;
+			const cards = Array.isArray(record.cards) ? record.cards : [];
+			const presetsRaw = (record.options as Record<string, unknown> | undefined)?.presets;
+			const presets = Object.entries(
+				(typeof presetsRaw === 'object' && presetsRaw !== null
+					? presetsRaw
+					: {}) as Record<string, unknown>,
+			).reduce<Record<string, string[]>>((all, [presetName, presetCards]) => {
+				if (!Array.isArray(presetCards)) return all;
+				all[presetName] = presetCards
+					.filter((card): card is string => typeof card === 'string')
+					.slice();
+				return all;
+			}, {});
+
+			const name = typeof record.givenName === 'string' ? record.givenName.trim() : '';
+			if (!name) return null;
+
+			return {
+				name,
+				type:
+					typeof record.creatureType === 'string'
+						? record.creatureType
+						: 'Unknown',
+				level:
+					typeof record.level === 'number' && Number.isFinite(record.level)
+						? record.level
+						: 0,
+				inRing: inRing.has(monster),
+				inEncounter: Boolean(record.inEncounter),
+				cardSlots:
+					typeof record.cardSlots === 'number' && Number.isFinite(record.cardSlots)
+						? record.cardSlots
+						: 0,
+				cards: cards.map((card) => getDisplayName(card)),
+				presets,
+			} satisfies InventoryMonsterSummary;
+		})
+		.filter((monster): monster is InventoryMonsterSummary => monster !== null);
+
+	const monsterItems = monsterSummaries.map((monsterSummary) => {
+		const monster = monsters.find(
+			(entry) =>
+				(entry as Record<string, unknown> | undefined)?.givenName ===
+				monsterSummary.name,
+		) as Record<string, unknown> | undefined;
+		const monsterInventory = Array.isArray(monster?.items) ? monster.items : [];
+		return {
+			monsterName: monsterSummary.name,
+			items: monsterInventory.map((item) => getDisplayName(item)),
+		};
+	});
+
+	return {
+		monsters: monsterSummaries,
+		unequippedDeck: deck.map((card) => getDisplayName(card)),
+		items: {
+			character: items.map((item) => getDisplayName(item)),
+			monsters: monsterItems,
+		},
+	};
+};
+
+const getMonsterCardsByName = ({
+	character,
+	monsterName,
+}: {
+	character: Record<string, unknown>;
+	monsterName: string;
+}): string[] => {
+	const monsters = Array.isArray(character.monsters) ? character.monsters : [];
+	const match = monsters.find((monster) => {
+		const name = (monster as Record<string, unknown> | undefined)?.givenName;
+		return typeof name === 'string' && name.toLowerCase() === monsterName.toLowerCase();
+	}) as Record<string, unknown> | undefined;
+	const cards = Array.isArray(match?.cards) ? match.cards : [];
+	return cards.map((card) => getDisplayName(card));
+};
+
+const publishPrivateAnnouncement = ({
+	eventBus,
+	userId,
+	text,
+	operation,
+}: {
+	eventBus: { publish: (event: GameEvent) => GameEvent } | { publish: (event: any) => any };
+	userId: string;
+	text: string;
+	operation: string;
+}): void => {
+	eventBus.publish({
+		type: 'announce',
+		scope: 'private',
+		targetUserId: userId,
+		text,
+		payload: {
+			source: 'workshop',
+			operation,
+		},
+	});
+};
+
 export type AppRouter = ReturnType<typeof createRouter>;
 
 // Increment when the client<->server protocol changes in a breaking way.
@@ -51,6 +195,43 @@ const BUILD_VERSION = process.env['BUILD_VERSION'] ?? 'dev';
 export const activeFlows = new Set<string>();
 
 const sortBySchema = z.enum(['xp', 'wins', 'winRate', 'coins']);
+
+type SilentChannelMessage = {
+	announce?: string;
+	question?: string;
+	choices?: Record<string, unknown> | string[];
+};
+
+function createSilentChannel({
+	eventBus,
+	userId,
+	commandId,
+}: {
+	eventBus: { publish: (event: GameEvent) => unknown };
+	userId: string;
+	commandId: string;
+}) {
+	return async ({ announce, question }: SilentChannelMessage): Promise<unknown> => {
+		if (question) {
+			throw new TRPCError({
+				code: 'BAD_REQUEST',
+				message: 'Interactive prompts are not supported for this operation.',
+			});
+		}
+
+		if (announce) {
+			eventBus.publish({
+				type: 'announce',
+				scope: 'private',
+				targetUserId: userId,
+				text: announce,
+				payload: { causedByCommandId: commandId, silent: true },
+			});
+		}
+
+		return undefined;
+	};
+}
 
 export function createRouter(roomManager: RoomManager) {
 	const leaderboardRouter = t.router({
@@ -443,6 +624,404 @@ export function createRouter(roomManager: RoomManager) {
 								: 0,
 					}))
 					.filter((monster: { name: string }) => monster.name.length > 0);
+			}),
+
+		myInventory: protectedProcedure
+			.input(z.object({ roomId: z.string().uuid() }))
+			.query(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const game = await roomManager.getGame(input.roomId);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character !== 'object') {
+					return {
+						monsters: [],
+						unequippedDeck: [],
+						items: { character: [], monsters: [] },
+					} satisfies InventorySummary;
+				}
+
+				const inRing = new Set(
+					game.ring.contestants
+						.filter((contestant) => contestant?.userId === ctx.userId && !contestant?.isBoss)
+						.map((contestant) => contestant?.monster)
+				);
+
+				return summarizeInventory({
+					character: character as Record<string, unknown>,
+					inRing,
+				});
+			}),
+
+		unequipCard: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+					cardName: z.string().min(1),
+					count: z.number().int().min(1).max(9).optional(),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.unequipCard !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.unequipCard({
+						channel,
+						cardName: input.cardName,
+						monsterName: input.monsterName,
+						count: input.count,
+					}),
+				);
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: { operation: 'unequipCard', ...result },
+				});
+				publishPrivateAnnouncement({
+					eventBus,
+					userId: ctx.userId,
+					text: `Unequipped ${result.removedCount} ${input.cardName} from ${result.monsterName}.`,
+					operation: 'unequipCard',
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: result.monsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: result.monsterName,
+						}),
+					},
+				});
+				return result;
+			}),
+
+		unequipAll: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.unequipAll !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.unequipAll({
+						channel,
+						monsterName: input.monsterName,
+					}),
+				);
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: { operation: 'unequipAll', ...result },
+				});
+				publishPrivateAnnouncement({
+					eventBus,
+					userId: ctx.userId,
+					text: `Cleared ${result.monsterName} (${result.removedCount} cards returned).`,
+					operation: 'unequipAll',
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: result.monsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: result.monsterName,
+						}),
+					},
+				});
+				return result;
+			}),
+
+		equipCards: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+					cardNames: z.array(z.string().min(1)).min(1),
+					replaceAll: z.boolean().optional(),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.equipMonster !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				await roomManager.runSerializedEngineWork(input.roomId, async () => {
+					if (input.replaceAll && typeof character.unequipAll === 'function') {
+						await character.unequipAll({
+							channel,
+							monsterName: input.monsterName,
+						});
+					}
+
+					await character.equipMonster({
+						channel,
+						monsterName: input.monsterName,
+						cardSelection: input.cardNames,
+					});
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						operation: 'equipCards',
+						monsterName: input.monsterName,
+						cardNames: input.cardNames,
+					},
+				});
+
+				publishPrivateAnnouncement({
+					eventBus,
+					userId: ctx.userId,
+					text: `Equipped ${input.monsterName} with ${input.cardNames.join(', ')}.`,
+					operation: 'equipCards',
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: input.monsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: input.monsterName,
+						}),
+					},
+				});
+				return { ok: true };
+			}),
+
+		moveCard: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					cardName: z.string().min(1),
+					fromMonsterName: z.string().min(1),
+					toMonsterName: z.string().min(1),
+					count: z.number().int().min(1).max(9).optional(),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.moveCard !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.moveCard({
+						channel,
+						cardName: input.cardName,
+						fromMonsterName: input.fromMonsterName,
+						toMonsterName: input.toMonsterName,
+						count: input.count,
+					}),
+				);
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: { operation: 'moveCard', ...result },
+				});
+				publishPrivateAnnouncement({
+					eventBus,
+					userId: ctx.userId,
+					text: `Moved ${result.movedCount} ${input.cardName} from ${result.fromMonsterName} to ${result.toMonsterName}.`,
+					operation: 'moveCard',
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: result.fromMonsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: result.fromMonsterName,
+						}),
+					},
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: result.toMonsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: result.toMonsterName,
+						}),
+					},
+				});
+				return result;
+			}),
+
+		savePreset: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+					presetName: z.string().min(1).max(32),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.savePreset !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.savePreset({
+						channel,
+						monsterName: input.monsterName,
+						presetName: input.presetName,
+					}),
+				);
+				return result;
+			}),
+
+		loadPreset: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+					presetName: z.string().min(1).max(32),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.loadPreset !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.loadPreset({
+						channel,
+						monsterName: input.monsterName,
+						presetName: input.presetName,
+					}),
+				);
+				eventBus.publish({
+					type: 'card.presetLoaded',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: result,
+				});
+				eventBus.publish({
+					type: 'card.equipped',
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: input.monsterName,
+						cards: getMonsterCardsByName({
+							character: character as Record<string, unknown>,
+							monsterName: input.monsterName,
+						}),
+					},
+				});
+				return {
+					equippedCount: result.equipped,
+					requestedCount: result.requested,
+					skippedCards: result.skippedCards,
+				};
+			}),
+
+		deletePreset: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+					presetName: z.string().min(1).max(32),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.deletePreset !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await roomManager.runSerializedEngineWork(input.roomId, () =>
+					character.deletePreset({
+						channel,
+						monsterName: input.monsterName,
+						presetName: input.presetName,
+					}),
+				);
+				return result;
 			}),
 
 		ringHistory: protectedProcedure


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Implemented card-management foundations in the engine: unified card/inventory views, unequip/move flows, preset save/load/delete APIs, new command handlers, and command catalog updates.
- Added server tRPC procedures for workshop operations: `game.myInventory`, `game.unequipCard`, `game.unequipAll`, `game.equipCards`, `game.moveCard`, `game.savePreset`, `game.loadPreset`, and `game.deletePreset`.
- Added targeted engine and server tests for the new behaviors.

## Testing
- `pnpm --filter @deck-monsters/engine test`
- `pnpm --filter @deck-monsters/server test`

## Notes
- Web workshop UI route/components/hooks are in progress in follow-up commits on this same branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f3cdf5-62a3-487b-b2cd-98688599721d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f3cdf5-62a3-487b-b2cd-98688599721d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

