### PR TITLE
Fix fight summary writes and ring-feed replay after buffer miss

### DIFF
--- a/apps/web/src/__tests__/console-history-event-map.test.ts
+++ b/apps/web/src/__tests__/console-history-event-map.test.ts
@@ -31,4 +31,19 @@ describe('mapConsoleHistoryEvent', () => {
       text: '-- reconnecting --',
     });
   });
+
+  it('maps system.gap to a system row', () => {
+    const mapped = mapConsoleHistoryEvent({
+      id: 'gap-1',
+      type: 'system.gap',
+      text: '── missed ──',
+      payload: { reason: 'buffer_or_retention' },
+    });
+
+    expect(mapped).toEqual({
+      id: 'gap-1',
+      type: 'system',
+      text: '── missed ──',
+    });
+  });
 });

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -365,8 +365,7 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         // Only process events targeted to this user
         const isPrivate = event.scope === 'private' && event.targetUserId === user?.id;
         const isPublicSystem = event.scope === 'public' && event.type === 'system';
-        const isGapNotice = event.type === 'system.gap' && isPrivate;
-        if (!isPrivate && !isPublicSystem && !isGapNotice) return;
+        if (!isPrivate && !isPublicSystem) return;
 
         onEvent?.(event);
         if (MONSTER_REFRESH_EVENT_TYPES.has(event.type)) {

--- a/apps/web/src/components/ConsolePane.tsx
+++ b/apps/web/src/components/ConsolePane.tsx
@@ -365,7 +365,8 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
         // Only process events targeted to this user
         const isPrivate = event.scope === 'private' && event.targetUserId === user?.id;
         const isPublicSystem = event.scope === 'public' && event.type === 'system';
-        if (!isPrivate && !isPublicSystem) return;
+        const isGapNotice = event.type === 'system.gap' && isPrivate;
+        if (!isPrivate && !isPublicSystem && !isGapNotice) return;
 
         onEvent?.(event);
         if (MONSTER_REFRESH_EVENT_TYPES.has(event.type)) {
@@ -378,6 +379,15 @@ export default function ConsolePane({ roomId, isActive, onEvent }: ConsolePanePr
           addConsoleEvent({
             id: event.id,
             type: 'input',
+            text: event.text,
+          });
+          return;
+        }
+
+        if (event.type === 'system.gap') {
+          addConsoleEvent({
+            id: event.id,
+            type: 'system',
             text: event.text,
           });
           return;

--- a/apps/web/src/utils/console-history-event-map.ts
+++ b/apps/web/src/utils/console-history-event-map.ts
@@ -18,6 +18,9 @@ export function mapConsoleHistoryEvent(event: ConsoleHistoryEvent): ConsoleHisto
   if (event.type === 'system' && payload.consoleInput) {
     return { id: event.id, type: 'input', text: event.text };
   }
+  if (event.type === 'system.gap') {
+    return { id: event.id, type: 'system', text: event.text };
+  }
   if (event.type === 'announce' || event.type === 'system') {
     return { id: event.id, type: event.type as 'announce' | 'system', text: event.text };
   }

--- a/apps/web/src/utils/ring-feed-events.test.ts
+++ b/apps/web/src/utils/ring-feed-events.test.ts
@@ -25,4 +25,8 @@ describe('shouldRenderRingEvent', () => {
     expect(shouldRenderRingEvent(event('ring.fight'))).to.equal(true);
     expect(shouldRenderRingEvent(event('ring.xp'))).to.equal(true);
   });
+
+  it('hides private reconnect gap notice', () => {
+    expect(shouldRenderRingEvent(event('system.gap'))).to.equal(false);
+  });
 });

--- a/apps/web/src/utils/ring-feed-events.ts
+++ b/apps/web/src/utils/ring-feed-events.ts
@@ -3,6 +3,8 @@ import type { GameEvent } from '@deck-monsters/server/types';
 const HIDDEN_RING_EVENT_TYPES = new Set<string>([
   // Internal analytics event; users already see flavorful fight-conclusion text.
   'ring.fightResolved',
+  // Private console reconnect notice; never belongs in the public ring feed.
+  'system.gap',
 ]);
 
 export function shouldRenderRingEvent(event: Pick<GameEvent, 'type'>): boolean {

--- a/packages/engine/src/events/index.ts
+++ b/packages/engine/src/events/index.ts
@@ -1,2 +1,2 @@
 export { RoomEventBus } from './room-event-bus.js';
-export type { GameEvent, EventType, EventScope, EventSubscriber } from './types.js';
+export type { GameEvent, EventType, EventScope, EventSubscriber, EventsSinceResult } from './types.js';

--- a/packages/engine/src/events/room-event-bus.test.ts
+++ b/packages/engine/src/events/room-event-bus.test.ts
@@ -211,4 +211,12 @@ describe('RoomEventBus getEventsSince', () => {
 		expect(r.truncated).to.equal(false);
 		expect(r.upToDate).to.equal(true);
 	});
+
+	it('does not mark truncated when the buffer is empty (fresh bus)', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		const r = bus.getEventsSince('any-cursor');
+		expect(r.events).to.have.length(0);
+		expect(r.truncated).to.equal(false);
+		expect(r.upToDate).to.equal(false);
+	});
 });

