### PR TITLE
Pace ring fight sub-events at the source (subEventDelay)

### DIFF
--- a/packages/engine/src/cards/base.ts
+++ b/packages/engine/src/cards/base.ts
@@ -1,6 +1,7 @@
 import { BaseItem, type BaseItemOptions, type BaseItemStatic } from '../items/base.js';
 import { mapSeries } from '../helpers/promise.js';
 import { ATTACK_PHASE, DEFENSE_PHASE, GLOBAL_PHASE } from '../constants/phases.js';
+import { subEventDelay } from '../helpers/delay-times.js';
 
 export interface CardOptions extends Omit<BaseItemOptions, 'flavors'> {
 	cardClass?: string[];
@@ -83,45 +84,43 @@ export class BaseCard<TOptions extends CardOptions = CardOptions> extends BaseIt
 		return !!(this.cardClass && this.cardClass.includes(cardClass));
 	}
 
-	applyEffects(
+	async applyEffects(
 		player: any,
 		proposedTarget: any,
 		ring: any,
 		activeContestants: any[]
-	): any {
+	): Promise<any> {
 		let card: any = this.clone();
 
 		if (activeContestants) {
-			card = activeContestants.reduce(
-				(contestantCard: any, contestant: any) =>
-					contestant.monster.encounterEffects.reduce((effectCard: any, effect: any) => {
-						const modifiedCard = effect({
-							activeContestants,
-							card: effectCard,
-							phase:
-								contestant.monster === player ? ATTACK_PHASE : DEFENSE_PHASE,
-							player,
-							ring,
-							proposedTarget,
-						});
-						return modifiedCard || effectCard;
-					}, contestantCard),
-				card
-			);
+			for (const contestant of activeContestants) {
+				for (const effect of contestant.monster.encounterEffects) {
+					const modifiedCard = await effect({
+						activeContestants,
+						card,
+						phase:
+							contestant.monster === player ? ATTACK_PHASE : DEFENSE_PHASE,
+						player,
+						ring,
+						proposedTarget,
+					});
+					card = modifiedCard || card;
+				}
+			}
 		}
 
 		if (ring && ring.encounterEffects) {
-			card = ring.encounterEffects.reduce((currentCard: any, effect: any) => {
-				const modifiedCard = effect({
+			for (const effect of ring.encounterEffects) {
+				const modifiedCard = await effect({
 					activeContestants,
-					card: currentCard,
+					card,
 					phase: GLOBAL_PHASE,
 					player,
 					ring,
 					proposedTarget,
 				});
-				return modifiedCard || currentCard;
-			}, card);
+				card = modifiedCard || card;
+			}
 		}
 
 		this.new = card;
@@ -157,17 +156,19 @@ export class BaseCard<TOptions extends CardOptions = CardOptions> extends BaseIt
 		shouldApplyEffects = true
 	): Promise<any> {
 		if (shouldApplyEffects) {
-			const card = this.applyEffects(
+			return this.applyEffects(
 				player,
 				proposedTarget,
 				ring,
 				activeContestants
+			).then(card =>
+				card.play(player, proposedTarget, ring, activeContestants, false)
 			);
-			return card.play(player, proposedTarget, ring, activeContestants, false);
 		}
 
-		return Promise.resolve().then(() => {
+		return Promise.resolve().then(async () => {
 			this.emit('played', { player });
+			await subEventDelay();
 
 			const targets = this.getTargets(
 				player,

--- a/packages/engine/src/cards/berserk.ts
+++ b/packages/engine/src/cards/berserk.ts
@@ -115,13 +115,13 @@ export class BerserkCard extends HitCard {
 		});
 	}
 
-	effectLoop(
+	async effectLoop(
 		iteration: number,
 		player: any,
 		target: any,
 		ring: any,
 		activeContestants: any
-	): any {
+	): Promise<any> {
 		this.iterations = iteration;
 
 		if (iteration > 2) this.increaseFatigue();
@@ -151,7 +151,7 @@ export class BerserkCard extends HitCard {
 			if (
 				this.cumulativeComboDamage <= Math.floor(target.maxHp / 2)
 			) {
-				target.hit(damage, player, this);
+				await target.hit(damage, player, this);
 			} else {
 				this.emit('narration', {
 					narration: `HUMILIATION! ${iteration} hits`,
@@ -200,12 +200,12 @@ export class BerserkCard extends HitCard {
 			.then(() => !target.dead);
 	}
 
-	override effect(
+	override async effect(
 		player: any,
 		target: any,
 		ring: any,
 		activeContestants?: any
-	): any {
+	): Promise<any> {
 		this.resetCard();
 		this.cumulativeComboDamage = 0;
 		return this.effectLoop(1, player, target, ring, activeContestants);

--- a/packages/engine/src/cards/blink.ts
+++ b/packages/engine/src/cards/blink.ts
@@ -89,7 +89,7 @@ export class BlinkCard extends CurseCard {
 		});
 
 		if (attackSuccess.success) {
-			const blinkEffect = ({ card, phase }: any) => {
+			const blinkEffect = async ({ card, phase }: any) => {
 				const { effect } = card;
 
 				if (effect && phase === DEFENSE_PHASE) {
@@ -157,10 +157,10 @@ export class BlinkCard extends CurseCard {
 							who: blinkPlayer,
 						});
 
-						blinkTarget.hit(hpToSteal.result, blinkPlayer, this);
-						blinkPlayer.heal(hpToSteal.result, blinkTarget, this);
+						await blinkTarget.hit(hpToSteal.result, blinkPlayer, this);
+						await blinkPlayer.heal(hpToSteal.result, blinkTarget, this);
 
-						super.effect(blinkPlayer, blinkTarget, ring);
+						await super.effect(blinkPlayer, blinkTarget, ring);
 						blinkPlayer.setModifier(this.cursedProp, xpToSteal.result);
 
 						card.play = () => Promise.resolve(true);

--- a/packages/engine/src/cards/boost.ts
+++ b/packages/engine/src/cards/boost.ts
@@ -95,7 +95,7 @@ export class BoostCard extends BaseCard<BoostCardOptions> {
 		return `${target.givenName}'s ${this.boostedProp} boosts have been maxed out. Boost will be granted to hp instead.`;
 	}
 
-	effect(player: any, target: any): any {
+	async effect(player: any, target: any): Promise<any> {
 		const preBoostedPropValue = target[this.boostedProp];
 		let { boostAmount } = this;
 		const postBoostedPropValue = preBoostedPropValue + boostAmount;
@@ -115,7 +115,7 @@ export class BoostCard extends BaseCard<BoostCardOptions> {
 			this.emit('narration', {
 				narration: this.getBoostOverflowNarrative(player, target),
 			});
-			player.heal(hpBoostOverflow, target, this);
+			await player.heal(hpBoostOverflow, target, this);
 		}
 
 		if (boostAmount > 0) {

--- a/packages/engine/src/cards/coil.test.ts
+++ b/packages/engine/src/cards/coil.test.ts
@@ -75,7 +75,7 @@ Turns immobilized resets on curse of loki.
 
 		return coil
 			.play(player, target, ring, ring.contestants)
-			.then(() => {
+			.then(async () => {
 				expect((target as any).encounterEffects.length).to.equal(1);
 				expect((target as any).hp).to.be.below(startingTargetHP);
 				ongoingHP = (target as any).hp;
@@ -83,19 +83,20 @@ Turns immobilized resets on curse of loki.
 
 				checkSuccessStub.returns({ success: false, strokeOfLuck: false, curseOfLoki: false });
 
-				const card = (target as any).encounterEffects.reduce((currentCard: any, effect: any) => {
-					const modifiedCard = effect({
+				let card = new HitCard();
+				for (const effect of (target as any).encounterEffects) {
+					const modifiedCard = await effect({
 						activeContestants: [target, player],
-						card: currentCard,
+						card,
 						phase: ATTACK_PHASE,
 						player,
 						ring,
 						target,
 					});
-					return modifiedCard || currentCard;
-				}, new HitCard());
+					card = modifiedCard || card;
+				}
 
-				return card.play(target, player, ring, ring.contestants).then(() => {
+				return card.play(target, player, ring, ring.contestants).then(async () => {
 					expect((target as any).hp).to.equal(ongoingHP - 1);
 					ongoingHP = (target as any).hp;
 					expect((player as any).hp).to.equal(startingPlayerHP);
@@ -103,17 +104,18 @@ Turns immobilized resets on curse of loki.
 
 					checkSuccessStub.returns({ success: true, strokeOfLuck: false, curseOfLoki: false });
 
-					const newcard = (target as any).encounterEffects.reduce((currentCard: any, effect: any) => {
-						const modifiedCard = effect({
+					let newcard = new HitCard();
+					for (const effect of (target as any).encounterEffects) {
+						const modifiedCard = await effect({
 							activeContestants: [target, player],
-							card: currentCard,
+							card: newcard,
 							phase: ATTACK_PHASE,
 							player,
 							ring,
 							target,
 						});
-						return modifiedCard || currentCard;
-					}, new HitCard());
+						newcard = modifiedCard || newcard;
+					}
 
 					return newcard.play(target, player, ring, ring.contestants).then(() => {
 						checkSuccessStub.restore();

--- a/packages/engine/src/cards/curse.ts
+++ b/packages/engine/src/cards/curse.ts
@@ -93,7 +93,7 @@ export class CurseCard extends HitCard {
 		});
 	}
 
-	override effect(player: any, target: any, ring: any, _activeContestants?: any): any {
+	override async effect(player: any, target: any, ring: any, _activeContestants?: any): Promise<any> {
 		const preCursedPropValue = target[this.cursedProp];
 		let curseAmount = Math.abs(this.curseAmount);
 		const postCursedPropValue = preCursedPropValue - curseAmount;
@@ -113,7 +113,7 @@ export class CurseCard extends HitCard {
 			this.emit('narration', {
 				narration: this.getCurseOverflowNarrative(player, target),
 			});
-			target.hit(
+			await target.hit(
 				Math.min(hpCurseOverflow, max(this.damageDice)),
 				player,
 				this
@@ -128,7 +128,7 @@ export class CurseCard extends HitCard {
 		}
 
 		if (this.hasChanceToHit) {
-			return super.effect(player, target, ring);
+			return await super.effect(player, target, ring);
 		}
 		return !target.dead;
 	}

--- a/packages/engine/src/cards/forked-stick.test.ts
+++ b/packages/engine/src/cards/forked-stick.test.ts
@@ -184,24 +184,25 @@ Turns immobilized resets on curse of loki.
 
 		return forkedStick
 			.play(player, target, ring, ring.contestants)
-			.then(() => {
+			.then(async () => {
 				expect((target as any).encounterEffects[0].effectType).to.equal('ImmobilizeEffect');
 
 				checkSuccessStub.returns({ success: false, strokeOfLuck: false, curseOfLoki: false });
 
 				expect((forkedStick as any).getFreedomThreshold(player, target)).to.equal(9);
 
-				const card = (target as any).encounterEffects.reduce((currentCard: any, effect: any) => {
-					const modifiedCard = effect({
+				let card = new HitCard();
+				for (const effect of (target as any).encounterEffects) {
+					const modifiedCard = await effect({
 						activeContestants: [target, player],
-						card: currentCard,
+						card,
 						phase: ATTACK_PHASE,
 						player,
 						ring,
 						target,
 					});
-					return modifiedCard || currentCard;
-				}, new HitCard());
+					card = modifiedCard || card;
+				}
 
 				return card.play(target, player, ring, ring.contestants).then(() => {
 					expect((forkedStick as any).getFreedomThreshold(player, target)).to.equal(6);
@@ -238,24 +239,25 @@ Turns immobilized resets on curse of loki.
 
 		return forkedStick
 			.play(player, target, ring, ring.contestants)
-			.then(() => {
+			.then(async () => {
 				expect((target as any).encounterEffects[0].effectType).to.equal('ImmobilizeEffect');
 				expect(getAttackRollImmobilizeSpy.callCount).to.equal(1);
 				expect(getFreedomRollImmobilizeSpy.callCount).to.equal(0);
 				expect(getImmobilizeRollImmobilizeSpy.callCount).to.equal(1);
 				expect(getAttackRollHitSpy.callCount).to.equal(0);
 
-				const card = (target as any).encounterEffects.reduce((currentCard: any, effect: any) => {
-					const modifiedCard = effect({
+				let card = new HitCard();
+				for (const effect of (target as any).encounterEffects) {
+					const modifiedCard = await effect({
 						activeContestants: [target, player],
-						card: currentCard,
+						card,
 						phase: ATTACK_PHASE,
 						player,
 						ring,
 						target,
 					});
-					return modifiedCard || currentCard;
-				}, new HitCard());
+					card = modifiedCard || card;
+				}
 
 				return card.play(target, player, ring, ring.contestants).then(() => {
 					expect(getAttackRollImmobilizeSpy.callCount).to.equal(1);
@@ -292,23 +294,24 @@ Turns immobilized resets on curse of loki.
 
 		return forkedStick
 			.play(player, target, ring, ring.contestants)
-			.then(() => {
+			.then(async () => {
 				expect((target as any).encounterEffects[0].effectType).to.equal('ImmobilizeEffect');
 
 				checkSuccessStub.returns({ success: false, strokeOfLuck: false, curseOfLoki: false });
 				(player as any).dead = true;
 
-				const card = (target as any).encounterEffects.reduce((currentCard: any, effect: any) => {
-					const modifiedCard = effect({
+				let card = new HitCard();
+				for (const effect of (target as any).encounterEffects) {
+					const modifiedCard = await effect({
 						activeContestants: [target, player],
-						card: currentCard,
+						card,
 						phase: ATTACK_PHASE,
 						player,
 						ring,
 						target,
 					});
-					return modifiedCard || currentCard;
-				}, new HitCard());
+					card = modifiedCard || card;
+				}
 
 				return card.play(target, player, ring, ring.contestants).then(() => {
 					checkSuccessStub.restore();

--- a/packages/engine/src/cards/hit.ts
+++ b/packages/engine/src/cards/hit.ts
@@ -1,4 +1,5 @@
 import { BaseCard, type CardOptions } from './base.js';
+import { subEventDelay } from '../helpers/delay-times.js';
 import { chance } from '../helpers/chance.js';
 import { ABUNDANT } from '../helpers/probabilities.js';
 import { ALMOST_NOTHING } from '../helpers/costs.js';
@@ -130,17 +131,20 @@ export class HitCard extends BaseCard<HitCardOptions> {
 		return damageRoll;
 	}
 
-	effect(player: any, target: any, ring: any, _activeContestants?: any): any {
+	async effect(player: any, target: any, ring: any, _activeContestants?: any): Promise<any> {
 		const { attackRoll, success, strokeOfLuck, curseOfLoki } = this.hitCheck(
 			player,
 			target
 		);
+		await subEventDelay();
 
 		if (success) {
 			const damageRoll = this.rollForDamage(player, target, strokeOfLuck);
+			await subEventDelay();
 			return target.hit(damageRoll.result, player, this);
 		} else if (curseOfLoki) {
 			const damageRoll = this.rollForDamage(target, player);
+			await subEventDelay();
 			return player.hit(damageRoll.result, target, this);
 		}
 
@@ -150,6 +154,7 @@ export class HitCard extends BaseCard<HitCardOptions> {
 			player,
 			target,
 		});
+		await subEventDelay();
 
 		return !target.dead;
 	}

--- a/packages/engine/src/cards/horn-gore.ts
+++ b/packages/engine/src/cards/horn-gore.ts
@@ -165,7 +165,7 @@ export class HornGore extends ImmobilizeCard {
 		});
 	}
 
-	gore(player: any, target: any, hornNumber: number): any {
+	async gore(player: any, target: any, hornNumber: number): Promise<any> {
 		const { attackRoll, success, strokeOfLuck, curseOfLoki } = this.hitCheck(
 			player,
 			target,
@@ -177,10 +177,10 @@ export class HornGore extends ImmobilizeCard {
 			const { dexModifier } = player.encounterModifiers;
 			player.encounterModifiers.dexModifier = dexModifier > 0 ? dexModifier + 1 : 1;
 			const damageRoll = this.rollForDamage(player, target, strokeOfLuck);
-			target.hit(damageRoll.result, player, this);
+			await target.hit(damageRoll.result, player, this);
 		} else if (curseOfLoki) {
 			const damageRoll = this.rollForDamage(target, player);
-			player.hit(damageRoll.result, target, this);
+			await player.hit(damageRoll.result, target, this);
 		}
 
 		return { attackRoll, success, strokeOfLuck, curseOfLoki };
@@ -219,17 +219,17 @@ export class HornGore extends ImmobilizeCard {
 		return immobilizeSuccess;
 	}
 
-	override effect(
+	override async effect(
 		player: any,
 		target: any,
 		ring: any,
 		activeContestants: any
-	): any {
+	): Promise<any> {
 		const originalDexModifier = player.encounterModifiers.dexModifier;
 
 		this.resetImmobilizeStrength();
-		const horn1 = this.gore(player, target, 1);
-		const horn2 = this.gore(player, target, 2);
+		const horn1 = await this.gore(player, target, 1);
+		const horn2 = await this.gore(player, target, 2);
 		const chanceToImmobilize = horn1.success || horn2.success;
 
 		player.encounterModifiers.dexModifier = originalDexModifier;

--- a/packages/engine/src/cards/immobilize.ts
+++ b/packages/engine/src/cards/immobilize.ts
@@ -228,7 +228,7 @@ ${ongoingDamageText}`;
 
 	getImmobilizeEffect(player: any, target: any, ring: any, _activeContestants?: any): any {
 		const immobilize = this;
-		const ImmobilizeEffect = ({ card, phase }: any) => {
+		const ImmobilizeEffect = async ({ card, phase }: any) => {
 			if (phase === ATTACK_PHASE) {
 				if (!player.dead) {
 					this.emit('effect', {
@@ -270,7 +270,7 @@ ${ongoingDamageText}`;
 							(effect: any) => effect.effectType !== 'ImmobilizeEffect'
 						);
 						if (strokeOfLuck && target !== player) {
-							player.hit(2, target, this);
+							await player.hit(2, target, this);
 						}
 					} else {
 						target.encounterModifiers.immobilizedTurns =
@@ -279,7 +279,7 @@ ${ongoingDamageText}`;
 							this.emit('narration', {
 								narration: `${target.givenName} takes ongoing damage from being ${this.actions.IMMOBILIZED}`,
 							});
-							target.hit(this.ongoingDamage, player, this);
+							await target.hit(this.ongoingDamage, player, this);
 						}
 						card.play = () => Promise.resolve(!target.dead);
 					}

--- a/packages/engine/src/cards/mesmerize.test.ts
+++ b/packages/engine/src/cards/mesmerize.test.ts
@@ -167,22 +167,23 @@ Turns immobilized resets on curse of loki.
 
 		return mesmerize
 			.play(player, basilisk, ring, ring.contestants)
-			.then(() => {
+			.then(async () => {
 				expect(basilisk.encounterEffects[0].effectType).to.equal('ImmobilizeEffect');
 
 				checkSuccessStub.returns({ success: true, strokeOfLuck: true, curseOfLoki: false });
 
-				const card = basilisk.encounterEffects.reduce((currentCard: any, effect: any) => {
-					const modifiedCard = effect({
+				let card = new HitCard();
+				for (const effect of basilisk.encounterEffects) {
+					const modifiedCard = await effect({
 						activeContestants: [basilisk, player],
-						card: currentCard,
+						card,
 						phase: ATTACK_PHASE,
 						player,
 						ring,
 						basilisk,
 					});
-					return modifiedCard || currentCard;
-				}, new HitCard());
+					card = modifiedCard || card;
+				}
 
 				return card.play(basilisk, player, ring, ring.contestants).then(() => {
 					expect(player.hp).to.be.below(playerBeforeHP);

--- a/packages/engine/src/cards/prion-disease.ts
+++ b/packages/engine/src/cards/prion-disease.ts
@@ -64,7 +64,7 @@ export class PrionDiseaseCard extends BaseCard {
 		}) as any[]).map(({ monster }: any) => monster);
 	}
 
-	effect(player: any, target: any): any {
+	async effect(player: any, target: any): Promise<any> {
 		const hpChange = this.getHPModifier(player, target);
 		let narration = `
 　　∧,,,∧
@@ -102,9 +102,9 @@ export class PrionDiseaseCard extends BaseCard {
 		this.emit('narration', { narration });
 
 		if (hpChange < 0) {
-			return target.hit(-hpChange, player, this);
+			return await target.hit(-hpChange, player, this);
 		} else if (hpChange > 0) {
-			return target.heal(hpChange, player, this);
+			return await target.heal(hpChange, player, this);
 		}
 
 		return true;

--- a/packages/engine/src/creatures/base.ts
+++ b/packages/engine/src/creatures/base.ts
@@ -367,9 +367,9 @@ Battles won: ${this.battles.wins}`;
 
 	get destroyed (): boolean { return this.hp < -this.bloodiedValue; }
 
-	hit (damage = 0, assailant?: BaseCreature, card?: CardInstance): boolean { return hit(this, damage, assailant, card); }
-	heal (amount = 0): boolean { return heal(this, amount); }
-	die (assailant?: BaseCreature): boolean { return die(this, assailant); }
+	hit (damage = 0, assailant?: BaseCreature, card?: CardInstance): Promise<boolean> { return hit(this, damage, assailant, card); }
+	heal (amount = 0): Promise<boolean> { return heal(this, amount); }
+	die (assailant?: BaseCreature): Promise<boolean> { return die(this, assailant); }
 	respawn (immediate?: boolean): number { return respawn(this, immediate); }
 
 	get respawnTimeoutBegan (): number {

--- a/packages/engine/src/creatures/health.ts
+++ b/packages/engine/src/creatures/health.ts
@@ -1,6 +1,7 @@
 import { capitalize } from '../helpers/capitalize.js';
 import { MELEE } from '../constants/card-classes.js';
 import { TIME_TO_RESURRECT_MS } from '../constants/timing.js';
+import { subEventDelay } from '../helpers/delay-times.js';
 import type { BaseCreature, CardInstance, HitLogEntry } from './base.js';
 
 // Duck-type guard: real creatures have `emit`; the synthetic `{ identityWithHp: 'mysterious causes' }` object does not.
@@ -9,7 +10,7 @@ function isRealCreature (assailant: unknown): assailant is BaseCreature {
 		typeof (assailant as Record<string, unknown>).emit === 'function';
 }
 
-export function hit (self: BaseCreature, damage = 0, assailant?: BaseCreature, card?: CardInstance): boolean {
+export async function hit (self: BaseCreature, damage = 0, assailant?: BaseCreature, card?: CardInstance): Promise<boolean> {
 	const hitLog: HitLogEntry[] = (self.encounterModifiers.hitLog as HitLogEntry[]) || [];
 	hitLog.unshift({ assailant, damage, card, when: Date.now() });
 	self.encounterModifiers.hitLog = hitLog;
@@ -22,6 +23,7 @@ export function hit (self: BaseCreature, damage = 0, assailant?: BaseCreature, c
 		self.emit('narration', {
 			narration: `${self.givenName} was braced for a hit, and was able to absorb ${damage} damage. ${capitalize(self.pronouns.his)} ac boost is now ${self.encounterModifiers.ac}.`
 		});
+		await subEventDelay();
 	} else {
 		let adjustedDamage = damage;
 
@@ -30,6 +32,7 @@ export function hit (self: BaseCreature, damage = 0, assailant?: BaseCreature, c
 			self.emit('narration', {
 				narration: `${self.givenName} was braced for a hit, and was able to absorb ${self.encounterModifiers.ac} damage. ${capitalize(self.pronouns.his)} ac boost is now 0.`
 			});
+			await subEventDelay();
 			(self.encounterModifiers as Record<string, unknown>).ac = 0;
 		}
 
@@ -38,6 +41,7 @@ export function hit (self: BaseCreature, damage = 0, assailant?: BaseCreature, c
 		self.hp = newHP;
 
 		self.emit('hit', { assailant, card, damage: adjustedDamage, newHP, prevHp: originalHP });
+		await subEventDelay();
 
 		if (originalHP > 0 && self.hp <= 0) {
 			return self.die(assailant);
@@ -47,7 +51,7 @@ export function hit (self: BaseCreature, damage = 0, assailant?: BaseCreature, c
 	return !self.dead;
 }
 
-export function heal (self: BaseCreature, amount = 0): boolean {
+export async function heal (self: BaseCreature, amount = 0): Promise<boolean> {
 	const hp = self.hp + amount;
 	const originalHP = self.hp;
 
@@ -60,6 +64,7 @@ export function heal (self: BaseCreature, amount = 0): boolean {
 	}
 
 	self.emit('heal', { amount, hp, prevHp: originalHP });
+	await subEventDelay();
 
 	if (hp <= 0) {
 		return self.die(self);
@@ -68,7 +73,7 @@ export function heal (self: BaseCreature, amount = 0): boolean {
 	return true;
 }
 
-export function die (self: BaseCreature, assailant?: BaseCreature): boolean {
+export async function die (self: BaseCreature, assailant?: BaseCreature): Promise<boolean> {
 	if (self.hp > 0) self.hp = 0;
 
 	if (isRealCreature(assailant)) {
@@ -76,6 +81,7 @@ export function die (self: BaseCreature, assailant?: BaseCreature): boolean {
 			if (assailant !== (self as unknown as BaseCreature)) assailant.killed = self;
 			self.killedBy = assailant;
 			self.emit('die', { destroyed: self.destroyed, assailant });
+			await subEventDelay();
 		}
 	}
 

--- a/packages/engine/src/exploration/discoveries/base.ts
+++ b/packages/engine/src/exploration/discoveries/base.ts
@@ -17,11 +17,11 @@ export class BaseDiscoveryCard extends BaseCard {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	override play(environment: any, monster: any): any {
-		return this.effect(environment, monster);
+	override play(environment: any, monster: any): Promise<any> {
+		return Promise.resolve(this.effect(environment, monster));
 	}
 
-	effect(_environment: any, _monster: any): boolean {
+	effect(_environment: any, _monster: any): boolean | Promise<boolean> {
 		return true;
 	}
 }

--- a/packages/engine/src/exploration/discoveries/death.ts
+++ b/packages/engine/src/exploration/discoveries/death.ts
@@ -9,8 +9,8 @@ export class DeathCard extends BaseDiscoveryCard {
 		return (this as any).flavor;
 	}
 
-	effect(_environment: any, monster: any): boolean {
-		monster.die(_environment);
+	async effect(_environment: any, monster: any): Promise<boolean> {
+		await monster.die(_environment);
 
 		return !monster.dead;
 	}

--- a/packages/engine/src/exploration/discoveries/hazard.ts
+++ b/packages/engine/src/exploration/discoveries/hazard.ts
@@ -91,8 +91,8 @@ export class HazardCard extends BaseDiscoveryCard {
 		return { hazards: damageFlavors[number] };
 	}
 
-	effect(_environment: any, monster: any): boolean {
-		monster.hit(this.damage, _environment, this);
+	async effect(_environment: any, monster: any): Promise<boolean> {
+		await monster.hit(this.damage, _environment, this);
 
 		return !monster.dead;
 	}

--- a/packages/engine/src/helpers/delay-times.test.ts
+++ b/packages/engine/src/helpers/delay-times.test.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 
-import { shortDelay, veryShortDelay } from './delay-times.js';
+import { shortDelay, subEventDelay, veryShortDelay } from './delay-times.js';
 
 const DELAY_ENV_KEYS = [
 	'DECK_MONSTERS_SKIP_DELAYS',
+	'DECK_MONSTERS_SUB_EVENT_DELAY_MIDPOINT_MS',
 	'DECK_MONSTERS_VERY_SHORT_DELAY_MIDPOINT_MS',
 	'DECK_MONSTERS_SHORT_DELAY_MIDPOINT_MS',
 	'DECK_MONSTERS_DELAY_ROUND_FACTOR_STEP',
@@ -70,5 +71,22 @@ describe('delay-times', () => {
 		Math.random = () => 0.999999;
 		expect(veryShortDelay(9)).to.equal(0);
 		expect(shortDelay(9)).to.equal(0);
+	});
+
+	it('subEventDelay resolves immediately when skipping', async () => {
+		process.env.DECK_MONSTERS_SKIP_DELAYS = '1';
+		const start = Date.now();
+		await subEventDelay();
+		expect(Date.now() - start).to.be.lessThan(50);
+	});
+
+	it('subEventDelay waits ~1000ms by default when not skipping', async () => {
+		process.env.DECK_MONSTERS_SUB_EVENT_DELAY_MIDPOINT_MS = '1000';
+		Math.random = () => 0;
+		const start = Date.now();
+		await subEventDelay();
+		const elapsed = Date.now() - start;
+		expect(elapsed).to.be.at.least(650);
+		expect(elapsed).to.be.at.most(1400);
 	});
 });

--- a/packages/engine/src/helpers/delay-times.ts
+++ b/packages/engine/src/helpers/delay-times.ts
@@ -117,11 +117,24 @@ export const mediumDelay = (round = 1): number =>
 export const longDelay = (round = 1): number =>
 	delayFor('long', round);
 
+const DEFAULT_SUB_EVENT_MS = 1000;
+
+export const subEventDelay = (): Promise<void> => {
+	if (skip()) return Promise.resolve();
+	const midpoint = parsePositiveInt(
+		process.env.DECK_MONSTERS_SUB_EVENT_DELAY_MIDPOINT_MS,
+		DEFAULT_SUB_EVENT_MS
+	);
+	const { min, max } = getRangeFromMidpoint(midpoint);
+	return new Promise(r => setTimeout(r, sampleInRange(min, max)));
+};
+
 const delayTimes = {
 	veryShortDelay,
 	shortDelay,
 	mediumDelay,
 	longDelay,
+	subEventDelay,
 	ONE_MINUTE
 };
 

--- a/packages/engine/src/helpers/targeting-strategies.test.ts
+++ b/packages/engine/src/helpers/targeting-strategies.test.ts
@@ -198,13 +198,13 @@ describe('./helpers/targeting-strategies.ts', () => {
 			expect(target).to.equal(defaultTarget);
 		});
 
-		it('targets the player who hit you last', () => {
+		it('targets the player who hit you last', async () => {
 			const { playerContestant, level1, contestants } = getContestants();
 
 			const hit = new HitCard();
 
-			playerContestant.monster.hit(1, level1.monster, hit);
-			playerContestant.monster.hit(1, playerContestant.monster, hit);
+			await playerContestant.monster.hit(1, level1.monster, hit);
+			await playerContestant.monster.hit(1, playerContestant.monster, hit);
 
 			const target = targetingStrategies.getTarget({
 				playerContestant,
@@ -217,13 +217,13 @@ describe('./helpers/targeting-strategies.ts', () => {
 	});
 
 	describe('TARGET_PLAYER_WHO_HIT_YOU_LAST_ACCORDING_TO_HANS', () => {
-		it('targets the player who hit you last', () => {
+		it('targets the player who hit you last', async () => {
 			const { playerContestant, level3, contestants } = getContestants();
 
 			const hit = new HitCard();
 
-			playerContestant.monster.hit(1, level3.monster, hit);
-			playerContestant.monster.hit(1, playerContestant.monster, hit);
+			await playerContestant.monster.hit(1, level3.monster, hit);
+			await playerContestant.monster.hit(1, playerContestant.monster, hit);
 
 			const target = targetingStrategies.getTarget({
 				playerContestant,

--- a/packages/engine/src/monsters/basilisk.test.ts
+++ b/packages/engine/src/monsters/basilisk.test.ts
@@ -62,16 +62,16 @@ describe('monsters/basilisk', () => {
 		expect(basilisk.destroyed).to.equal(true);
 	});
 
-	it('can be hit', () => {
+	it('can be hit', async () => {
 		const basilisk = new Basilisk();
 		const beforeHP = basilisk.hp;
 
-		basilisk.hit(1, basilisk);
+		await basilisk.hit(1, basilisk);
 
 		expect(basilisk.hp).to.equal(beforeHP - 1);
 	});
 
-	it('can die from being hit', () => {
+	it('can die from being hit', async () => {
 		const basilisk = new Basilisk();
 		const basiliskProto = Object.getPrototypeOf(basilisk);
 		const creatureProto = Object.getPrototypeOf(basiliskProto);
@@ -81,7 +81,7 @@ describe('monsters/basilisk', () => {
 
 		expect(basilisk.dead).to.equal(false);
 
-		basilisk.hit(1, basilisk);
+		await basilisk.hit(1, basilisk);
 
 		expect(dieSpy.calledOnce).to.equal(true);
 		expect(basilisk.dead).to.equal(true);
@@ -89,7 +89,7 @@ describe('monsters/basilisk', () => {
 		dieSpy.restore();
 	});
 
-	it('does not re-die if already dead', () => {
+	it('does not re-die if already dead', async () => {
 		const basilisk = new Basilisk();
 		const basiliskProto = Object.getPrototypeOf(basilisk);
 		const creatureProto = Object.getPrototypeOf(basiliskProto);
@@ -97,11 +97,11 @@ describe('monsters/basilisk', () => {
 
 		expect(dieSpy.called).to.equal(false);
 
-		basilisk.die();
+		await basilisk.die();
 		expect(dieSpy.calledOnce).to.equal(true);
 		expect(basilisk.dead).to.equal(true);
 
-		basilisk.hit(1, basilisk);
+		await basilisk.hit(1, basilisk);
 		expect(dieSpy.calledOnce).to.equal(true);
 		expect(basilisk.hp).to.equal(-1);
 

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -6,7 +6,7 @@ import { getTarget } from '../helpers/targeting-strategies.js';
 import { randomContestant } from '../helpers/bosses.js';
 import { getLevel } from '../helpers/levels.js';
 import { sortCardsAlphabetically } from '../cards/helpers/sort.js';
-import { shortDelay, veryShortDelay } from '../helpers/delay-times.js';
+import { shortDelay, subEventDelay, veryShortDelay } from '../helpers/delay-times.js';
 import { uniqueCards } from '../cards/helpers/unique-cards.js';
 import type { RoomEventBus } from '../events/index.js';
 
@@ -643,8 +643,9 @@ export class Ring extends BaseClass {
 					.play(player, proposedTarget, ring, getAllActiveContestants())
 					.then(() => {
 						if (getAllActiveContestants().length > 1) {
-							const waitMs = veryShortDelay(round);
-							return new Promise<void>(r => setTimeout(r, waitMs)).then(() => next());
+							return new Promise<void>(r => setTimeout(r, 0))
+								.then(() => subEventDelay())
+								.then(() => next());
 						}
 
 						return Promise.resolve().then(() => resolve(playerContestant));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `subEventDelay()` (~1000ms midpoint, jittered via existing range helpers) so narrative events from a single card are spaced in real time instead of bursting through the connector. Respects `DECK_MONSTERS_SKIP_DELAYS=1` for tests.

## Key changes

- **`creatures/health.ts`**: `hit`, `heal`, `die` are async; await `subEventDelay()` after each relevant `emit`; await `die()` from `hit`/`heal` when applicable.
- **`cards/base.ts`**: After `'played'`, await `subEventDelay()` before effects. `applyEffects` is async and sequentially awaits encounter/ring effect hooks so async immobilize logic completes before play continues.
- **`cards/hit.ts`**: Async `effect` with delays after attack roll, damage roll, and miss.
- **`ring/index.ts`**: Success path between cards uses `subEventDelay()` instead of stacking `veryShortDelay` on top of intra-card pacing; error path still uses `veryShortDelay`.
- **Call sites**: Await/async updates where cards called `hit`/`heal` without returning the promise (berserk, horn-gore, boost, curse, prion-disease, blink, immobilize effect); exploration hazard/death cards.
- **Tests**: `delay-times.test.ts` for skip vs real delay; targeting/basilisk tests use `await`; coil/forked-stick/mesmerize tests await async immobilize effects when simulating `applyEffects` manually.

## Verification

`pnpm build` and `pnpm --filter @deck-monsters/engine test` — **451 passing**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68f638c5-c52d-4cec-8639-c58574795bfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68f638c5-c52d-4cec-8639-c58574795bfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

