### PR TITLE
Improve workshop card compatibility visibility and filtering

### DIFF
--- a/apps/web/src/__tests__/consolePane-scroll-behavior.test.tsx
+++ b/apps/web/src/__tests__/consolePane-scroll-behavior.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+const scrollToIndexMock = vi.fn();
+
+const subscriptionHandlers: {
+  onData?: (event: { id: string; data: any }) => void;
+} = {};
+
+vi.mock('react-virtuoso', () => {
+  const React = require('react');
+
+  const Virtuoso = React.forwardRef((props: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      scrollToIndex: scrollToIndexMock,
+    }));
+
+    return (
+      <div>
+        <div data-testid="event-count">{props.data?.length ?? 0}</div>
+        <button type="button" onClick={() => props.atBottomStateChange?.(false)}>
+          Mark not at bottom
+        </button>
+        <button type="button" onClick={() => props.atBottomStateChange?.(true)}>
+          Mark at bottom
+        </button>
+      </div>
+    );
+  });
+
+  return { Virtuoso };
+});
+
+vi.mock('../lib/auth-context.js', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('../hooks/useHandshake.js', () => ({
+  useHandshake: () => ({
+    handleHandshakeEvent: () => undefined,
+  }),
+}));
+
+vi.mock('../lib/command-insert-context.js', () => ({
+  useCommandInsert: () => ({
+    registerInsertFn: () => undefined,
+  }),
+}));
+
+vi.mock('../hooks/useCommandAutocomplete.js', () => ({
+  useCommandAutocomplete: () => [],
+}));
+
+vi.mock('./CommandSuggestions.js', () => ({
+  default: () => null,
+}));
+
+vi.mock('./InlineChoices.js', () => ({
+  default: () => null,
+}));
+
+vi.mock('../lib/trpc.js', () => ({
+  trpc: {
+    game: {
+      consoleHistory: {
+        useQuery: () => ({ data: [] }),
+      },
+      pendingPrompt: {
+        useQuery: () => ({ data: null, refetch: vi.fn(async () => ({ data: null })) }),
+      },
+      myMonsters: {
+        useQuery: () => ({ data: [] }),
+      },
+      command: {
+        useMutation: () => ({ mutateAsync: vi.fn(async () => ({ ok: true })) }),
+      },
+      respondToPrompt: {
+        useMutation: () => ({ mutateAsync: vi.fn(async () => ({ ok: true })) }),
+      },
+      cancelPrompt: {
+        useMutation: () => ({ mutateAsync: vi.fn(async () => ({ ok: true })) }),
+      },
+      cancelFlow: {
+        useMutation: () => ({ mutateAsync: vi.fn(async () => ({ ok: true })) }),
+      },
+      ringFeed: {
+        useSubscription: (_input: unknown, handlers: { onData?: (event: { id: string; data: any }) => void }) => {
+          subscriptionHandlers.onData = handlers.onData;
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('../utils/format-event-text.js', () => ({
+  formatEventText: (text: string) => text,
+}));
+
+vi.mock('../utils/console-history-event-map.js', () => ({
+  mapConsoleHistoryEvent: () => null,
+}));
+
+import ConsolePane from '../components/ConsolePane.js';
+
+describe('ConsolePane scroll behavior', () => {
+  beforeEach(() => {
+    scrollToIndexMock.mockReset();
+    subscriptionHandlers.onData = undefined;
+  });
+
+  it('only follows new events when already at bottom', () => {
+    render(<ConsolePane roomId="11111111-1111-1111-1111-111111111111" isActive onEvent={() => undefined} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark not at bottom' }));
+    subscriptionHandlers.onData?.({
+      id: 'evt-1',
+      data: {
+        id: 'evt-1',
+        type: 'announce',
+        scope: 'private',
+        targetUserId: 'user-1',
+        text: 'hello',
+        payload: {},
+      },
+    });
+
+    expect(scrollToIndexMock).not.toHaveBeenCalledWith({ index: 'LAST', behavior: 'auto' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark at bottom' }));
+    subscriptionHandlers.onData?.({
+      id: 'evt-2',
+      data: {
+        id: 'evt-2',
+        type: 'announce',
+        scope: 'private',
+        targetUserId: 'user-1',
+        text: 'hello again',
+        payload: {},
+      },
+    });
+
+    expect(scrollToIndexMock).toHaveBeenCalledWith({ index: 'LAST', behavior: 'auto' });
+  });
+});

--- a/apps/web/src/__tests__/consolePane-scroll-behavior.test.tsx
+++ b/apps/web/src/__tests__/consolePane-scroll-behavior.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 
 const scrollToIndexMock = vi.fn();
+let restoreRaf: (() => void) | null = null;
 
 const subscriptionHandlers: {
   onData?: (event: { id: string; data: any }) => void;
@@ -64,7 +65,7 @@ vi.mock('../lib/trpc.js', () => ({
   trpc: {
     game: {
       consoleHistory: {
-        useQuery: () => ({ data: [] }),
+        useQuery: () => ({ data: undefined }),
       },
       pendingPrompt: {
         useQuery: () => ({ data: null, refetch: vi.fn(async () => ({ data: null })) }),
@@ -107,39 +108,54 @@ describe('ConsolePane scroll behavior', () => {
   beforeEach(() => {
     scrollToIndexMock.mockReset();
     subscriptionHandlers.onData = undefined;
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    restoreRaf = () => rafSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    restoreRaf?.();
+    restoreRaf = null;
   });
 
   it('only follows new events when already at bottom', () => {
-    render(<ConsolePane roomId="11111111-1111-1111-1111-111111111111" isActive onEvent={() => undefined} />);
+    render(<ConsolePane roomId="11111111-1111-1111-1111-111111111111" isActive={false} onEvent={() => undefined} />);
+    scrollToIndexMock.mockClear();
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark not at bottom' }));
-    subscriptionHandlers.onData?.({
-      id: 'evt-1',
-      data: {
+    act(() => {
+      subscriptionHandlers.onData?.({
         id: 'evt-1',
-        type: 'announce',
-        scope: 'private',
-        targetUserId: 'user-1',
-        text: 'hello',
-        payload: {},
-      },
+        data: {
+          id: 'evt-1',
+          type: 'announce',
+          scope: 'private',
+          targetUserId: 'user-1',
+          text: 'hello',
+          payload: {},
+        },
+      });
     });
 
-    expect(scrollToIndexMock).not.toHaveBeenCalledWith({ index: 'LAST', behavior: 'auto' });
+    expect(scrollToIndexMock).toHaveBeenCalledTimes(0);
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark at bottom' }));
-    subscriptionHandlers.onData?.({
-      id: 'evt-2',
-      data: {
+    act(() => {
+      subscriptionHandlers.onData?.({
         id: 'evt-2',
-        type: 'announce',
-        scope: 'private',
-        targetUserId: 'user-1',
-        text: 'hello again',
-        payload: {},
-      },
+        data: {
+          id: 'evt-2',
+          type: 'announce',
+          scope: 'private',
+          targetUserId: 'user-1',
+          text: 'hello again',
+          payload: {},
+        },
+      });
     });
 
-    expect(scrollToIndexMock).toHaveBeenCalledWith({ index: 'LAST', behavior: 'auto' });
+    expect(scrollToIndexMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/__tests__/inventoryPanel.multiselect.test.tsx
+++ b/apps/web/src/__tests__/inventoryPanel.multiselect.test.tsx
@@ -18,7 +18,7 @@ describe('InventoryPanel multi-select behavior', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Heal' }));
-    expect(onSelectCard).toHaveBeenCalledWith({ kind: 'inventory' }, 'Heal', 'inventory:1');
+    expect(onSelectCard).toHaveBeenCalledWith({ kind: 'inventory' }, 'Heal', 'inventory:1', 1);
     expect(onTapSlot).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/__tests__/inventoryPanel.multiselect.test.tsx
+++ b/apps/web/src/__tests__/inventoryPanel.multiselect.test.tsx
@@ -11,7 +11,7 @@ describe('InventoryPanel multi-select behavior', () => {
       <InventoryPanel
         cards={['Hit', 'Heal']}
         selectedCards={[{ location: { kind: 'inventory' }, cardName: 'Hit', selectionId: 'inventory:0' }]}
-        onDropCard={() => undefined}
+        onDropCard={() => Promise.resolve()}
         onTapSlot={onTapSlot}
         onSelectCard={onSelectCard}
       />,

--- a/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
+++ b/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
@@ -56,7 +56,56 @@ describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
     fireEvent.drop(targetSlot, { dataTransfer });
 
     expect(onDropCard).toHaveBeenCalledTimes(1);
-    expect(onDropCard).toHaveBeenCalledWith({ kind: 'inventory' }, 'Hit');
+    expect(onDropCard).toHaveBeenCalledWith({ kind: 'inventory' }, 'Hit', undefined, 'Stonefang:0');
+  });
+
+  it('passes slot index to drop handler for reorder support', async () => {
+    const onDropCard = vi.fn(async () => undefined);
+    render(
+      <MonsterWorkshopPanel
+        monster={{
+          ...baseMonster,
+          cardSlots: 2,
+          cards: ['Hit', null as unknown as string],
+        }}
+        showSelectionHint={false}
+        selectedCards={[]}
+        onDropCard={onDropCard}
+        onTapSlot={() => undefined}
+        onSelectCard={() => undefined}
+        onUnequipAll={() => undefined}
+        onSavePreset={() => undefined}
+        onLoadPreset={() => undefined}
+        onDeletePreset={() => undefined}
+      />,
+    );
+
+    const targetSlots = screen.getAllByRole('button', { name: 'Empty slot' });
+    const targetSlot = targetSlots[0];
+    const dataTransfer = {
+      store: {} as Record<string, string>,
+      setData(type: string, value: string) {
+        this.store[type] = value;
+      },
+      getData(type: string) {
+        return this.store[type] ?? '';
+      },
+      effectAllowed: 'none',
+    };
+    dataTransfer.setData(
+      'application/x-deck-monsters-card',
+      JSON.stringify({ location: { kind: 'monster', monsterName: 'Stonefang' }, cardName: 'Hit' }),
+    );
+
+    fireEvent.dragOver(targetSlot, { dataTransfer });
+    fireEvent.drop(targetSlot, { dataTransfer });
+
+    expect(onDropCard).toHaveBeenCalledWith(
+      { kind: 'monster', monsterName: 'Stonefang' },
+      'Hit',
+      undefined,
+      'Stonefang:1',
+    );
   });
 
   it('keeps monster slots locked during an encounter', () => {

--- a/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
+++ b/apps/web/src/__tests__/monsterWorkshopPanel.dragdrop.test.tsx
@@ -161,6 +161,7 @@ describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
       { kind: 'monster', monsterName: 'Stonefang' },
       'Hit',
       'Stonefang:0',
+      0,
     );
   });
 
@@ -197,6 +198,7 @@ describe('MonsterWorkshopPanel drag/drop lock behavior', () => {
       { kind: 'monster', monsterName: 'Stonefang' },
       'Heal',
       'Stonefang:1',
+      1,
     );
     expect(onTapSlot).not.toHaveBeenCalled();
   });

--- a/apps/web/src/__tests__/ringPane-scroll-behavior.test.tsx
+++ b/apps/web/src/__tests__/ringPane-scroll-behavior.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import RingPane from '../components/RingPane.js';
 
@@ -85,25 +85,30 @@ describe('RingPane scroll follow behavior', () => {
 
     expect(typeof subscriptionCallbacks.onData).toBe('function');
     if (!subscriptionCallbacks.onData) throw new Error('subscription callback missing');
+    const onData = subscriptionCallbacks.onData;
 
     const atBottomHandler = setAtBottomState[0];
     expect(typeof atBottomHandler).toBe('function');
     if (!atBottomHandler) throw new Error('atBottomStateChange missing');
 
     // Simulate user scrolling up.
-    atBottomHandler(false);
+    act(() => {
+      atBottomHandler(false);
+    });
 
     scrollToIndexMock.mockClear();
-    subscriptionCallbacks.onData({
-      id: 'ev-1',
-      data: {
-        id: 'event-1',
-        type: 'announce',
-        scope: 'public',
-        text: 'new public event',
-        payload: {},
-        timestamp: Date.now(),
-      },
+    act(() => {
+      onData({
+        id: 'ev-1',
+        data: {
+          id: 'event-1',
+          type: 'announce',
+          scope: 'public',
+          text: 'new public event',
+          payload: {},
+          timestamp: Date.now(),
+        },
+      });
     });
 
     expect(scrollToIndexMock).not.toHaveBeenCalledWith(

--- a/apps/web/src/__tests__/ringPane-scroll-behavior.test.tsx
+++ b/apps/web/src/__tests__/ringPane-scroll-behavior.test.tsx
@@ -1,0 +1,113 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import RingPane from '../components/RingPane.js';
+
+const subscriptionCallbacks: {
+  onData?: (tracked: { id: string; data: unknown }) => void;
+  onError?: () => void;
+} = {};
+
+const scrollToIndexMock = vi.fn();
+const setAtBottomState: Array<(atBottom: boolean) => void> = [];
+
+vi.mock('../hooks/useHandshake.js', () => ({
+  useHandshake: () => ({
+    handleHandshakeEvent: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useRingKeyTimestamps.js', () => ({
+  useRingKeyTimestamps: () => ({ ringKeyTimestampsEnabled: false }),
+}));
+
+vi.mock('../hooks/useTimeAgo.js', () => ({
+  useTimeAgo: () => 'just now',
+}));
+
+vi.mock('../lib/trpc.js', () => ({
+  trpc: {
+    game: {
+      ringHistory: {
+        useQuery: () => ({ data: [] }),
+      },
+      recentFights: {
+        useQuery: () => ({ data: [] }),
+      },
+      ringFeed: {
+        useSubscription: (_input: unknown, callbacks: { onData?: (tracked: { id: string; data: unknown }) => void; onError?: () => void }) => {
+          subscriptionCallbacks.onData = callbacks.onData;
+          subscriptionCallbacks.onError = callbacks.onError;
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('../utils/ring-feed-events.js', () => ({
+  shouldRenderRingEvent: () => true,
+}));
+
+vi.mock('react-virtuoso', () => {
+  const React = require('react');
+  return {
+    Virtuoso: React.forwardRef(
+      (
+        props: {
+          atBottomStateChange?: (atBottom: boolean) => void;
+          data?: Array<unknown>;
+          itemContent?: (index: number, item: unknown) => React.ReactNode;
+        },
+        ref: React.Ref<{ scrollToIndex: (input: { index: 'LAST'; behavior: 'auto' | 'smooth' }) => void }>,
+      ) => {
+        React.useImperativeHandle(ref, () => ({
+          scrollToIndex: (input: { index: 'LAST'; behavior: 'auto' | 'smooth' }) => {
+            scrollToIndexMock(input);
+          },
+        }));
+        React.useEffect(() => {
+          if (props.atBottomStateChange) setAtBottomState.push(props.atBottomStateChange);
+        }, [props.atBottomStateChange]);
+        return (
+          <div>
+            {(props.data ?? []).map((item, index) => (
+              <div key={index}>{props.itemContent?.(index, item) ?? null}</div>
+            ))}
+          </div>
+        );
+      },
+    ),
+  };
+});
+
+describe('RingPane scroll follow behavior', () => {
+  it('does not auto-scroll when user has scrolled away from bottom', () => {
+    render(<RingPane roomId="room-123" isActive onEvent={() => undefined} />);
+
+    expect(typeof subscriptionCallbacks.onData).toBe('function');
+    if (!subscriptionCallbacks.onData) throw new Error('subscription callback missing');
+
+    const atBottomHandler = setAtBottomState[0];
+    expect(typeof atBottomHandler).toBe('function');
+    if (!atBottomHandler) throw new Error('atBottomStateChange missing');
+
+    // Simulate user scrolling up.
+    atBottomHandler(false);
+
+    scrollToIndexMock.mockClear();
+    subscriptionCallbacks.onData({
+      id: 'ev-1',
+      data: {
+        id: 'event-1',
+        type: 'announce',
+        scope: 'public',
+        text: 'new public event',
+        payload: {},
+        timestamp: Date.now(),
+      },
+    });
+
+    expect(scrollToIndexMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'smooth' }),
+    );
+  });
+});

--- a/apps/web/src/__tests__/useDeckWorkshop.test.ts
+++ b/apps/web/src/__tests__/useDeckWorkshop.test.ts
@@ -68,7 +68,7 @@ describe('useDeckWorkshop', () => {
       isLoading: false,
     });
     mocks.myInventoryUseQuery.mockReturnValue({
-      data: { monsters: [], unequippedDeck: [], items: { character: [], monsters: [] } },
+      data: { monsters: [], unequippedDeck: [], cardCompatibility: {}, items: { character: [], monsters: [] } },
       isLoading: false,
       isFetching: false,
       refetch: vi.fn(),

--- a/apps/web/src/__tests__/useDeckWorkshop.test.ts
+++ b/apps/web/src/__tests__/useDeckWorkshop.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => {
     savePresetUseMutation: vi.fn(defaultMutation),
     loadPresetUseMutation: vi.fn(defaultMutation),
     deletePresetUseMutation: vi.fn(defaultMutation),
+    reorderCardsUseMutation: vi.fn(defaultMutation),
   };
 });
 
@@ -54,6 +55,7 @@ vi.mock('../lib/trpc.js', () => ({
       savePreset: { useMutation: mocks.savePresetUseMutation },
       loadPreset: { useMutation: mocks.loadPresetUseMutation },
       deletePreset: { useMutation: mocks.deletePresetUseMutation },
+      reorderCards: { useMutation: mocks.reorderCardsUseMutation },
     },
   },
 }));

--- a/apps/web/src/__tests__/workshopView.review-regressions.test.tsx
+++ b/apps/web/src/__tests__/workshopView.review-regressions.test.tsx
@@ -38,6 +38,7 @@ const workshopMock = vi.hoisted(() => ({
   unequipCard: vi.fn(async () => ({ removedCount: 1, monsterName: 'Stonefang' })),
   unequipAll: vi.fn(async () => ({ removedCount: 0, monsterName: 'Stonefang' })),
   moveCard: vi.fn(async () => ({ movedCount: 1, fromMonsterName: 'Stonefang', toMonsterName: 'Emberclaw' })),
+  reorderCards: vi.fn(async () => ({ monsterName: 'Stonefang', cards: ['Hit'] })),
   savePreset: vi.fn(async () => undefined),
   loadPreset: vi.fn(async () => ({ equippedCount: 0, requestedCount: 0, skippedCards: [] as string[] })),
   deletePreset: vi.fn(async () => undefined),
@@ -88,13 +89,20 @@ vi.mock('../components/MonsterWorkshopPanel.js', () => ({
     compatibilityHint,
     onToggleFilter,
     isFilterTarget,
+    onReorderCard,
   }: {
     monster: { name: string };
     showSelectionHint: boolean;
-    onDropCard: (source: { kind: 'inventory' }, cardName: string) => Promise<void> | void;
+    onDropCard: (
+      source: { kind: 'inventory' | 'monster'; monsterName?: string },
+      cardName: string,
+      sourceSelectionId?: string,
+      targetSelectionId?: string,
+    ) => Promise<void> | void;
     compatibilityHint?: 'none' | 'eligible' | 'ineligible';
     onToggleFilter?: () => void;
     isFilterTarget?: boolean;
+    onReorderCard?: (sourceSelectionId: string, targetSelectionId: string) => Promise<void> | void;
   }) => (
     <section>
       <div data-testid={`hint-${monster.name}`}>{showSelectionHint ? 'hint-on' : 'hint-off'}</div>
@@ -108,6 +116,18 @@ vi.mock('../components/MonsterWorkshopPanel.js', () => ({
         onClick={() => void onDropCard({ kind: 'inventory' }, 'Hit')}
       >
         Drop on {monster.name}
+      </button>
+      <button
+        type="button"
+        onClick={() => void onDropCard({ kind: 'monster', monsterName: monster.name }, 'Hit', `${monster.name}:0`, `${monster.name}:1`)}
+      >
+        Reorder on {monster.name}
+      </button>
+      <button
+        type="button"
+        onClick={() => void onReorderCard?.(`${monster.name}:0`, `${monster.name}:1`)}
+      >
+        Reorder via callback {monster.name}
       </button>
     </section>
   ),
@@ -179,5 +199,18 @@ describe('WorkshopView review regressions', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear inventory filter' }));
     expect(screen.getByTestId('inventory-filter-name')).toHaveTextContent('none');
+  });
+
+  it('handles same-monster reorder drops through reorderCards mutation', async () => {
+    renderWorkshop();
+    fireEvent.click(screen.getByRole('button', { name: 'Reorder on Stonefang' }));
+
+    await waitFor(() => {
+      expect(workshopMock.reorderCards).toHaveBeenCalledWith({
+        monsterName: 'Stonefang',
+        fromIndex: 0,
+        toIndex: 1,
+      });
+    });
   });
 });

--- a/apps/web/src/__tests__/workshopView.review-regressions.test.tsx
+++ b/apps/web/src/__tests__/workshopView.review-regressions.test.tsx
@@ -28,6 +28,9 @@ const workshopMock = vi.hoisted(() => ({
     },
   ],
   unequippedDeck: ['Hit'],
+  cardCompatibility: {
+    Hit: ['Stonefang'],
+  },
   loading: false,
   busy: false,
   latestError: null as string | null,
@@ -50,13 +53,30 @@ vi.mock('../components/AppShell.js', () => ({
 }));
 
 vi.mock('../components/InventoryPanel.js', () => ({
-  default: ({ onSelectCard }: { onSelectCard: (location: { kind: 'inventory' }, cardName: string, selectionId: string) => void }) => (
-    <button
-      type="button"
-      onClick={() => onSelectCard({ kind: 'inventory' }, 'Hit', 'inventory:0')}
-    >
-      Select inventory card
-    </button>
+  default: ({
+    onSelectCard,
+    activeMonsterFilterName,
+    onClearMonsterFilter,
+    isCardUnavailable,
+  }: {
+    onSelectCard: (location: { kind: 'inventory' }, cardName: string, selectionId: string) => void;
+    activeMonsterFilterName?: string | null;
+    onClearMonsterFilter?: () => void;
+    isCardUnavailable?: (cardName: string) => boolean;
+  }) => (
+    <div>
+      <div data-testid="inventory-filter-name">{activeMonsterFilterName ?? 'none'}</div>
+      <div data-testid="inventory-hit-unavailable">{String(isCardUnavailable?.('Hit') ?? false)}</div>
+      <button
+        type="button"
+        onClick={() => onSelectCard({ kind: 'inventory' }, 'Hit', 'inventory:0')}
+      >
+        Select inventory card
+      </button>
+      <button type="button" onClick={() => onClearMonsterFilter?.()}>
+        Clear inventory filter
+      </button>
+    </div>
   ),
 }));
 
@@ -65,13 +85,24 @@ vi.mock('../components/MonsterWorkshopPanel.js', () => ({
     monster,
     showSelectionHint,
     onDropCard,
+    compatibilityHint,
+    onToggleFilter,
+    isFilterTarget,
   }: {
     monster: { name: string };
     showSelectionHint: boolean;
     onDropCard: (source: { kind: 'inventory' }, cardName: string) => Promise<void> | void;
+    compatibilityHint?: 'none' | 'eligible' | 'ineligible';
+    onToggleFilter?: () => void;
+    isFilterTarget?: boolean;
   }) => (
     <section>
       <div data-testid={`hint-${monster.name}`}>{showSelectionHint ? 'hint-on' : 'hint-off'}</div>
+      <div data-testid={`compat-${monster.name}`}>{compatibilityHint ?? 'none'}</div>
+      <div data-testid={`filter-target-${monster.name}`}>{isFilterTarget ? 'yes' : 'no'}</div>
+      <button type="button" onClick={() => onToggleFilter?.()}>
+        Toggle filter {monster.name}
+      </button>
       <button
         type="button"
         onClick={() => void onDropCard({ kind: 'inventory' }, 'Hit')}
@@ -105,6 +136,8 @@ describe('WorkshopView review regressions', () => {
 
     expect(screen.getByTestId('hint-Stonefang')).toHaveTextContent('hint-on');
     expect(screen.getByTestId('hint-Emberclaw')).toHaveTextContent('hint-on');
+    expect(screen.getByTestId('compat-Stonefang')).toHaveTextContent('eligible');
+    expect(screen.getByTestId('compat-Emberclaw')).toHaveTextContent('ineligible');
   });
 
   it('clears selected banner after drag/drop actions', async () => {
@@ -132,5 +165,19 @@ describe('WorkshopView review regressions', () => {
     await waitFor(() => {
       expect(screen.queryByText(/1 selected:/i)).not.toBeInTheDocument();
     });
+  });
+
+  it('toggles monster filter and forwards filter state to inventory', () => {
+    renderWorkshop();
+    expect(screen.getByTestId('inventory-filter-name')).toHaveTextContent('none');
+    expect(screen.getByTestId('inventory-hit-unavailable')).toHaveTextContent('false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle filter Emberclaw' }));
+    expect(screen.getByTestId('inventory-filter-name')).toHaveTextContent('Emberclaw');
+    expect(screen.getByTestId('inventory-hit-unavailable')).toHaveTextContent('true');
+    expect(screen.getByTestId('filter-target-Emberclaw')).toHaveTextContent('yes');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear inventory filter' }));
+    expect(screen.getByTestId('inventory-filter-name')).toHaveTextContent('none');
   });
 });

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -56,7 +56,23 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
         {roomName && (
           <>
             <span style={{ color: 'var(--color-fg-dim)' }}>/</span>
-            <span style={{ color: 'var(--color-fg)', fontSize: '0.9rem' }}>{roomName}</span>
+            {roomId ? (
+              <Link
+                to={`/room/${roomId}`}
+                style={{
+                  color: 'var(--color-fg)',
+                  fontSize: '0.9rem',
+                  textDecoration: 'none',
+                  borderBottom: '1px solid transparent',
+                }}
+                title="Back to Ring and Console"
+                aria-label={`Back to ${roomName} terminal`}
+              >
+                {roomName}
+              </Link>
+            ) : (
+              <span style={{ color: 'var(--color-fg)', fontSize: '0.9rem' }}>{roomName}</span>
+            )}
             {roomId && (
               <Link
                 to={`/room/${roomId}/settings`}
@@ -84,6 +100,11 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
           style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
           aria-label="Main navigation"
         >
+          {roomId && (
+            <Link to={`/room/${roomId}`} className="btn" style={{ fontSize: '0.8rem' }}>
+              Terminal
+            </Link>
+          )}
           <button
             className="btn"
             style={{ fontSize: '0.8rem' }}
@@ -177,6 +198,11 @@ export default function AppShell({ children, roomName, roomId }: AppShellProps) 
             onClick={(e) => e.stopPropagation()}
           >
             <Link to="/rooms" className="btn" onClick={() => setMenuOpen(false)}>Rooms</Link>
+            {roomId && (
+              <Link to={`/room/${roomId}`} className="btn" onClick={() => setMenuOpen(false)}>
+                Terminal
+              </Link>
+            )}
             <Link
               to={roomId ? `/room/${roomId}/leaderboard` : '/leaderboard'}
               className="btn"

--- a/apps/web/src/components/CardSlot.tsx
+++ b/apps/web/src/components/CardSlot.tsx
@@ -12,8 +12,17 @@ interface CardSlotProps {
   disabled?: boolean;
   incompatible?: boolean;
   selected?: boolean;
-  onSelectCard?: (location: WorkshopCardLocation, cardName: string, selectionId: string) => void;
-  onDropCard?: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
+  onSelectCard?: (
+    location: WorkshopCardLocation,
+    cardName: string,
+    selectionId: string,
+    slotIndex?: number,
+  ) => void;
+  onDropCard?: (
+    source: WorkshopCardLocation,
+    cardName: string,
+    sourceSelectionId?: string,
+  ) => Promise<void> | void;
   onTapSlot?: (target: WorkshopCardLocation) => Promise<void> | void;
 }
 
@@ -37,8 +46,12 @@ export default function CardSlot({
     if (!payload) return;
     event.preventDefault();
     try {
-      const parsed = JSON.parse(payload) as { location: WorkshopCardLocation; cardName: string };
-      await onDropCard?.(parsed.location, parsed.cardName);
+      const parsed = JSON.parse(payload) as {
+        location: WorkshopCardLocation;
+        cardName: string;
+        selectionId?: string;
+      };
+      await onDropCard?.(parsed.location, parsed.cardName, parsed.selectionId);
     } catch {
       // Ignore malformed payloads.
     }
@@ -53,7 +66,7 @@ export default function CardSlot({
     if (!cardName || disabled) return;
     event.dataTransfer.setData(
       'application/x-deck-monsters-card',
-      JSON.stringify({ location, cardName }),
+      JSON.stringify({ location, cardName, selectionId }),
     );
     event.dataTransfer.effectAllowed = 'move';
   }
@@ -61,7 +74,9 @@ export default function CardSlot({
   async function handleClick() {
     if (disabled) return;
     if (cardName) {
-      onSelectCard?.(location, cardName, selectionId);
+      const slotFromSelectionId = Number.parseInt(selectionId.split(':').at(-1) ?? '', 10);
+      const slotIndex = Number.isFinite(slotFromSelectionId) ? slotFromSelectionId : undefined;
+      onSelectCard?.(location, cardName, selectionId, slotIndex);
       return;
     }
     await onTapSlot?.(location);

--- a/apps/web/src/components/CardSlot.tsx
+++ b/apps/web/src/components/CardSlot.tsx
@@ -10,6 +10,7 @@ interface CardSlotProps {
   cardName: string | null;
   isDropActive?: boolean;
   disabled?: boolean;
+  incompatible?: boolean;
   selected?: boolean;
   onSelectCard?: (location: WorkshopCardLocation, cardName: string, selectionId: string) => void;
   onDropCard?: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
@@ -22,6 +23,7 @@ export default function CardSlot({
   cardName,
   isDropActive = false,
   disabled = false,
+  incompatible = false,
   selected = false,
   onSelectCard,
   onDropCard,
@@ -74,6 +76,7 @@ export default function CardSlot({
         isDropActive ? 'drop-over' : '',
         selected ? 'selected' : '',
         disabled ? 'disabled' : '',
+        incompatible ? 'incompatible' : '',
       ]
         .filter(Boolean)
         .join(' ')}
@@ -83,8 +86,8 @@ export default function CardSlot({
       onDragOver={handleDragOver}
       onDrop={(event) => void handleDrop(event)}
       onClick={() => void handleClick()}
-      title={cardName ?? 'Empty slot'}
-      aria-label={cardName ?? 'Empty slot'}
+      title={cardName ? (incompatible ? `${cardName} (not usable for current filter)` : cardName) : 'Empty slot'}
+      aria-label={cardName ? (incompatible ? `${cardName} (not usable for current filter)` : cardName) : 'Empty slot'}
     >
       {cardName ? (
         <>

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -104,6 +104,8 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const seenRef = useRef(new Set<string>());
   const latestTrackedEventIdRef = useRef<string | undefined>(undefined);
   const historyApplied = useRef(false);
+  const previousConsoleLengthRef = useRef(0);
+  const shouldScrollOnAppendRef = useRef(false);
   const autoScroll = useFeedAutoScroll();
   const ftuxStorageKey = useMemo(
     () => (user?.id ? `ftuxComplete:${user.id}` : 'ftuxComplete'),
@@ -274,16 +276,20 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const cancelFlowMutation = trpc.game.cancelFlow.useMutation();
 
   function addConsoleEvent(ev: ConsoleEvent) {
-    setConsoleEvents(prev => {
-      const next = [...prev, ev];
-      if (autoScroll.shouldFollowRef.current) {
-        requestAnimationFrame(() => {
-          virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'smooth' });
-        });
-      }
-      return next;
-    });
+    shouldScrollOnAppendRef.current = autoScroll.shouldFollowRef.current;
+    setConsoleEvents(prev => [...prev, ev]);
   }
+
+  useEffect(() => {
+    const hasNewEvent = consoleEvents.length > previousConsoleLengthRef.current;
+    if (hasNewEvent && shouldScrollOnAppendRef.current) {
+      requestAnimationFrame(() => {
+        virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'smooth' });
+      });
+    }
+    shouldScrollOnAppendRef.current = false;
+    previousConsoleLengthRef.current = consoleEvents.length;
+  }, [consoleEvents.length]);
 
   const upsertPendingPrompt = useCallback((prompt: PendingPromptSnapshot) => {
     setConsoleEvents(prev => {

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -13,6 +13,7 @@ import CommandSuggestions from './CommandSuggestions.js';
 import InlineChoices from './InlineChoices.js';
 import { formatEventText } from '../utils/format-event-text.js';
 import { mapConsoleHistoryEvent } from '../utils/console-history-event-map.js';
+import { useFeedAutoScroll } from '../hooks/useFeedAutoScroll.js';
 
 interface ActivePrompt {
   requestId: string;
@@ -103,6 +104,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const seenRef = useRef(new Set<string>());
   const latestTrackedEventIdRef = useRef<string | undefined>(undefined);
   const historyApplied = useRef(false);
+  const autoScroll = useFeedAutoScroll();
   const ftuxStorageKey = useMemo(
     () => (user?.id ? `ftuxComplete:${user.id}` : 'ftuxComplete'),
     [user?.id]
@@ -172,21 +174,24 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
     // Jump to bottom after history loads (instant, no animation)
     requestAnimationFrame(() => {
       virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'auto' });
+      autoScroll.resetToBottom();
     });
-  }, [history]);
+  }, [history, autoScroll]);
 
   // Scroll to bottom when this pane becomes active (tab switch)
   useEffect(() => {
     if (isActive) {
       virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'auto' });
       setIsAtBottom(true);
+      autoScroll.resetToBottom();
     }
-  }, [isActive]);
+  }, [isActive, autoScroll]);
 
   const scrollToBottom = useCallback(() => {
     virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'smooth' });
     setIsAtBottom(true);
-  }, []);
+    autoScroll.enable();
+  }, [autoScroll]);
 
   const { data: myMonsters, refetch: refetchMyMonsters } = trpc.game.myMonsters.useQuery(
     { roomId },
@@ -269,7 +274,15 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
   const cancelFlowMutation = trpc.game.cancelFlow.useMutation();
 
   function addConsoleEvent(ev: ConsoleEvent) {
-    setConsoleEvents(prev => [...prev, ev]);
+    setConsoleEvents(prev => {
+      const next = [...prev, ev];
+      if (autoScroll.shouldFollowRef.current) {
+        requestAnimationFrame(() => {
+          virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'smooth' });
+        });
+      }
+      return next;
+    });
   }
 
   const upsertPendingPrompt = useCallback((prompt: PendingPromptSnapshot) => {
@@ -673,7 +686,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         aria-label="Console messages"
         tabIndex={0}
         data={consoleEvents}
-        followOutput="smooth"
+        followOutput={false}
         components={{
           // Cast through any because Virtuoso's List type expects HTMLDivElement internally.
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -713,7 +726,10 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
             </li>
           );
         }}
-        atBottomStateChange={(atBottom) => setIsAtBottom(atBottom)}
+        atBottomStateChange={(atBottom) => {
+          setIsAtBottom(atBottom);
+          autoScroll.onAtBottomChange(atBottom);
+        }}
       />
 
       {!isAtBottom && (

--- a/apps/web/src/components/InventoryPanel.tsx
+++ b/apps/web/src/components/InventoryPanel.tsx
@@ -7,7 +7,11 @@ interface InventoryPanelProps {
     cardName: string;
     selectionId: string;
   }>;
-  onDropCard: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
+  onDropCard: (
+    source: WorkshopCardLocation,
+    cardName: string,
+    targetSelectionId?: string,
+  ) => Promise<void> | void;
   onTapSlot: () => Promise<void> | void;
   onSelectCard: (location: WorkshopCardLocation, cardName: string, selectionId: string) => void;
   activeMonsterFilterName?: string | null;
@@ -85,8 +89,12 @@ export default function InventoryPanel({
           const payload = event.dataTransfer.getData('application/x-deck-monsters-card');
           if (!payload) return;
           try {
-            const parsed = JSON.parse(payload) as { location: WorkshopCardLocation; cardName: string };
-            void onDropCard(parsed.location, parsed.cardName);
+            const parsed = JSON.parse(payload) as {
+              location: WorkshopCardLocation;
+              cardName: string;
+              selectionId?: string;
+            };
+            void onDropCard(parsed.location, parsed.cardName, parsed.selectionId);
           } catch {
             // Ignore malformed payloads.
           }

--- a/apps/web/src/components/InventoryPanel.tsx
+++ b/apps/web/src/components/InventoryPanel.tsx
@@ -10,6 +10,10 @@ interface InventoryPanelProps {
   onDropCard: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
   onTapSlot: () => Promise<void> | void;
   onSelectCard: (location: WorkshopCardLocation, cardName: string, selectionId: string) => void;
+  activeMonsterFilterName?: string | null;
+  compatibleCardCount?: number | null;
+  onClearMonsterFilter?: () => void;
+  isCardUnavailable?: (cardName: string) => boolean;
 }
 
 export default function InventoryPanel({
@@ -18,13 +22,32 @@ export default function InventoryPanel({
   onDropCard,
   onTapSlot,
   onSelectCard,
+  activeMonsterFilterName = null,
+  compatibleCardCount = null,
+  onClearMonsterFilter,
+  isCardUnavailable,
 }: InventoryPanelProps) {
   const location: WorkshopCardLocation = { kind: 'inventory' };
   return (
     <section className="workshop-inventory">
       <header className="workshop-section-header">
-        <h2>Your Inventory</h2>
-        <span>{cards.length} unequipped cards</span>
+        <div>
+          <h2>Your Inventory</h2>
+          {activeMonsterFilterName && (
+            <p className="workshop-filter-summary">
+              Showing cards usable by {activeMonsterFilterName}
+              {typeof compatibleCardCount === 'number' ? ` (${compatibleCardCount}/${cards.length})` : ''}.
+            </p>
+          )}
+        </div>
+        <div className="workshop-inventory-summary">
+          <span>{cards.length} unequipped cards</span>
+          {activeMonsterFilterName && (
+            <button type="button" className="btn workshop-inline-btn" onClick={() => onClearMonsterFilter?.()}>
+              Clear filter
+            </button>
+          )}
+        </div>
       </header>
 
       {cards.length < 1 ? (
@@ -33,20 +56,23 @@ export default function InventoryPanel({
         <div className="workshop-card-grid inventory-grid">
           {cards.map((cardName, index) => {
             const selectionId = `inventory:${index}`;
+            const unavailable = isCardUnavailable?.(cardName) ?? false;
             return (
-            <CardSlot
-              key={`${cardName}-${index}`}
-              location={location}
-              selectionId={selectionId}
-              cardName={cardName}
-              selected={selectedCards.some(
-                (selectedCard) =>
-                  selectedCard.location.kind === 'inventory' &&
-                  selectedCard.selectionId === selectionId,
-              )}
-              onTapSlot={() => onTapSlot()}
-              onSelectCard={onSelectCard}
-            />
+              <CardSlot
+                key={`${cardName}-${index}`}
+                location={location}
+                selectionId={selectionId}
+                cardName={cardName}
+                disabled={unavailable}
+                incompatible={unavailable}
+                selected={selectedCards.some(
+                  (selectedCard) =>
+                    selectedCard.location.kind === 'inventory' &&
+                    selectedCard.selectionId === selectionId,
+                )}
+                onTapSlot={() => onTapSlot()}
+                onSelectCard={onSelectCard}
+              />
             );
           })}
         </div>

--- a/apps/web/src/components/MonsterWorkshopPanel.tsx
+++ b/apps/web/src/components/MonsterWorkshopPanel.tsx
@@ -17,7 +17,12 @@ type MonsterPanelProps = {
   };
   showSelectionHint: boolean;
   selectedCards: Array<{ location: WorkshopCardLocation; cardName: string; selectionId: string }>;
-  onDropCard: (source: WorkshopCardLocation, cardName: string) => Promise<void> | void;
+  onDropCard: (
+    source: WorkshopCardLocation,
+    cardName: string,
+    sourceSelectionId?: string,
+    targetSelectionId?: string,
+  ) => Promise<void> | void;
   onTapSlot: (target: WorkshopCardLocation) => void;
   onSelectCard: (location: WorkshopCardLocation, cardName: string, selectionId: string) => void;
   onUnequipAll: () => void;
@@ -137,7 +142,9 @@ export default function MonsterWorkshopPanel({
               disabled={locked}
               onSelectCard={onSelectCard}
               onTapSlot={onTapSlot}
-              onDropCard={onDropCard}
+              onDropCard={(source, droppedCardName, sourceSelectionId) =>
+                onDropCard(source, droppedCardName, sourceSelectionId, selectionId)
+              }
             />
           );
         })}

--- a/apps/web/src/components/MonsterWorkshopPanel.tsx
+++ b/apps/web/src/components/MonsterWorkshopPanel.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import CardSlot, { type WorkshopCardLocation } from './CardSlot.js';
 import PresetControl from './PresetControl.js';
 
+type MonsterCompatibilityHint = 'none' | 'eligible' | 'ineligible';
+
 type MonsterPanelProps = {
   monster: {
     name: string;
@@ -22,6 +24,10 @@ type MonsterPanelProps = {
   onSavePreset: (presetName: string) => void;
   onLoadPreset: (presetName: string) => void;
   onDeletePreset: (presetName: string) => void;
+  isFilterActive?: boolean;
+  isFilterTarget?: boolean;
+  compatibilityHint?: MonsterCompatibilityHint;
+  onToggleFilter?: () => void;
 };
 
 export default function MonsterWorkshopPanel({
@@ -35,6 +41,10 @@ export default function MonsterWorkshopPanel({
   onSavePreset,
   onLoadPreset,
   onDeletePreset,
+  isFilterActive = false,
+  isFilterTarget = false,
+  compatibilityHint = 'none',
+  onToggleFilter,
 }: MonsterPanelProps) {
   const locked = monster.inEncounter;
   const slots = useMemo(() => {
@@ -44,10 +54,34 @@ export default function MonsterWorkshopPanel({
   const usagePct = Math.min(100, Math.round((monster.cards.length / Math.max(monster.cardSlots, 1)) * 100));
 
   return (
-    <section className={`workshop-monster-panel${monster.inRing ? ' in-ring' : ''}${locked ? ' locked' : ''}`}>
+    <section
+      className={[
+        'workshop-monster-panel',
+        monster.inRing ? 'in-ring' : '',
+        locked ? 'locked' : '',
+        isFilterActive ? 'filter-active' : '',
+        isFilterTarget ? 'filter-target' : '',
+        compatibilityHint === 'eligible' ? 'compatibility-eligible' : '',
+        compatibilityHint === 'ineligible' ? 'compatibility-ineligible' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
       <div className="workshop-monster-header">
-        <div>
-          <h3>{monster.name}</h3>
+        <div className="workshop-monster-title">
+          <button
+            type="button"
+            className={`workshop-monster-filter-btn${isFilterTarget ? ' active' : ''}`}
+            onClick={() => onToggleFilter?.()}
+            aria-pressed={isFilterTarget}
+            title={
+              isFilterTarget
+                ? `Clear inventory filter for ${monster.name}`
+                : `Filter inventory cards for ${monster.name}`
+            }
+          >
+            <span>{monster.name}</span>
+          </button>
           <p>
             {monster.type}, L{monster.level}
           </p>
@@ -69,6 +103,15 @@ export default function MonsterWorkshopPanel({
           ⟲
         </button>
       </div>
+
+      {isFilterTarget && <p className="workshop-filter-hint">Inventory filtered for {monster.name}.</p>}
+
+      {compatibilityHint === 'eligible' && (
+        <p className="workshop-compatibility-hint eligible">Can use selected inventory card.</p>
+      )}
+      {compatibilityHint === 'ineligible' && (
+        <p className="workshop-compatibility-hint ineligible">Cannot use selected inventory card.</p>
+      )}
 
       {locked && (
         <p className="workshop-warning">

--- a/apps/web/src/components/RingPane.tsx
+++ b/apps/web/src/components/RingPane.tsx
@@ -110,6 +110,7 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
+  const shouldFollowOutputRef = useRef(true);
   // Timer state is pushed from the server via ring.state events and the handshake payload.
   // No HTTP polling needed.
   const [timerState, setTimerState] = useState<TimerState>({
@@ -175,10 +176,12 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
       return merged;
     });
 
-    // Jump to bottom after history loads (instant, no animation)
-    requestAnimationFrame(() => {
-      virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'auto' });
-    });
+    if (shouldFollowOutputRef.current) {
+      // Jump to bottom after history loads only when auto-follow is enabled.
+      requestAnimationFrame(() => {
+        virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'auto' });
+      });
+    }
   }, [history]);
 
   // Scroll to bottom when this pane becomes active (tab switch)
@@ -186,12 +189,14 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
     if (isActive) {
       virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'auto' });
       setIsAtBottom(true);
+      shouldFollowOutputRef.current = true;
     }
   }, [isActive]);
 
   const scrollToBottom = useCallback(() => {
     virtuosoRef.current?.scrollToIndex({ index: 'LAST', behavior: 'smooth' });
     setIsAtBottom(true);
+    shouldFollowOutputRef.current = true;
   }, []);
 
   trpc.game.ringFeed.useSubscription(
@@ -280,7 +285,9 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
         aria-label="Ring events"
         tabIndex={0}
         data={events}
-        followOutput="smooth"
+        followOutput={(atBottom) =>
+          shouldFollowOutputRef.current || atBottom ? 'smooth' : false
+        }
         components={{
           List: FeedList,
           EmptyPlaceholder: () => (
@@ -314,7 +321,14 @@ export default function RingPane({ roomId, isActive, onEvent }: RingPaneProps) {
             </li>
           );
         }}
-        atBottomStateChange={(atBottom) => setIsAtBottom(atBottom)}
+        atBottomStateChange={(atBottom) => {
+          setIsAtBottom(atBottom);
+          if (atBottom) {
+            shouldFollowOutputRef.current = true;
+            return;
+          }
+          shouldFollowOutputRef.current = false;
+        }}
       />
 
       {lastFight?.[0] && (

--- a/apps/web/src/hooks/useDeckWorkshop.ts
+++ b/apps/web/src/hooks/useDeckWorkshop.ts
@@ -62,6 +62,7 @@ export function useDeckWorkshop(roomId?: string) {
   const savePresetMutation = trpc.game.savePreset.useMutation(mutationOptions);
   const loadPresetMutation = trpc.game.loadPreset.useMutation(mutationOptions);
   const deletePresetMutation = trpc.game.deletePreset.useMutation(mutationOptions);
+  const reorderCardsMutation = trpc.game.reorderCards.useMutation(mutationOptions);
 
   const inventory = (inventoryQuery.data ?? EMPTY_INVENTORY) as WorkshopInventory;
   const monsters = inventory.monsters ?? [];
@@ -76,6 +77,7 @@ export function useDeckWorkshop(roomId?: string) {
       unequipAllMutation.isPending ||
       equipCardsMutation.isPending ||
       moveCardMutation.isPending ||
+      reorderCardsMutation.isPending ||
       savePresetMutation.isPending ||
       loadPresetMutation.isPending ||
       deletePresetMutation.isPending,
@@ -85,6 +87,7 @@ export function useDeckWorkshop(roomId?: string) {
       inventoryQuery.isFetching,
       loadPresetMutation.isPending,
       moveCardMutation.isPending,
+      reorderCardsMutation.isPending,
       savePresetMutation.isPending,
       unequipAllMutation.isPending,
       unequipCardMutation.isPending,
@@ -104,6 +107,7 @@ export function useDeckWorkshop(roomId?: string) {
       unequipAllMutation.error?.message ??
       equipCardsMutation.error?.message ??
       moveCardMutation.error?.message ??
+      reorderCardsMutation.error?.message ??
       savePresetMutation.error?.message ??
       loadPresetMutation.error?.message ??
       deletePresetMutation.error?.message,
@@ -128,6 +132,14 @@ export function useDeckWorkshop(roomId?: string) {
     }) => {
       if (!roomId) throw new Error('Room not selected');
       return moveCardMutation.mutateAsync({ roomId, ...input });
+    },
+    reorderCards: (input: {
+      monsterName: string;
+      fromIndex: number;
+      toIndex: number;
+    }) => {
+      if (!roomId) throw new Error('Room not selected');
+      return reorderCardsMutation.mutateAsync({ roomId, ...input });
     },
     savePreset: (input: { monsterName: string; presetName: string }) => {
       if (!roomId) throw new Error('Room not selected');

--- a/apps/web/src/hooks/useDeckWorkshop.ts
+++ b/apps/web/src/hooks/useDeckWorkshop.ts
@@ -15,6 +15,7 @@ type WorkshopMonster = {
 type WorkshopInventory = {
   monsters: WorkshopMonster[];
   unequippedDeck: string[];
+  cardCompatibility: Record<string, string[]>;
   items: {
     character: string[];
     monsters: Array<{ monsterName: string; items: string[] }>;
@@ -24,6 +25,7 @@ type WorkshopInventory = {
 const EMPTY_INVENTORY: WorkshopInventory = {
   monsters: [],
   unequippedDeck: [],
+  cardCompatibility: {},
   items: {
     character: [],
     monsters: [],
@@ -64,6 +66,7 @@ export function useDeckWorkshop(roomId?: string) {
   const inventory = (inventoryQuery.data ?? EMPTY_INVENTORY) as WorkshopInventory;
   const monsters = inventory.monsters ?? [];
   const unequippedDeck = inventory.unequippedDeck ?? [];
+  const cardCompatibility = inventory.cardCompatibility ?? {};
 
   const loading = roomQuery.isLoading || inventoryQuery.isLoading;
   const busy = useMemo(
@@ -93,6 +96,7 @@ export function useDeckWorkshop(roomId?: string) {
     inventory,
     monsters,
     unequippedDeck,
+    cardCompatibility,
     loading,
     busy,
     latestError:

--- a/apps/web/src/hooks/useFeedAutoScroll.ts
+++ b/apps/web/src/hooks/useFeedAutoScroll.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef } from 'react';
+
+export function useFeedAutoScroll() {
+  const shouldFollowRef = useRef(true);
+
+  const onAtBottomChange = useCallback((atBottom: boolean) => {
+    shouldFollowRef.current = atBottom;
+  }, []);
+
+  const resetToBottom = useCallback(() => {
+    shouldFollowRef.current = true;
+  }, []);
+
+  const enable = useCallback(() => {
+    shouldFollowRef.current = true;
+  }, []);
+
+  return {
+    shouldFollowRef,
+    onAtBottomChange,
+    resetToBottom,
+    enable,
+  };
+}
+

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -262,9 +262,28 @@ button {
   gap: 0.75rem;
 }
 
-.workshop-monster-header h3 {
+.workshop-monster-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.workshop-monster-filter-btn {
   font-size: 0.95rem;
   color: var(--color-fg-bright);
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 0.05rem 0.2rem;
+  text-align: left;
+}
+
+.workshop-monster-filter-btn:hover {
+  border-color: var(--color-border);
+}
+
+.workshop-monster-filter-btn.active {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .workshop-monster-header p {
@@ -320,7 +339,7 @@ button {
 .workshop-section-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -332,6 +351,18 @@ button {
 
 .workshop-section-header span {
   font-size: 0.75rem;
+  color: var(--color-fg-dim);
+}
+
+.workshop-inventory-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.workshop-filter-summary {
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
   color: var(--color-fg-dim);
 }
 
@@ -380,6 +411,11 @@ button {
 .workshop-card-slot.disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.workshop-card-slot.incompatible {
+  opacity: 0.35;
+  border-style: dashed;
 }
 
 .workshop-card-slot.class-melee {
@@ -459,6 +495,39 @@ button {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.35rem;
+}
+
+.workshop-filter-hint {
+  font-size: 0.72rem;
+  color: var(--color-accent);
+}
+
+.workshop-compatibility-hint {
+  font-size: 0.72rem;
+}
+
+.workshop-compatibility-hint.eligible {
+  color: var(--color-success);
+}
+
+.workshop-compatibility-hint.ineligible {
+  color: var(--color-fg-dim);
+}
+
+.workshop-monster-panel.filter-active {
+  opacity: 0.72;
+}
+
+.workshop-monster-panel.filter-active.filter-target {
+  opacity: 1;
+}
+
+.workshop-monster-panel.compatibility-eligible {
+  border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
+}
+
+.workshop-monster-panel.compatibility-ineligible {
+  border-color: color-mix(in srgb, var(--color-fg-dim) 50%, var(--color-border));
 }
 
 .workshop-inline-btn {

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -439,6 +439,10 @@ button {
   text-align: center;
   font-size: 0.74rem;
   line-height: 1.2;
+  width: 100%;
+  max-width: 100%;
+  color: var(--color-fg);
+  white-space: normal;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/apps/web/src/views/WorkshopView.tsx
+++ b/apps/web/src/views/WorkshopView.tsx
@@ -32,6 +32,7 @@ export default function WorkshopView() {
     unequipCard,
     unequipAll,
     moveCard,
+    reorderCards,
     savePreset,
     loadPreset,
     deletePreset,
@@ -115,11 +116,10 @@ export default function WorkshopView() {
     source: WorkshopCardLocation,
     target: WorkshopCardLocation,
     cardName: string,
+    sourceSelectionId?: string,
+    targetSelectionId?: string,
   ) {
     if (!roomId) return;
-    if (source.kind === 'monster' && target.kind === 'monster' && source.monsterName === target.monsterName) {
-      return;
-    }
     setSelectedCards([]);
 
     try {
@@ -148,6 +148,19 @@ export default function WorkshopView() {
       }
 
       if (source.kind === 'monster' && target.kind === 'monster') {
+        if (source.monsterName === target.monsterName) {
+          const sourceIndex = Number.parseInt(sourceSelectionId?.split(':').pop() ?? '', 10);
+          const targetIndex = Number.parseInt(targetSelectionId?.split(':').pop() ?? '', 10);
+          if (!Number.isInteger(sourceIndex) || !Number.isInteger(targetIndex)) return;
+          if (sourceIndex === targetIndex) return;
+          await reorderCards({
+            monsterName: source.monsterName,
+            fromIndex: sourceIndex,
+            toIndex: targetIndex,
+          });
+          setMessage(`Reordered ${source.monsterName}'s deck.`);
+          return;
+        }
         await moveCard({
           cardName,
           fromMonsterName: source.monsterName,
@@ -316,8 +329,14 @@ export default function WorkshopView() {
               monster={monster}
               selectedCards={selectedCards}
               showSelectionHint={selectedCards.length > 0}
-              onDropCard={(source, cardName) =>
-                handleDrop(source, { kind: 'monster', monsterName: monster.name }, cardName)
+              onDropCard={(source, cardName, sourceSelectionId, targetSelectionId) =>
+                handleDrop(
+                  source,
+                  { kind: 'monster', monsterName: monster.name },
+                  cardName,
+                  sourceSelectionId,
+                  targetSelectionId,
+                )
               }
               onTapSlot={(target) => {
                 void handleSlotClick(target);

--- a/apps/web/src/views/WorkshopView.tsx
+++ b/apps/web/src/views/WorkshopView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import AppShell from '../components/AppShell.js';
 import InventoryPanel from '../components/InventoryPanel.js';
@@ -16,6 +16,7 @@ export type SelectionState = {
 export default function WorkshopView() {
   const { roomId } = useParams<{ roomId: string }>();
   const [selectedCards, setSelectedCards] = useState<SelectionState[]>([]);
+  const [activeMonsterFilter, setActiveMonsterFilter] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,6 +24,7 @@ export default function WorkshopView() {
     roomName,
     monsters,
     unequippedDeck,
+    cardCompatibility,
     loading,
     busy,
     latestError,
@@ -52,6 +54,51 @@ export default function WorkshopView() {
     if (!latestError) return;
     setError(latestError);
   }, [latestError]);
+
+  useEffect(() => {
+    if (!activeMonsterFilter) return;
+    if (monsters.some((monster) => monster.name === activeMonsterFilter)) return;
+    setActiveMonsterFilter(null);
+  }, [activeMonsterFilter, monsters]);
+
+  const normalizedCompatibility = useMemo(() => {
+    const all = new Map<string, Set<string>>();
+    for (const [cardName, compatibleMonsters] of Object.entries(cardCompatibility)) {
+      all.set(
+        cardName.trim().toLowerCase(),
+        new Set(compatibleMonsters.map((monsterName) => monsterName.trim().toLowerCase())),
+      );
+    }
+    return all;
+  }, [cardCompatibility]);
+
+  const isCardCompatibleWithMonster = useCallback((cardName: string, monsterName: string): boolean => {
+    const compatibleMonsters = normalizedCompatibility.get(cardName.trim().toLowerCase());
+    if (!compatibleMonsters) return true;
+    return compatibleMonsters.has(monsterName.trim().toLowerCase());
+  }, [normalizedCompatibility]);
+
+  useEffect(() => {
+    if (!activeMonsterFilter) return;
+    setSelectedCards((previous) =>
+      previous.filter((entry) => {
+        if (entry.location.kind !== 'inventory') return true;
+        return isCardCompatibleWithMonster(entry.cardName, activeMonsterFilter);
+      }),
+    );
+  }, [activeMonsterFilter, isCardCompatibleWithMonster]);
+
+  const selectedInventoryCardName = useMemo(() => {
+    if (selectedCards.length !== 1) return null;
+    const selection = selectedCards[0];
+    if (!selection || selection.location.kind !== 'inventory') return null;
+    return selection.cardName;
+  }, [selectedCards]);
+
+  const compatibleCardCount = useMemo(() => {
+    if (!activeMonsterFilter) return null;
+    return unequippedDeck.filter((cardName) => isCardCompatibleWithMonster(cardName, activeMonsterFilter)).length;
+  }, [activeMonsterFilter, isCardCompatibleWithMonster, unequippedDeck]);
 
   const selectedSummary = useMemo(() => {
     if (selectedCards.length < 1) return '';
@@ -161,10 +208,9 @@ export default function WorkshopView() {
     }
   }
 
-  function isSameSource(a: WorkshopCardLocation, b: WorkshopCardLocation): boolean {
-    if (a.kind !== b.kind) return false;
-    if (a.kind === 'inventory') return true;
-    return b.kind === 'monster' && a.monsterName === b.monsterName;
+  function handleToggleMonsterFilter(monsterName: string) {
+    setSelectedCards([]);
+    setActiveMonsterFilter((previous) => (previous === monsterName ? null : monsterName));
   }
 
   async function handleSlotClick(target: WorkshopCardLocation) {
@@ -289,6 +335,14 @@ export default function WorkshopView() {
               onDeletePreset={(presetName) => {
                 void handleDeletePreset(monster.name, presetName);
               }}
+              isFilterActive={Boolean(activeMonsterFilter)}
+              isFilterTarget={activeMonsterFilter === monster.name}
+              compatibilityHint={
+                selectedInventoryCardName
+                  ? (isCardCompatibleWithMonster(selectedInventoryCardName, monster.name) ? 'eligible' : 'ineligible')
+                  : 'none'
+              }
+              onToggleFilter={() => handleToggleMonsterFilter(monster.name)}
             />
           ))}
         </div>
@@ -296,6 +350,12 @@ export default function WorkshopView() {
         <InventoryPanel
           cards={unequippedDeck}
           selectedCards={selectedCards}
+          activeMonsterFilterName={activeMonsterFilter}
+          compatibleCardCount={compatibleCardCount}
+          onClearMonsterFilter={() => setActiveMonsterFilter(null)}
+          isCardUnavailable={(cardName) =>
+            activeMonsterFilter ? !isCardCompatibleWithMonster(cardName, activeMonsterFilter) : false
+          }
           onDropCard={(source, cardName) => handleDrop(source, { kind: 'inventory' }, cardName)}
           onTapSlot={() => {
             void handleSlotClick({ kind: 'inventory' });

--- a/packages/engine/src/characters/beastmaster.test.ts
+++ b/packages/engine/src/characters/beastmaster.test.ts
@@ -134,6 +134,24 @@ describe('characters/beastmaster', () => {
 		expect(toMonster.cards.map(card => card.cardType)).to.deep.equal(['Blink', 'Hit']);
 	});
 
+	it('reorders a monster hand by moving a card to a new index', async () => {
+		const beastmaster = new Beastmaster();
+		const monster = makeMonster('Stonefang', [makeCard('Hit'), makeCard('Heal'), makeCard('Blink')]);
+		beastmaster.monsters = [monster as any];
+
+		const result = await beastmaster.reorderCards({
+			channel: channelStub,
+			monsterName: 'Stonefang',
+			fromIndex: 0,
+			toIndex: 2,
+		});
+
+		expect(result.monsterName).to.equal('Stonefang');
+		expect(result.fromIndex).to.equal(0);
+		expect(result.toIndex).to.equal(2);
+		expect(monster.cards.map(card => card.cardType)).to.deep.equal(['Heal', 'Blink', 'Hit']);
+	});
+
 	it('saves, loads, and deletes presets', async () => {
 		const beastmaster = new Beastmaster();
 		const monster = makeMonster('Stonefang', [makeCard('Hit'), makeCard('Heal')]);

--- a/packages/engine/src/characters/beastmaster.ts
+++ b/packages/engine/src/characters/beastmaster.ts
@@ -630,6 +630,70 @@ class Beastmaster extends BaseCharacter {
 		}));
 	}
 
+	reorderCards({
+		monsterName,
+		fromIndex,
+		toIndex,
+		channel,
+	}: {
+		monsterName: string;
+		fromIndex: number;
+		toIndex: number;
+		channel: ChannelFn;
+	}): Promise<{ monsterName: string; movedCard: string; fromIndex: number; toIndex: number; cards: string[] }> {
+		const monster = this.findMonsterByName(monsterName);
+		if (!monster) {
+			return announceAndThrow(channel, `I can find no monster named ${monsterName}.`);
+		}
+		if (monster.inEncounter) {
+			return announceAndThrow(channel, `You cannot reorder ${monster.givenName}'s cards while they are fighting!`);
+		}
+
+		const cards = [...monster.cards];
+		if (cards.length < 2) {
+			return announceAndThrow(channel, `${monster.givenName} needs at least 2 cards to reorder.`);
+		}
+
+		const from = Number.isInteger(fromIndex) ? fromIndex : Number.parseInt(String(fromIndex), 10);
+		const to = Number.isInteger(toIndex) ? toIndex : Number.parseInt(String(toIndex), 10);
+		if (!Number.isFinite(from) || !Number.isFinite(to)) {
+			return announceAndThrow(channel, 'Card reorder indices must be valid numbers.');
+		}
+		if (from < 0 || from >= cards.length || to < 0 || to >= cards.length) {
+			return announceAndThrow(
+				channel,
+				`Card reorder indices must be between 0 and ${cards.length - 1}.`,
+			);
+		}
+		if (from === to) {
+			const names = cards.map(card => getCardName(card));
+			return Promise.resolve(channel({
+				announce: `${monster.givenName}'s card order is unchanged.`,
+			})).then(() => ({
+				monsterName: monster.givenName,
+				movedCard: getCardName(cards[from]),
+				fromIndex: from,
+				toIndex: to,
+				cards: names,
+			}));
+		}
+
+		const movedCard = cards.splice(from, 1)[0];
+		cards.splice(to, 0, movedCard);
+		monster.cards = cards;
+		const names = cards.map(card => getCardName(card));
+
+		return Promise.resolve(channel({
+			announce: `Reordered ${monster.givenName}'s deck: moved ${getCardName(movedCard)} from slot ${from + 1} to ${to + 1}.`,
+		})).then(() => ({
+			monsterName: monster.givenName,
+			movedCard: getCardName(movedCard),
+			fromIndex: from,
+			toIndex: to,
+			cards: names,
+		}));
+	}
+
 	moveCards({
 		cardNames,
 		fromMonsterName,

--- a/packages/engine/src/helpers/delay-times.test.ts
+++ b/packages/engine/src/helpers/delay-times.test.ts
@@ -34,12 +34,12 @@ describe('delay-times', () => {
 
 	it('keeps default ranges unchanged when no env overrides are set', () => {
 		Math.random = () => 0;
-		expect(veryShortDelay()).to.equal(1000);
-		expect(shortDelay()).to.equal(1500);
-
-		Math.random = () => 0.999999;
 		expect(veryShortDelay()).to.equal(2000);
 		expect(shortDelay()).to.equal(3000);
+
+		Math.random = () => 0.999999;
+		expect(veryShortDelay()).to.equal(4000);
+		expect(shortDelay()).to.equal(6000);
 	});
 
 	it('uses midpoint env vars to derive min and max ranges', () => {
@@ -61,8 +61,8 @@ describe('delay-times', () => {
 		process.env.DECK_MONSTERS_DELAY_ROUND_MAX_FACTOR = '1.2';
 
 		Math.random = () => 0;
-		// Base veryShort min is 1000ms. Round 3 => factor 1 + 0.5 * 2 = 2.0, capped to 1.2.
-		expect(veryShortDelay(3)).to.equal(1200);
+		// Base veryShort min is 2000ms. Round 3 => factor 1 + 0.5 * 2 = 2.0, capped to 1.2.
+		expect(veryShortDelay(3)).to.equal(2400);
 	});
 
 	it('returns zero delays when delay skipping is enabled', () => {

--- a/packages/engine/src/helpers/delay-times.ts
+++ b/packages/engine/src/helpers/delay-times.ts
@@ -2,16 +2,17 @@ export const ONE_MINUTE = 60000;
 
 type DelayKind = 'very_short' | 'short' | 'medium' | 'long';
 
-// Preserve existing behavior by default:
-// - very_short: 1000–2000ms (midpoint 1500)
-// - short:      1500–3000ms (midpoint 2250)
-// - medium:     2000–4000ms (midpoint 3000)
-// - long:       3000–6000ms (midpoint 4500)
+// Default pacing values (roughly doubled from legacy) to make ring fights easier
+// to follow in live feeds:
+// - very_short: 2000–4000ms (midpoint 3000)
+// - short:      3000–6000ms (midpoint 4500)
+// - medium:     4000–8000ms (midpoint 6000)
+// - long:       6000–12000ms (midpoint 9000)
 const DEFAULT_MIDPOINTS: Record<DelayKind, number> = {
-	very_short: 1500,
-	short: 2250,
-	medium: 3000,
-	long: 4500,
+	very_short: 3000,
+	short: 4500,
+	medium: 6000,
+	long: 9000,
 };
 
 const MIDPOINT_ENV: Record<DelayKind, string> = {

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -231,6 +231,7 @@ describe('trpc/router card management procedures', () => {
 
 	it('routes game.reorderCards through character.reorderCards', async () => {
 		let receivedInput: Record<string, unknown> | undefined;
+		const publishedEvents: Array<{ type?: unknown; payload?: Record<string, unknown> }> = [];
 		const reorderCards = async (input: Record<string, unknown>) => {
 			receivedInput = input;
 			return {
@@ -246,7 +247,11 @@ describe('trpc/router card management procedures', () => {
 			getGame: async () => ({
 				characters: { [USER_ID]: { reorderCards } },
 			}),
-			getEventBus: async () => ({ publish: () => undefined }),
+			getEventBus: async () => ({
+				publish: (event: { type?: unknown; payload?: Record<string, unknown> }) => {
+					publishedEvents.push(event);
+				},
+			}),
 			runSerializedEngineWork: async (_roomId: string, fn: () => Promise<unknown>) => fn(),
 		} as unknown as Parameters<typeof createRouter>[0];
 
@@ -266,6 +271,15 @@ describe('trpc/router card management procedures', () => {
 		expect(callInput.fromIndex).to.equal(0);
 		expect(callInput.toIndex).to.equal(1);
 		expect(result).to.deep.equal({
+			monsterName: 'Stonefang',
+			fromIndex: 0,
+			toIndex: 1,
+			cards: ['Heal', 'Hit'],
+		});
+		const cardEquippedEvents = publishedEvents.filter((event) => event.type === 'card.equipped');
+		expect(cardEquippedEvents).to.have.length(1);
+		expect(cardEquippedEvents[0]?.payload).to.deep.equal({
+			operation: 'reorderCards',
 			monsterName: 'Stonefang',
 			fromIndex: 0,
 			toIndex: 1,

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -228,4 +228,48 @@ describe('trpc/router card management procedures', () => {
 			skippedCards: ['Heal'],
 		});
 	});
+
+	it('routes game.reorderCards through character.reorderCards', async () => {
+		let receivedInput: Record<string, unknown> | undefined;
+		const reorderCards = async (input: Record<string, unknown>) => {
+			receivedInput = input;
+			return {
+				monsterName: 'Stonefang',
+				fromIndex: 0,
+				toIndex: 1,
+				cards: ['Heal', 'Hit'],
+			};
+		};
+
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => ({
+				characters: { [USER_ID]: { reorderCards } },
+			}),
+			getEventBus: async () => ({ publish: () => undefined }),
+			runSerializedEngineWork: async (_roomId: string, fn: () => Promise<unknown>) => fn(),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const result = await caller.game.reorderCards({
+			roomId: ROOM_ID,
+			monsterName: 'Stonefang',
+			fromIndex: 0,
+			toIndex: 1,
+		});
+
+		expect(receivedInput).to.not.equal(undefined);
+		if (!receivedInput) throw new Error('Expected reorderCards to be called');
+		const callInput = receivedInput;
+		expect(callInput.monsterName).to.equal('Stonefang');
+		expect(callInput.fromIndex).to.equal(0);
+		expect(callInput.toIndex).to.equal(1);
+		expect(result).to.deep.equal({
+			monsterName: 'Stonefang',
+			fromIndex: 0,
+			toIndex: 1,
+			cards: ['Heal', 'Hit'],
+		});
+	});
 });

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -62,11 +62,23 @@ describe('trpc/router card management procedures', () => {
 			cards: [{ cardType: 'Hit' }],
 			items: [{ itemType: 'Potion' }],
 			options: { presets: { aggro: ['Hit'] } },
+			canHoldCard: (card: { cardType?: string }) => card.cardType !== 'Blink',
+		};
+		const supportMonster = {
+			givenName: 'Mirebell',
+			creatureType: 'Jinn',
+			level: 2,
+			inEncounter: false,
+			cardSlots: 9,
+			cards: [],
+			items: [],
+			options: { presets: {} },
+			canHoldCard: (card: { cardType?: string }) => card.cardType === 'Blink',
 		};
 		const game = {
 			characters: {
 				[USER_ID]: {
-					monsters: [targetMonster],
+					monsters: [targetMonster, supportMonster],
 					deck: [{ cardType: 'Blink' }],
 					items: [{ itemType: 'Scroll' }],
 				},
@@ -82,13 +94,16 @@ describe('trpc/router card management procedures', () => {
 		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
 		const result = await caller.game.myInventory({ roomId: ROOM_ID });
 
-		expect(result.monsters).to.have.length(1);
+		expect(result.monsters).to.have.length(2);
 		expect(result.monsters[0]).to.include({
 			name: 'Stonefang',
 			type: 'Basilisk',
 			inRing: true,
 		});
 		expect(result.unequippedDeck).to.deep.equal(['Blink']);
+		expect(result.cardCompatibility).to.deep.equal({
+			Blink: ['Mirebell'],
+		});
 		expect(result.items.character).to.deep.equal(['Scroll']);
 	});
 

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -48,6 +48,7 @@ type InventoryMonsterSummary = {
 type InventorySummary = {
 	monsters: InventoryMonsterSummary[];
 	unequippedDeck: string[];
+	cardCompatibility: Record<string, string[]>;
 	items: {
 		character: string[];
 		monsters: Array<{ monsterName: string; items: string[] }>;
@@ -75,6 +76,20 @@ const getDisplayName = (entity: unknown): string => {
 	return byItemType ?? byCardType ?? byName ?? 'Unknown';
 };
 
+const canMonsterHoldCard = (monster: unknown, card: unknown): boolean => {
+	if (!monster || typeof monster !== 'object') return false;
+	const canHoldCard = (monster as { canHoldCard?: unknown }).canHoldCard;
+	if (typeof canHoldCard !== 'function') {
+		// Test doubles and legacy snapshots may not provide this function.
+		return true;
+	}
+	try {
+		return Boolean(canHoldCard.call(monster, card));
+	} catch {
+		return false;
+	}
+};
+
 const summarizeInventory = ({
 	character,
 	inRing,
@@ -86,7 +101,7 @@ const summarizeInventory = ({
 	const deck = Array.isArray(character.deck) ? character.deck : [];
 	const items = Array.isArray(character.items) ? character.items : [];
 
-	const monsterSummaries = monsters
+	const monsterEntries = monsters
 		.map((monster) => {
 			const record = (monster ?? {}) as Record<string, unknown>;
 			const cards = Array.isArray(record.cards) ? record.cards : [];
@@ -107,43 +122,64 @@ const summarizeInventory = ({
 			if (!name) return null;
 
 			return {
-				name,
-				type:
-					typeof record.creatureType === 'string'
-						? record.creatureType
-						: 'Unknown',
-				level:
-					typeof record.level === 'number' && Number.isFinite(record.level)
-						? record.level
-						: 0,
-				inRing: inRing.has(monster),
-				inEncounter: Boolean(record.inEncounter),
-				cardSlots:
-					typeof record.cardSlots === 'number' && Number.isFinite(record.cardSlots)
-						? record.cardSlots
-						: 0,
-				cards: cards.map((card) => getDisplayName(card)),
-				presets,
-			} satisfies InventoryMonsterSummary;
+				monster,
+				summary: {
+					name,
+					type:
+						typeof record.creatureType === 'string'
+							? record.creatureType
+							: 'Unknown',
+					level:
+						typeof record.level === 'number' && Number.isFinite(record.level)
+							? record.level
+							: 0,
+					inRing: inRing.has(monster),
+					inEncounter: Boolean(record.inEncounter),
+					cardSlots:
+						typeof record.cardSlots === 'number' && Number.isFinite(record.cardSlots)
+							? record.cardSlots
+							: 0,
+					cards: cards.map((card) => getDisplayName(card)),
+					presets,
+				} satisfies InventoryMonsterSummary,
+			};
 		})
-		.filter((monster): monster is InventoryMonsterSummary => monster !== null);
+		.filter(
+			(
+				monsterEntry,
+			): monsterEntry is { monster: unknown; summary: InventoryMonsterSummary } =>
+				monsterEntry !== null,
+		);
 
-	const monsterItems = monsterSummaries.map((monsterSummary) => {
-		const monster = monsters.find(
-			(entry) =>
-				(entry as Record<string, unknown> | undefined)?.givenName ===
-				monsterSummary.name,
-		) as Record<string, unknown> | undefined;
-		const monsterInventory = Array.isArray(monster?.items) ? monster.items : [];
+	const monsterSummaries = monsterEntries.map((entry) => entry.summary);
+
+	const monsterItems = monsterEntries.map((entry) => {
+		const monster = (entry.monster ?? {}) as Record<string, unknown>;
+		const monsterInventory = Array.isArray(monster.items) ? monster.items : [];
 		return {
-			monsterName: monsterSummary.name,
+			monsterName: entry.summary.name,
 			items: monsterInventory.map((item) => getDisplayName(item)),
 		};
 	});
 
+	const cardCompatibility = deck.reduce<Record<string, string[]>>((all, card) => {
+		const cardName = getDisplayName(card);
+		if (!all[cardName]) {
+			all[cardName] = [];
+		}
+		for (const entry of monsterEntries) {
+			if (!canMonsterHoldCard(entry.monster, card)) continue;
+			if (!all[cardName]?.includes(entry.summary.name)) {
+				all[cardName]?.push(entry.summary.name);
+			}
+		}
+		return all;
+	}, {});
+
 	return {
 		monsters: monsterSummaries,
 		unequippedDeck: deck.map((card) => getDisplayName(card)),
+		cardCompatibility,
 		items: {
 			character: items.map((item) => getDisplayName(item)),
 			monsters: monsterItems,
@@ -660,6 +696,7 @@ export function createRouter(roomManager: RoomManager) {
 					return {
 						monsters: [],
 						unequippedDeck: [],
+						cardCompatibility: {},
 						items: { character: [], monsters: [] },
 					} satisfies InventorySummary;
 				}

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -988,6 +988,67 @@ export function createRouter(roomManager: RoomManager) {
 				return result;
 			}),
 
+		reorderCards: protectedProcedure
+			.input(
+				z.object({
+					roomId: z.string().uuid(),
+					monsterName: z.string().min(1),
+					fromIndex: z.number().int().min(0),
+					toIndex: z.number().int().min(0),
+				}),
+			)
+			.mutation(async ({ input, ctx }) => {
+				await roomManager.assertMember(ctx.userId, input.roomId);
+				const [game, eventBus] = await Promise.all([
+					roomManager.getGame(input.roomId),
+					roomManager.getEventBus(input.roomId),
+				]);
+				const character = game.characters?.[ctx.userId];
+				if (!character || typeof character.reorderCards !== 'function') {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Character not found' });
+				}
+
+				const commandId = randomUUID();
+				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
+				const result = await runSerializedMutation(input.roomId, () =>
+					character.reorderCards({
+						channel,
+						monsterName: input.monsterName,
+						fromIndex: input.fromIndex,
+						toIndex: input.toIndex,
+					}),
+				) as { monsterName: string; fromIndex: number; toIndex: number; cards: string[] };
+				eventBus.publish({
+					type: 'card.equipped' as EventType,
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						operation: 'reorderCards',
+						monsterName: result.monsterName,
+						fromIndex: result.fromIndex,
+						toIndex: result.toIndex,
+					},
+				});
+				publishPrivateAnnouncement({
+					eventBus,
+					userId: ctx.userId,
+					text: `Reordered ${result.monsterName}'s deck (${result.fromIndex + 1} → ${result.toIndex + 1}).`,
+					operation: 'reorderCards',
+				});
+				eventBus.publish({
+					type: 'card.equipped' as EventType,
+					scope: 'private',
+					targetUserId: ctx.userId,
+					text: '',
+					payload: {
+						monsterName: result.monsterName,
+						cards: result.cards,
+					},
+				});
+				return result;
+			}),
+
 		savePreset: protectedProcedure
 			.input(
 				z.object({

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -55,6 +55,13 @@ type InventorySummary = {
 	};
 };
 
+const reorderCardsResultSchema = z.object({
+	monsterName: z.string().min(1),
+	fromIndex: z.number().int().min(0),
+	toIndex: z.number().int().min(0),
+	cards: z.array(z.string()),
+});
+
 type PublishableEvent = {
 	type: EventType;
 	scope: EventScope;
@@ -1010,26 +1017,15 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const rawResult = await runSerializedMutation(input.roomId, () =>
 					character.reorderCards({
 						channel,
 						monsterName: input.monsterName,
 						fromIndex: input.fromIndex,
 						toIndex: input.toIndex,
 					}),
-				) as { monsterName: string; fromIndex: number; toIndex: number; cards: string[] };
-				eventBus.publish({
-					type: 'card.equipped' as EventType,
-					scope: 'private',
-					targetUserId: ctx.userId,
-					text: '',
-					payload: {
-						operation: 'reorderCards',
-						monsterName: result.monsterName,
-						fromIndex: result.fromIndex,
-						toIndex: result.toIndex,
-					},
-				});
+				);
+				const result = reorderCardsResultSchema.parse(rawResult);
 				publishPrivateAnnouncement({
 					eventBus,
 					userId: ctx.userId,
@@ -1042,7 +1038,10 @@ export function createRouter(roomManager: RoomManager) {
 					targetUserId: ctx.userId,
 					text: '',
 					payload: {
+						operation: 'reorderCards',
 						monsterName: result.monsterName,
+						fromIndex: result.fromIndex,
+						toIndex: result.toIndex,
 						cards: result.cards,
 					},
 				});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add same-monster card reordering in Deck Workshop by drag-and-drop, backed by new engine/server `reorderCards` flow and client mutation wiring
- improve workshop usability by making card names consistently visible on desktop cards and preserving monster-filter compatibility visuals
- add explicit return-to-terminal navigation in room-scoped screens: a `Terminal` menu item plus clickable room-name breadcrumb back to `/room/:roomId`
- make ring/console feed auto-scroll less greedy: new events no longer force-scroll when the user is reading older messages; `Latest` (or returning to bottom) re-enables follow behavior
- slow default fight pacing by doubling baseline delay midpoints while keeping existing env-var overrides intact
- address review blockers by deduplicating `card.equipped` publish in `reorderCards` and moving ConsolePane scroll side-effects out of state updaters
- expand tests across engine, server, and web (including feed-scroll behavior checks and reorder publish regression assertions)

## Walkthrough artifacts
<a href="https://cursor.com/agents/bc-4d94c405-473c-4187-9a7e-a507a3953b49/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkshop_reorder_filter_and_card_names_demo.mp4"><img src="https://cursor.com/artifacts/c/art-2d3bf7b9-018b-4a44-9d22-ba1b292192fe" alt="workshop_reorder_filter_and_card_names_demo.mp4" /></a>
Workshop: desktop card names + compatibility filter + same-monster reorder.

<a href="https://cursor.com/agents/bc-4d94c405-473c-4187-9a7e-a507a3953b49/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froom_screen_navigation_to_terminal_demo.mp4"><img src="https://cursor.com/artifacts/c/art-d45bd9fc-d706-4e03-a1df-a084d55e82a2" alt="room_screen_navigation_to_terminal_demo.mp4" /></a>
Navigation: Workshop/Fight Log back to main Terminal via new menu item and room breadcrumb link.

![Desktop card names visible in workshop](https://cursor.com/artifacts/c/art-f037ec34-21b5-412b-bbb4-09500e37c592)
![Stonefang filter active with incompatible cards greyed](https://cursor.com/artifacts/c/art-0e827f5e-5538-4028-9109-a35234c74179)
![Same-monster reorder visual position change](https://cursor.com/artifacts/c/art-a89232d7-a623-494b-9c1c-bc98290b6eac)
![Filter cleared with full inventory restored](https://cursor.com/artifacts/c/art-86369398-3e1f-4e9a-b08f-f7af9c678c13)
![Workshop header showing Terminal return path](https://cursor.com/artifacts/c/art-4368b0d5-fe75-4858-8b4d-a891302605fd)
![Terminal destination after using Terminal nav](https://cursor.com/artifacts/c/art-5797a13c-6a2f-4d29-99e5-17d36a0f7c01)
![Room-name breadcrumb returning to terminal](https://cursor.com/artifacts/c/art-cf65b913-5e25-42fa-8a36-35f6caca4dc2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d94c405-473c-4187-9a7e-a507a3953b49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d94c405-473c-4187-9a7e-a507a3953b49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