--- a/packages/engine/src/events/room-event-bus.test.ts
+++ b/packages/engine/src/events/room-event-bus.test.ts
@@ -157,3 +157,58 @@ describe('RoomEventBus pending prompt snapshots', () => {
 		expect(bus.getPendingPromptForUser('nobody')).to.equal(null);
 	});
 });
+
+describe('RoomEventBus getEventsSince', () => {
+	it('returns slice after id when cursor is in the buffer', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		const a = bus.publish({
+			type: 'announce',
+			scope: 'public',
+			text: 'a',
+			payload: {},
+		});
+		const b = bus.publish({
+			type: 'announce',
+			scope: 'public',
+			text: 'b',
+			payload: {},
+		});
+		const c = bus.publish({
+			type: 'announce',
+			scope: 'public',
+			text: 'c',
+			payload: {},
+		});
+		const r = bus.getEventsSince(a.id);
+		expect(r.truncated).to.equal(false);
+		expect(r.upToDate).to.equal(false);
+		expect(r.events.map(e => e.id)).to.deep.equal([b.id, c.id]);
+	});
+
+	it('marks truncated when id was evicted and cursor is behind newest', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		const oldIds: string[] = [];
+		for (let i = 0; i < 210; i++) {
+			const e = bus.publish({
+				type: 'announce',
+				scope: 'public',
+				text: `m${i}`,
+				payload: {},
+			});
+			if (i === 0) oldIds.push(e.id);
+		}
+		const r = bus.getEventsSince(oldIds[0]!);
+		expect(r.events).to.have.length(0);
+		expect(r.truncated).to.equal(true);
+		expect(r.upToDate).to.equal(false);
+	});
+
+	it('marks upToDate when cursor is lexicographically newer than buffer tail', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		bus.publish({ type: 'announce', scope: 'public', text: 'x', payload: {} });
+		const r = bus.getEventsSince('9999999999999-zzzzzzzz');
+		expect(r.events).to.have.length(0);
+		expect(r.truncated).to.equal(false);
+		expect(r.upToDate).to.equal(true);
+	});
+});

--- a/packages/engine/src/events/room-event-bus.ts
+++ b/packages/engine/src/events/room-event-bus.ts
@@ -70,6 +70,10 @@ export class RoomEventBus {
 		if (idx !== -1) {
 			return { events: this.eventLog.slice(idx + 1), truncated: false, upToDate: false };
 		}
+		// Fresh room after restart (or no events yet): do not treat as buffer truncation.
+		if (this.eventLog.length === 0) {
+			return { events: [], truncated: false, upToDate: false };
+		}
 		const newestId = this.eventLog.at(-1)?.id;
 		const isAhead = newestId !== undefined && eventId > newestId;
 		return { events: [], truncated: !isAhead, upToDate: isAhead };

--- a/packages/engine/src/events/room-event-bus.ts
+++ b/packages/engine/src/events/room-event-bus.ts
@@ -1,12 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
-import type { GameEvent, EventSubscriber, EventScope, EventType } from './types.js';
+import type { GameEvent, EventSubscriber, EventScope, EventType, EventsSinceResult } from './types.js';
 
-// TODO(ordering): When a client reconnects with a lastEventId that has already
-// been evicted from this buffer, getEventsSince() returns [] with no signal
-// that history was truncated.  The client silently presents an incomplete
-// replay.  Fix: return a synthetic gap event (or throw a typed error) when
-// lastEventId is not found, so clients can show "you missed some events".
 const RING_BUFFER_SIZE = 200;
 
 type PublishInput = {
@@ -70,9 +65,14 @@ export class RoomEventBus {
 		this.subscribers.delete(id);
 	}
 
-	getEventsSince(eventId: string): GameEvent[] {
+	getEventsSince(eventId: string): EventsSinceResult {
 		const idx = this.eventLog.findIndex(e => e.id === eventId);
-		return idx === -1 ? [] : this.eventLog.slice(idx + 1);
+		if (idx !== -1) {
+			return { events: this.eventLog.slice(idx + 1), truncated: false, upToDate: false };
+		}
+		const newestId = this.eventLog.at(-1)?.id;
+		const isAhead = newestId !== undefined && eventId > newestId;
+		return { events: [], truncated: !isAhead, upToDate: isAhead };
 	}
 
 	getRecentEvents(count: number): GameEvent[] {

--- a/packages/engine/src/events/types.ts
+++ b/packages/engine/src/events/types.ts
@@ -1,4 +1,5 @@
 export type EventType =
+	| 'system.gap'
 	| 'ring.add'
 	| 'ring.remove'
 	| 'ring.clear'
@@ -45,4 +46,16 @@ export interface GameEvent {
 export interface EventSubscriber {
 	userId?: string;
 	deliver: (event: GameEvent) => void;
+}
+
+/** Result of resolving missed events relative to an in-memory ring buffer cursor. */
+export interface EventsSinceResult {
+	events: GameEvent[];
+	/** `lastEventId` was evicted from the buffer — callers should fall back to durable storage. */
+	truncated: boolean;
+	/**
+	 * Cursor is newer than anything still in the buffer (client already caught up).
+	 * When true with an empty `events` array, this is not a truncation miss.
+	 */
+	upToDate: boolean;
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,11 +6,11 @@ import Game from './game.js';
 import type { ChannelCallback } from './channel/index.js';
 import { ConnectorAdapter } from './channel/index.js';
 import { RoomEventBus } from './events/index.js';
-import type { GameEvent, EventType, EventScope, EventSubscriber } from './events/index.js';
+import type { GameEvent, EventType, EventScope, EventSubscriber, EventsSinceResult } from './events/index.js';
 
 export { Game, ConnectorAdapter, RoomEventBus };
 export type { GameAnalyticsCallbacks, LeaderboardSortKey } from './game.js';
-export type { ChannelCallback, GameEvent, EventType, EventScope, EventSubscriber };
+export type { ChannelCallback, GameEvent, EventType, EventScope, EventSubscriber, EventsSinceResult };
 export type { StateStore } from './types/state-store.js';
 export { engineReady, getHydratorStatus } from './helpers/engine-ready.js';
 export { COMMAND_CATALOG } from './commands/catalog.js';

--- a/packages/server/src/event-persister.ts
+++ b/packages/server/src/event-persister.ts
@@ -26,7 +26,7 @@ export function attachEventPersister(
 
 	// Event types that are transient state-sync signals and should not be
 	// persisted to the history table — they have no replay value.
-	const EPHEMERAL_TYPES = new Set(['ring.state', 'handshake']);
+	const EPHEMERAL_TYPES = new Set(['ring.state', 'handshake', 'system.gap']);
 
 	return eventBus.subscribe(subscriberId, {
 		deliver(event: GameEvent) {

--- a/packages/server/src/fight-summary-writer.ts
+++ b/packages/server/src/fight-summary-writer.ts
@@ -1,6 +1,6 @@
 /**
  * Assembles fight_summaries rows from ring.fight (start) + ring.fightResolved + ring.cardDrop.
- * Best-effort: errors are logged, not propagated.
+ * Best-effort: errors are logged and counted in metrics; pending fight metadata is kept until a successful write.
  */
 import { eq, sql } from 'drizzle-orm';
 
@@ -8,6 +8,7 @@ import type { RoomEventBus, GameEvent } from '@deck-monsters/engine';
 import type { Db } from './db/index.js';
 import { fightSummaries, rooms } from './db/schema.js';
 import { createLogger } from './logger.js';
+import { fightSummaryWriteFailures } from './metrics/index.js';
 
 const log = createLogger('fight-summary');
 
@@ -18,10 +19,32 @@ type Pending = {
 
 const pendingByRoom = new Map<string, Pending>();
 
+/** Serialize fight-summary writes per room so concurrent fightResolved handlers do not corrupt pending state. */
+const fightSummaryWriteQueues = new Map<string, Promise<void>>();
+
+function enqueueFightSummaryWrite(roomId: string, fn: () => Promise<void>): void {
+	const prev = fightSummaryWriteQueues.get(roomId) ?? Promise.resolve();
+	const next = prev
+		.catch(() => {
+			/* continue the chain after a prior failure */
+		})
+		.then(fn);
+	fightSummaryWriteQueues.set(roomId, next);
+}
+
+/** Accept any UUID-shaped hex so non-v4 profile IDs still pass; rejects Discord snowflakes etc. */
+const UUID_HEX_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function profileUuidOrNull(value: string | undefined): string | null {
+	if (!value || !UUID_HEX_RE.test(value)) return null;
+	return value;
+}
+
 export function attachFightSummaryWriter(
 	eventBus: RoomEventBus,
 	db: Db,
-	log: (err: unknown) => void = () => {}
+	legacyLog: (err: unknown) => void = () => {}
 ): () => void {
 	const roomId = eventBus.roomId;
 	const subscriberId = `fight-summary:${roomId}`;
@@ -32,7 +55,8 @@ export function attachFightSummaryWriter(
 				try {
 					onRingFight(roomId, event);
 				} catch (err) {
-					log(err);
+					legacyLog(err);
+					log.error('fight-summary-writer: onRingFight threw', { err, roomId });
 				}
 				return;
 			}
@@ -41,7 +65,25 @@ export function attachFightSummaryWriter(
 				return;
 			}
 			if (event.type === 'ring.fightResolved') {
-				void onFightResolved(db, roomId, event).catch(log);
+				enqueueFightSummaryWrite(roomId, async () => {
+					try {
+						await onFightResolved(db, roomId, event);
+					} catch (err) {
+						fightSummaryWriteFailures.inc({ room_id: roomId });
+						const stack = err instanceof Error ? err.stack : undefined;
+						const pg =
+							err && typeof err === 'object' && 'code' in err
+								? String((err as { code?: unknown }).code)
+								: undefined;
+						log.error('fight-summary-writer: failed to write fight summary', {
+							err,
+							roomId,
+							stack,
+							pgCode: pg,
+						});
+						legacyLog(err);
+					}
+				});
 			}
 		},
 	});
@@ -66,7 +108,6 @@ function onCardDrop(roomId: string, event: GameEvent): void {
 
 async function onFightResolved(db: Db, roomId: string, event: GameEvent): Promise<void> {
 	const pending = pendingByRoom.get(roomId);
-	pendingByRoom.delete(roomId);
 
 	const payload = event.payload as {
 		rounds: number;
@@ -126,10 +167,10 @@ async function onFightResolved(db: Db, roomId: string, event: GameEvent): Promis
 			outcome: payload.outcome,
 			winnerMonsterId: payload.winnerMonsterId ?? null,
 			winnerMonsterName: payload.winnerMonsterName ?? null,
-			winnerOwnerUserId: payload.winnerOwnerUserId ?? null,
+			winnerOwnerUserId: profileUuidOrNull(payload.winnerOwnerUserId),
 			loserMonsterId: payload.loserMonsterId ?? null,
 			loserMonsterName: payload.loserMonsterName ?? null,
-			loserOwnerUserId: payload.loserOwnerUserId ?? null,
+			loserOwnerUserId: profileUuidOrNull(payload.loserOwnerUserId),
 			roundCount: payload.rounds,
 			winnerXpGained: winnerXp,
 			loserXpGained: loserXp,
@@ -148,4 +189,6 @@ async function onFightResolved(db: Db, roomId: string, event: GameEvent): Promis
 			loser: payload.loserMonsterName,
 		});
 	});
+
+	pendingByRoom.delete(roomId);
 }

--- a/packages/server/src/fight-summary-writer.ts
+++ b/packages/server/src/fight-summary-writer.ts
@@ -81,7 +81,6 @@ export function attachFightSummaryWriter(
 							stack,
 							pgCode: pg,
 						});
-						legacyLog(err);
 					}
 				});
 			}

--- a/packages/server/src/metrics/index.ts
+++ b/packages/server/src/metrics/index.ts
@@ -189,6 +189,27 @@ export const fightErrors = new Counter({
 	registers: [registry],
 });
 
+export const fightSummaryWriteFailures = new Counter({
+	name: 'dm_fight_summary_write_failures_total',
+	help: 'Failed inserts into fight_summaries (after retries, pending state preserved)',
+	labelNames: ['room_id'] as const,
+	registers: [registry],
+});
+
+export const ringFeedReplayFromDbTotal = new Counter({
+	name: 'dm_ring_feed_replay_from_db_total',
+	help: 'ringFeed reconnects that loaded history from room_events after ring-buffer miss',
+	labelNames: ['room_id'] as const,
+	registers: [registry],
+});
+
+export const ringFeedReplayGapTotal = new Counter({
+	name: 'dm_ring_feed_replay_gap_total',
+	help: 'ringFeed reconnects where DB had no rows after lastEventId (retention gap)',
+	labelNames: ['room_id'] as const,
+	registers: [registry],
+});
+
 export const roomHydrationFailures = new Counter({
 	name: 'dm_room_hydration_failures_total',
 	help: 'State blob hydration failures (blob quarantined, fresh game started)',

--- a/packages/server/src/room-manager.test.ts
+++ b/packages/server/src/room-manager.test.ts
@@ -19,11 +19,15 @@ import { RoomManager } from './room-manager.js';
  */
 function makeSelectChain(result: unknown[]) {
 	const limitStub = sinon.stub().resolves(result);
-	const whereResult = Object.assign(Promise.resolve(result), { limit: limitStub });
+	const orderByStub = sinon.stub().returns({ limit: limitStub });
+	const whereResult = Object.assign(Promise.resolve(result), {
+		limit: limitStub,
+		orderBy: orderByStub,
+	});
 	const whereStub = sinon.stub().returns(whereResult);
 	const innerJoinStub = sinon.stub().returns({ where: whereStub });
 	const fromStub = sinon.stub().returns({ where: whereStub, innerJoin: innerJoinStub });
-	return { from: fromStub };
+	return { from: fromStub, _orderByStub: orderByStub };
 }
 
 interface DbStubOpts {
@@ -481,6 +485,95 @@ describe('RoomManager', () => {
 			expect((rm as any).active.has(roomA)).to.be.false;
 			expect((rm as any).active.has(roomB)).to.be.true;
 			expect(saveStateFn.calledOnce).to.be.true;
+		});
+	});
+
+	describe('getEventsSinceForRingFeed', () => {
+		const memberRow = [{ roomId: ROOM_ID, userId: USER_ID, role: 'member' }];
+
+		const sampleEventRow = (overrides: Partial<{
+			id: number;
+			eventId: string | null;
+			scope: string;
+			targetUserId: string | null;
+			type: string;
+			text: string;
+			payload: Record<string, unknown>;
+		}> = {}) => ({
+			id: overrides.id ?? 10,
+			roomId: ROOM_ID,
+			type: overrides.type ?? 'announce',
+			scope: overrides.scope ?? 'public',
+			targetUserId: overrides.targetUserId ?? null,
+			payload: overrides.payload ?? {},
+			text: overrides.text ?? 'hi',
+			eventId: overrides.eventId ?? '2000-aaaaaaaa',
+			createdAt: new Date(),
+		});
+
+		it('uses id > anchor when anchor row exists', async () => {
+			const anchor = [{ id: 5 }];
+			const replay = [
+				sampleEventRow({ id: 6, eventId: '2001-bbbbbbbb', text: 'after' }),
+			];
+			const db = makeDbStub({ selectResults: [memberRow, anchor, replay] });
+			const { deps } = makeEngineDeps();
+			const rm = new RoomManager(db as never, () => {}, deps);
+
+			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '1999-anchor', 500);
+
+			expect(events).to.have.length(1);
+			expect(events[0]!.text).to.equal('after');
+			expect(events[0]!.id).to.equal('2001-bbbbbbbb');
+		});
+
+		it('queries by event_id > lastEventId when anchor is missing (24h window)', async () => {
+			const replay = [
+				sampleEventRow({ id: 2, eventId: '2001-bbbbbbbb' }),
+			];
+			const db = makeDbStub({ selectResults: [memberRow, [], replay] });
+			const { deps } = makeEngineDeps();
+			const rm = new RoomManager(db as never, () => {}, deps);
+
+			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '2000-aaaaaaaa', 500);
+
+			expect(events).to.have.length(1);
+			expect(events[0]!.id).to.equal('2001-bbbbbbbb');
+		});
+
+		it('falls back to 7d window with event_id filter when 24h returns nothing', async () => {
+			const replay = [
+				sampleEventRow({ id: 3, eventId: '1999-olddddd' }),
+			];
+			const db = makeDbStub({ selectResults: [memberRow, [], [], replay] });
+			const { deps } = makeEngineDeps();
+			const rm = new RoomManager(db as never, () => {}, deps);
+
+			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '1998-cursorrr', 500);
+
+			expect(events).to.have.length(1);
+			expect(events[0]!.id).to.equal('1999-olddddd');
+		});
+
+		it('includes private events only for the requesting user', async () => {
+			const replay = [
+				sampleEventRow({
+					id: 7,
+					eventId: '2002-cccccccc',
+					scope: 'private',
+					targetUserId: USER_ID,
+					text: 'dm',
+				}),
+			];
+			const db = makeDbStub({ selectResults: [memberRow, [], replay] });
+			const { deps } = makeEngineDeps();
+			const rm = new RoomManager(db as never, () => {}, deps);
+
+			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '2000-aaaaaaaa', 500);
+
+			expect(events).to.have.length(1);
+			expect(events[0]!.scope).to.equal('private');
+			expect(events[0]!.targetUserId).to.equal(USER_ID);
 		});
 	});
 });

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -541,6 +541,8 @@ export class RoomManager {
 		const cutoff24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
 		const cutoff7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
+		// Anchor lookup uses event_id; migrations define room_events_room_id_event_id_key
+		// (unique on room_id, event_id) and room_events_event_id_idx for efficient resolution.
 		const anchor = await this.db
 			.select({ id: roomEvents.id })
 			.from(roomEvents)
@@ -580,15 +582,18 @@ export class RoomManager {
 		rows = await this.db
 			.select()
 			.from(roomEvents)
-			.where(and(eq(roomEvents.roomId, roomId), visibility, gte(roomEvents.createdAt, cutoff7d)))
-			.orderBy(desc(roomEvents.id))
+			.where(
+				and(
+					eq(roomEvents.roomId, roomId),
+					visibility,
+					gte(roomEvents.createdAt, cutoff7d),
+					gt(roomEvents.eventId, lastEventId)
+				)
+			)
+			.orderBy(asc(roomEvents.id))
 			.limit(limit);
 
-		return rows
-			.reverse()
-			.map(dbRowToGameEvent)
-			.filter(e => e.id > lastEventId)
-			.slice(0, limit);
+		return rows.map(dbRowToGameEvent);
 	}
 
 	async getConsoleHistory(userId: string, roomId: string): Promise<GameEvent[]> {

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { TRPCError } from '@trpc/server';
-import { eq, and, count, gte, desc } from 'drizzle-orm';
+import { eq, and, count, gte, desc, gt, or, asc } from 'drizzle-orm';
 import { createLogger } from './logger.js';
 
 const log = createLogger('room-manager');
@@ -518,6 +518,77 @@ export class RoomManager {
 		}
 
 		return rows.reverse().map(dbRowToGameEvent);
+	}
+
+	/**
+	 * Events after `lastEventId` for ringFeed replay when the in-memory ring buffer
+	 * no longer contains the cursor. Uses `room_events`; event ids are `${Date.now()}-…`
+	 * so lexicographic `event_id` ordering matches time order when the anchor row is missing.
+	 */
+	async getEventsSinceForRingFeed(
+		userId: string,
+		roomId: string,
+		lastEventId: string,
+		limit = 500
+	): Promise<GameEvent[]> {
+		await this.assertMember(userId, roomId);
+
+		const visibility = or(
+			eq(roomEvents.scope, 'public'),
+			and(eq(roomEvents.scope, 'private'), eq(roomEvents.targetUserId, userId))
+		);
+
+		const cutoff24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+		const cutoff7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+		const anchor = await this.db
+			.select({ id: roomEvents.id })
+			.from(roomEvents)
+			.where(and(eq(roomEvents.roomId, roomId), eq(roomEvents.eventId, lastEventId)))
+			.limit(1);
+
+		const afterId = anchor[0]?.id;
+
+		if (afterId !== undefined) {
+			const rows = await this.db
+				.select()
+				.from(roomEvents)
+				.where(and(eq(roomEvents.roomId, roomId), visibility, gt(roomEvents.id, afterId)))
+				.orderBy(asc(roomEvents.id))
+				.limit(limit);
+			return rows.map(dbRowToGameEvent);
+		}
+
+		let rows = await this.db
+			.select()
+			.from(roomEvents)
+			.where(
+				and(
+					eq(roomEvents.roomId, roomId),
+					visibility,
+					gte(roomEvents.createdAt, cutoff24h),
+					gt(roomEvents.eventId, lastEventId)
+				)
+			)
+			.orderBy(asc(roomEvents.id))
+			.limit(limit);
+
+		if (rows.length > 0) {
+			return rows.map(dbRowToGameEvent);
+		}
+
+		rows = await this.db
+			.select()
+			.from(roomEvents)
+			.where(and(eq(roomEvents.roomId, roomId), visibility, gte(roomEvents.createdAt, cutoff7d)))
+			.orderBy(desc(roomEvents.id))
+			.limit(limit);
+
+		return rows
+			.reverse()
+			.map(dbRowToGameEvent)
+			.filter(e => e.id > lastEventId)
+			.slice(0, limit);
 	}
 
 	async getConsoleHistory(userId: string, roomId: string): Promise<GameEvent[]> {

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -11,7 +11,12 @@ import { t } from './trpc.js';
 import { protectedProcedure, serviceProcedure } from './middleware.js';
 import type { RoomManager } from '../room-manager.js';
 import { ensureConnectorUser } from '../auth/connector-users.js';
-import { commandsTotal, wsConnectionsActive } from '../metrics/index.js';
+import {
+	commandsTotal,
+	wsConnectionsActive,
+	ringFeedReplayFromDbTotal,
+	ringFeedReplayGapTotal,
+} from '../metrics/index.js';
 import { db } from '../db/index.js';
 import {
 	loadFightEventsForSummary,
@@ -1231,7 +1236,34 @@ export function createRouter(roomManager: RoomManager) {
 
 				// Deliver any missed events since the last received event ID.
 				if (input.lastEventId) {
-					const missed = eventBus.getEventsSince(input.lastEventId);
+					const { events: buffered, truncated, upToDate } = eventBus.getEventsSince(
+						input.lastEventId
+					);
+					let missed: GameEvent[] = buffered;
+					if (truncated && !upToDate) {
+						missed = await roomManager.getEventsSinceForRingFeed(
+							ctx.userId,
+							input.roomId,
+							input.lastEventId
+						);
+						if (missed.length > 0) {
+							ringFeedReplayFromDbTotal.inc({ room_id: input.roomId });
+						} else {
+							ringFeedReplayGapTotal.inc({ room_id: input.roomId });
+							const gapId = `system-gap-${Date.now()}-${randomUUID().slice(0, 8)}`;
+							const gapEvent: GameEvent = {
+								id: gapId,
+								roomId: input.roomId,
+								timestamp: Date.now(),
+								type: 'system.gap' as EventType,
+								scope: 'private' as EventScope,
+								targetUserId: ctx.userId,
+								text: '── Some events were missed while you were away. ──',
+								payload: { reason: 'buffer_or_retention' },
+							};
+							yield tracked(gapId, gapEvent);
+						}
+					}
 					for (const event of missed) {
 						if (
 							event.scope === 'public' ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change addresses three related production issues around fight log persistence and reconnect replay.

### #342 — Fight summaries not written

- **Per-room write queue** so concurrent `ring.fightResolved` handlers cannot corrupt shared `pendingByRoom` state.
- **Delete pending metadata only after** the `fight_summaries` transaction succeeds, so a failed insert can be retried on the next resolution path without losing `startedAt` / card-drop data.
- **Owner user IDs**: only UUID-shaped values are written to `winner_owner_user_id` / `loser_owner_user_id` (avoids Postgres errors when a non-UUID connector id slips through).
- **Errors**: structured `log.error` with optional stack and Postgres `code`, plus **`dm_fight_summary_write_failures_total`** counter (no duplicate `legacyLog` on write failure).

### #343 / #344 — Console / ring reconnect and buffer miss

- **`RoomEventBus.getEventsSince`** now returns `{ events, truncated, upToDate }` (exported as `EventsSinceResult`). Empty in-memory buffer after restart returns **non-truncated** so reconnects do not spuriously hit DB/gap.
- **`game.ringFeed`**: on truncation (and not up-to-date), loads catch-up from **`room_events`** via **`getEventsSinceForRingFeed`** (room + visibility: public or private for that user). The 7d fallback applies **`event_id > lastEventId` in SQL** with `orderBy(asc)` + `limit`. Metrics: **`dm_ring_feed_replay_from_db_total`**, **`dm_ring_feed_replay_gap_total`**.
- If the DB has nothing after the cursor (e.g. retention), yields a private **`system.gap`** event with visible text instead of a silent empty replay.
- **Web**: `ConsolePane` shows `system.gap`; `mapConsoleHistoryEvent` maps it for HTTP history; `shouldRenderRingEvent` hides it from the public ring feed.
- **Event persister**: `system.gap` is ephemeral (not stored in `room_events`).

### Review follow-up (post-merge request feedback)

- Empty `eventLog` edge case fixed.
- 7d branch SQL filter aligned with 24h branch.
- **`getEventsSinceForRingFeed`** unit tests** in `room-manager.test.ts`.
- **`room_events` indexing**: migrations already define `room_events_event_id_idx` and unique `(room_id, event_id)` — noted inline at anchor query.

## Verification

- `pnpm build`
- `pnpm --filter @deck-monsters/engine test`
- `pnpm --filter @deck-monsters/server test`
- `pnpm --filter @deck-monsters/web test`

Closes #342. Closes #343. Closes #344.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63306d9f-cb04-48ad-92ae-abcc97e61533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63306d9f-cb04-48ad-92ae-abcc97e61533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

