### PR TITLE
fix(engine,server): resolve bug-doc #15–#18, #20–#25 — timing, sync, reconnect replay, and cross-room correctness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,6 @@ Missing a room filter is a recurring source of bugs. See [`docs/room-scoping.md`
 
 ### Active known bugs
 
-Two open bugs in the real-time data layer — do not close or work around without fixing the root cause:
+- **Card shop is a process-wide singleton** — every room shares one shop inventory and closing time (`packages/engine/src/items/store/shop.ts`), violating the room-scoping rule above. Needs a design decision (per-room shop vs. intentionally shared) before implementation. See bug #26 in `docs/roadmap/10-bug-fixes.md`.
 
-- **Fight log stale after new fights** — the fight log page (`/room/:roomId/fights`) doesn't update when new fights complete. Subscription or query-cache invalidation is broken. See bug #15 in `docs/roadmap/10-bug-fixes.md`.
-- **Console missing history on reconnect** — the console pane doesn't replay events from while the user was away. The reconnect-with-replay path exists but isn't delivering historical data. See bug #16 in `docs/roadmap/10-bug-fixes.md`.
+Previously listed here and now fixed: fight log stale after new fights (#15 — the root cause was write-side races and dropped retries in `fight-summary-writer.ts`, not query-cache invalidation) and console history missing on reconnect (#16/#17 — the engine's cold ring buffer reported "nothing missed" instead of triggering the durable-storage replay). See `docs/roadmap/10-bug-fixes.md` for full write-ups.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,10 @@ Every DB query on game data needs a `where room_id = ?` clause. Every tRPC proce
 
 See [`docs/room-scoping.md`](docs/room-scoping.md) for the full rule with code examples, a code-review checklist, and a table of common failure patterns. Past bugs have been caused by missing room filters — treat this as a hard constraint, not a guideline.
 
+## Critical Architecture Rule: Concurrency, Timing, and Prompt Flows
+
+Fight pacing, the serialized engine lanes, `activeFlows`, and the interactive prompt lifecycle interact in non-obvious ways and have caused the most persistent production bugs (fights flying by, commands appearing ignored, multi-step flows crashing). Before touching `helpers/delay-times.ts`, `ring/index.ts` pacing, `events/room-event-bus.ts` prompts, or the server command pipeline in `trpc/router.ts`, read [`docs/engine-concurrency-and-timing.md`](docs/engine-concurrency-and-timing.md). Key invariants: interactive command actions run fire-and-forget in a per-`roomId:userId` lane (never room-wide — that starves other users); awaited workshop mutations must stay prompt-free; the `PROMPT_CANCELLED` sentinel must be translated to `PromptCancelledError` before reaching game code.
+
 ## Architecture Notes for New Connectors
 
 1. Implement the channel callback: `({ announce, question?, choices?, delay? }) => Promise`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,10 +241,11 @@ Fight pacing, the serialized engine lanes, `activeFlows`, and the interactive pr
 
 ## Known Issues
 
-- **Fight log not updating** — the web fight log page goes stale after initial load; new fights don't appear without a manual refresh. Subscription or cache invalidation is not wired correctly. (#15 in `docs/roadmap/10-bug-fixes.md`)
-- **Console missing history on reconnect** — the console pane doesn't replay events from while the user was away. The reconnect-with-replay path exists but isn't delivering historical data. (#16 in `docs/roadmap/10-bug-fixes.md`)
+- **Card shop is a process-wide singleton** — every room shares one shop inventory/closing time, violating the room-scoping rule. Needs a design decision before implementation. (#26 in `docs/roadmap/10-bug-fixes.md`)
 - **`creatures/base.ts` still large** — ~977 lines after the TypeScript migration (down from ~2000). Continue incremental decomposition into `creatures/combat.ts`, `creatures/stats.ts`, etc.
 - **`DMG.md` / `CARDS.md` differentiation** — build scripts differentiate the headers but a full content pass distinguishing DM-facing vs. player-facing content hasn't happened yet.
+
+Previously listed here and now fixed (see `docs/roadmap/10-bug-fixes.md` for root causes): fight log not updating (#15 — write-side races and dropped retries in the fight-summary writer, not UI cache invalidation) and console history missing on reconnect (#16/#17 — the engine's cold ring buffer suppressed the durable-storage replay fallback).
 
 ## Archived / Deferred
 

--- a/docs/engine-concurrency-and-timing.md
+++ b/docs/engine-concurrency-and-timing.md
@@ -147,20 +147,63 @@ builder must never throw, since it runs inside the command pipeline. Suggestions
 are emitted on both success and failure paths and are deliberately not
 persisted.
 
-## 7. Other timing machinery worth knowing
+## 7. The global semaphore and room-scoped guarding (read before adding ANY `game.on(...)` listener)
+
+All `Game`/creature/card/item/ring events ride one **process-wide**
+`EventEmitter` (`helpers/semaphore.ts`'s `globalSemaphore`). `Game` is
+constructed with `super(options, globalSemaphore)`, so **any** `this.on(...)`
+registered inside `Game` (directly, or via `BaseClass.on`) receives **every**
+matching event from **every** loaded room and creature in the process, not
+just this one. `Ring`/`Monster`/`Character` instances default to their own
+private `EventEmitter` instead, so this only bites listeners registered
+directly on `Game`.
+
+**Every listener `Game.initializeEvents()` registers on a `creature.*` or
+`stateChange` event MUST be wrapped with `createRoomScopedEventGuard`**
+(exported from `announcements/index.ts`) before doing anything with its
+arguments. This was a real, shipped bug: the reward-granting listeners
+(`creature.win`/`loss`/`permaDeath`/`fled` → `handleWinner`/etc.) were
+unwrapped for a long time, so a single fight's outcome granted its reward
+once *per currently-loaded room on the server* — XP, coins, and drawn cards
+all multiplied by room count. `stateChange` had the same gap (see below).
+`announcements/index.ts`'s own listeners were already correctly guarded; if
+you add a new `Game`-level listener, follow that pattern, not the
+now-fixed-but-easy-to-regress shortcut.
+
+**The guard itself must stay side-effect-free.** `createRoomScopedEventGuard`
+decides ownership by checking whether the emitted arguments are (or contain)
+one of this game's own characters/monsters/cards/items. It reads a raw
+`optionsStore` value for each of those (`rawArray()` in
+`announcements/index.ts`), deliberately **not** the public getters
+(`character.deck`, `monster.cards`, etc.). Several of those getters lazily
+initialize themselves on first read by calling `setOptions()` internally
+(e.g. `BaseCharacter.cards` builds a starter deck the first time it's
+touched) — and `setOptions()` broadcasts `stateChange` synchronously. Reading
+one of those getters from inside the guard, while already inside another
+`stateChange` broadcast triggered by that same lazy init, re-enters the
+still-uninitialized getter and recurses without bound until the stack
+overflows. This is exactly the failure mode a fresh character's first card
+draw hits if the guard is ever changed back to reading live getters — keep
+new ownership checks reading `optionsStore` directly.
 
 - **Fight timer**: `startFightTimer()` clears and restarts the 60s countdown
   on every ring add/remove — the fight fires 60s after the *last* membership
   change (legacy behavior, intentional). `nextFightAt` / `nextBossSpawnAt` are
   published via `ring.state` events for client countdowns.
 - **State saves**: `Game.scheduleSave()` debounces 30s off `stateChange`
-  events; `RoomManager.unloadRoom` flushes via `game.saveState()`. Direct
-  mutation of `options`-backed arrays (e.g. `contestants.splice`) does not
-  emit `stateChange` — use `setOptions` if persistence matters.
-- **Global semaphore**: all `Game`/creature events ride one process-wide
-  emitter (`helpers/semaphore.ts`). `announcements/index.ts` gates listeners
-  by ownership (`createRoomScopedEventGuard`) so multi-room servers don't
-  cross-announce. Ring listeners are instance-scoped and skip the guard.
-- **Timers must be disposed**: `Game.dispose()` → `Ring.dispose()` +
-  per-creature `disposeTimers()`. Any new `setTimeout`/`setInterval` on a
-  long-lived object needs a dispose path or unloaded rooms keep firing.
+  events, now correctly room-scoped (see above) so one room's activity can't
+  keep resetting another's debounce indefinitely. Any direct mutation of an
+  `options`-backed array (e.g. `contestants.splice`, `items.splice`) instead
+  of going through its setter skips `setOptions()` and so never emits
+  `stateChange` — always build a new array and assign through the setter
+  (`ring.contestants = updated`, `creature.items = remaining`, …) if the
+  mutation needs to survive a restart. `RoomManager.unloadRoom` also flushes
+  via `game.saveState()` before eviction, and now refuses to unload a room
+  whose `ring.inEncounter` is true — a fight in progress keeps the room in
+  the active cache until the next sweep.
+- **Timers must be disposed AND tracked**: `Game.dispose()` → `Ring.dispose()`
+  + per-creature `disposeTimers()`. Any new `setTimeout`/`setInterval` on a
+  long-lived object needs both a stored handle *and* a dispose path — a timer
+  that exists only as an anonymous closure (no handle kept anywhere) cannot
+  be cancelled later no matter how thorough `dispose()` is. `Ring`'s
+  `bossDespawnTimers` Set is the pattern to copy for anything similar.

--- a/docs/engine-concurrency-and-timing.md
+++ b/docs/engine-concurrency-and-timing.md
@@ -1,0 +1,120 @@
+# Engine Concurrency, Timing, and Prompt Flows
+
+Read this before touching fight pacing, the command pipeline, or anything that
+awaits user input. These systems interact in non-obvious ways and have caused
+the most persistent production bugs (fights flying by, commands appearing
+ignored, multi-step flows crashing). See `docs/roadmap/10-bug-fixes.md` #20 for
+the incident history.
+
+## 1. Fight pacing (`packages/engine/src/helpers/delay-times.ts`)
+
+All fight pacing flows through one module. There are two kinds of delay:
+
+- **`veryShortDelay` / `shortDelay` / `mediumDelay` / `longDelay`** — pacing
+  *between* game beats (card-to-card, round-to-round). Midpoints are 3s / 4.5s /
+  6s / 9s, sampled uniformly in [⅔·mid, 4/3·mid], overridable per-kind via
+  `DECK_MONSTERS_*_DELAY_MIDPOINT_MS` / `_CAP_MS` env vars.
+- **`subEventDelay`** — ~1s pacing between sub-events *within* a single card
+  play (roll → hit → damage → death). Used inside `cards/hit.ts`,
+  `cards/base.ts`, `creatures/health.ts`.
+
+`DECK_MONSTERS_SKIP_DELAYS=1` zeroes everything (tests/harness). It is checked
+at **call time**, not module load time, so test setup files can set it late.
+
+**Invariant**: the main fight loop in `ring/index.ts` (`doAction`) must pace
+card-to-card transitions with `veryShortDelay(round)` and round transitions
+with `shortDelay(round)`. A past regression used `subEventDelay` between card
+plays, which made whole fights scroll past in seconds. If you add a new
+continuation path to `doAction` (there are several: played, invalid card, play
+error, end-of-deck), give it the same pacing treatment as its siblings — in
+skip mode use `queueMicrotask`/resolved promise, otherwise a real timer.
+
+Note: the fight is a promise/timer chain, **not** awaited by anything in the
+server. `Ring.fightTimer` fires `fight()` from a `setTimeout` completely
+outside the server's serialization lanes (below). Fights interleave with
+command handling by design; card plays mutate only fight-local state plus the
+monsters in the ring.
+
+## 2. Server command pipeline (`packages/server/src/trpc/router.ts`)
+
+Three coordination mechanisms exist. Know which one you are touching:
+
+1. **`activeFlows` (Set, key `roomId:userId`)** — one interactive console flow
+   per user per room. Added before dispatch, removed in `.finally()`. A second
+   `command` call while set returns `ok:false` + the pending prompt so the UI
+   can re-surface it. `cancelFlow` force-clears it.
+
+2. **Per-user engine lane** — the `command` mutation runs its action through
+   `roomManager.runSerializedEngineWork(`${roomId}:${userId}`, …)` and is
+   **fire-and-forget** (the HTTP request returns immediately; output arrives
+   over the ringFeed WebSocket). The lane key MUST include the userId: an
+   interactive flow legitimately holds its lane for minutes while waiting on
+   `sendPrompt` answers. Keying by room alone starves every other member's
+   commands (this was a real production bug — "the game ignores my commands").
+
+3. **Per-room workshop lane** — non-interactive card-management mutations
+   (`equipCards`, `unequipCard`, `moveCard`, `reorderCards`, presets, …) run
+   through `runSerializedMutation(roomId, userId, …)`, which serializes
+   per-room AND first rejects with `PRECONDITION_FAILED` if the caller has an
+   `activeFlows` entry. Rationale: these are awaited HTTP calls that must never
+   (a) hang behind a minutes-long interactive flow, nor (b) interleave with the
+   caller's own in-flight flow mutating the same deck. Silent channels
+   (`createSilentChannel`) throw on any `question` — workshop paths must stay
+   non-interactive.
+
+**Rules of thumb**: anything that may call `channel({ question })` belongs in
+the per-user lane and must be fire-and-forget. Anything awaited by HTTP must
+be prompt-free and short. Never hold any lane across a user-input wait that
+other requests in the same lane depend on.
+
+## 3. Prompt lifecycle (`packages/engine/src/events/room-event-bus.ts`)
+
+`sendPrompt(userId, question, choices)` publishes a `prompt.request` event and
+returns a promise that settles one of three ways:
+
+- **answered** — `respondToPrompt(requestId, answer, callerId)` resolves it
+  with the user's text. (tRPC `respondToPrompt` — deliberately NOT serialized
+  in any engine lane, or answers could never reach a flow that holds a lane.)
+- **timeout** — 120s default; the promise **rejects** with
+  `Error('Prompt timed out …')`. Expected when users walk away; the router
+  suppresses it from error logs.
+- **cancelled** — `cancelPrompt`/`cancelAllUserPrompts` **resolve** (not
+  reject) with the exported sentinel `PROMPT_CANCELLED` (`'__cancelled__'`).
+  Resolving lets the in-flight action chain settle and release `activeFlows`.
+
+**The sentinel must never reach game code as an answer.** The router's channel
+wrapper converts it to a thrown `PromptCancelledError` (exported from the
+engine) immediately after `sendPrompt` resolves, and the fire-and-forget catch
+suppresses that error like a timeout. `items/helpers/choose.ts` has a
+defensive check too. If you build a new connector channel that awaits
+`sendPrompt` (directly or via `ConnectorAdapter`), replicate the translation.
+
+## 4. Multi-step selection parsing (`packages/engine/src/items/helpers/choose.ts`)
+
+`chooseItems` (and `chooseCards` wrapping it) is the backbone of equip, store
+buy, and similar flows. Answers pass through `helpers/get-array.ts` (quoted
+lists, JSON arrays, comma/whitespace splitting) and are then resolved against
+the displayed catalog as **numeric indices or case-insensitive item names**.
+Invalid entries are announced and skipped — never abort the whole flow on a
+typo; an empty selection falls through to the caller, which re-prompts
+(equip) or proceeds harmlessly (store). Historical bug: index-only parsing
+plus `Promise.reject(channel({announce}))` — note that idiom rejects with a
+*Promise* as the reason, which logs as `[object Promise]`; don't add new uses.
+
+## 5. Other timing machinery worth knowing
+
+- **Fight timer**: `startFightTimer()` clears and restarts the 60s countdown
+  on every ring add/remove — the fight fires 60s after the *last* membership
+  change (legacy behavior, intentional). `nextFightAt` / `nextBossSpawnAt` are
+  published via `ring.state` events for client countdowns.
+- **State saves**: `Game.scheduleSave()` debounces 30s off `stateChange`
+  events; `RoomManager.unloadRoom` flushes via `game.saveState()`. Direct
+  mutation of `options`-backed arrays (e.g. `contestants.splice`) does not
+  emit `stateChange` — use `setOptions` if persistence matters.
+- **Global semaphore**: all `Game`/creature events ride one process-wide
+  emitter (`helpers/semaphore.ts`). `announcements/index.ts` gates listeners
+  by ownership (`createRoomScopedEventGuard`) so multi-room servers don't
+  cross-announce. Ring listeners are instance-scoped and skip the guard.
+- **Timers must be disposed**: `Game.dispose()` → `Ring.dispose()` +
+  per-creature `disposeTimers()`. Any new `setTimeout`/`setInterval` on a
+  long-lived object needs a dispose path or unloaded rooms keep firing.

--- a/docs/engine-concurrency-and-timing.md
+++ b/docs/engine-concurrency-and-timing.md
@@ -101,7 +101,53 @@ typo; an empty selection falls through to the caller, which re-prompts
 plus `Promise.reject(channel({announce}))` — note that idiom rejects with a
 *Promise* as the reason, which logs as `[object Promise]`; don't add new uses.
 
-## 5. Other timing machinery worth knowing
+## 5. Reconnect replay (`ringFeed`)
+
+Clients resume the event stream with a cursor. Three layers cooperate, and the
+failure mode when they disagree is silent (the user sees an empty pane), so be
+careful here.
+
+- **Client** (`ConsolePane.tsx` / `RingPane.tsx`): each pane keeps
+  `latestTrackedEventIdRef` updated on every event **except** `handshake` and
+  `heartbeat` (those are transport frames, not stream positions), and on
+  `onError` copies it into the subscription input so the reconnect carries a
+  cursor. DB-backed history (`consoleHistory` / `ringHistory`) is fetched once
+  on mount and merged under a `historyApplied` guard — it covers page loads,
+  not reconnects.
+- **In-memory buffer** (`RoomEventBus.getEventsSince`): a 200-event ring buffer
+  per room. Returns a `status` — `found`, `ahead`, `evicted`, or `cold` — and
+  `truncated: true` for anything memory cannot resolve.
+- **Durable fallback** (`RoomManager.getEventsSinceForRingFeed`): resolves the
+  cursor to a `room_events` row, then returns everything after it; if the anchor
+  row is missing it falls back to a lexicographic `event_id` comparison inside a
+  24h-then-7d window.
+
+**Invariants**:
+1. `cold` (empty buffer after a restart or idle eviction) MUST still hit durable
+   storage — this was the #16/#17 bug — but MUST NOT raise a `system.gap`
+   warning when storage is also empty, or every deploy shows a false alarm.
+   `evicted` is the opposite: an empty result there means real events were lost.
+2. Any id a client might echo back as a cursor MUST start with `${epochMs}-`.
+   Both resolution layers key off that leading timestamp (`parseTs`, and
+   Postgres text ordering on `event_id`). Synthetic frames — `handshake`,
+   `heartbeat`, the gap marker — follow this shape even though they are never
+   persisted, so a stray cursor degrades to a time-based match instead of
+   becoming permanently unresolvable.
+3. Events with no replay value belong in the persister's `EPHEMERAL_TYPES`
+   (`ring.state`, `handshake`, `system.gap`, `quick_actions`). Anything added
+   there is invisible to the DB fallback — fine for state-sync signals, wrong
+   for anything the console renders as history.
+
+## 6. Quick actions (`packages/server/src/quick-actions.ts`)
+
+`buildQuickActions(game, userId)` produces the console's chip strip after each
+command settles. Two rules: every `command` string must be real parser syntax
+(chips dispatch verbatim — keep them aligned with `COMMAND_CATALOG`), and the
+builder must never throw, since it runs inside the command pipeline. Suggestions
+are emitted on both success and failure paths and are deliberately not
+persisted.
+
+## 7. Other timing machinery worth knowing
 
 - **Fight timer**: `startFightTimer()` clears and restarts the 60s countdown
   on every ring add/remove — the fight fires 60s after the *last* membership

--- a/docs/roadmap/10-bug-fixes.md
+++ b/docs/roadmap/10-bug-fixes.md
@@ -88,6 +88,20 @@ The web app already handles `quick_actions` events correctly — the suggestions
 
 ---
 
+### 20. Engine timing / command-sync / multi-step command failures — FIXED
+
+Three long-standing complaints traced to root causes and fixed together:
+
+1. **Fights fly by in the live feed** — `Ring.fight()`'s normal card-play path paced card-to-card transitions with `subEventDelay()` (~0.7–1.3s) instead of the configured `veryShortDelay` (2–4s) used by every other fight path. The pacing system in `helpers/delay-times.ts` (deliberately doubled "to make ring fights easier to follow") was never consumed by the main loop. **Fixed**: the played-card path now waits `veryShortDelay(round)` between plays when delays aren't skipped; test/harness mode (`DECK_MONSTERS_SKIP_DELAYS`) is unchanged.
+
+2. **Commands not followed / room appears out of sync** — the tRPC `command` mutation ran interactive actions inside the **room-wide** serialized engine lane. A single user's multi-prompt flow (up to 120s per prompt) held the lane for minutes, silently starving every other member's commands and hanging all awaited workshop mutations in the room. **Fixed**: command actions now serialize per `roomId:userId` lane (same-user ordering is what matters; `activeFlows` already prevents concurrent flows per user). Workshop mutations keep the room lane but now fail fast with `PRECONDITION_FAILED` when the caller has a console flow in progress, instead of hanging and interleaving.
+
+3. **Complex multi-step commands crash/abort** — two compounding bugs: (a) cancelling a flow resolved pending prompts with the literal string `'__cancelled__'`, which no game code recognized, so it was parsed as a card/item selection; (b) `items/helpers/choose.ts` only accepted numeric indices — typing a card *name* produced `Number(name) → NaN` and aborted the entire flow via `Promise.reject(channel(...))` (rejecting with a Promise, so even the log was `[object Promise]`). **Fixed**: the engine exports `PROMPT_CANCELLED` + `PromptCancelledError`; the server channel wrapper translates the sentinel into a clean abort (suppressed in logs like prompt timeouts); `chooseItems` accepts indices **or** case-insensitive item names, skips invalid entries with an announce instead of aborting, and re-prompts via the existing flow when nothing valid was selected.
+
+**Status**: Fixed.
+
+---
+
 ## Known Bugs (original list)
 
 ### 1. "Barely blocked" message fires incorrectly (upstream #181)

--- a/docs/roadmap/10-bug-fixes.md
+++ b/docs/roadmap/10-bug-fixes.md
@@ -2,7 +2,7 @@
 
 **Category**: Bug / Tech Debt  
 **Priority**: High (fix before major new development)  
-**Status**: Active — 12 of 14 original items resolved. Five open bugs: fight log sync (#15), console history on reconnect (#16), event ring buffer gap detection (#17), quick actions emission (#18), and deck equip batch flakiness (#19). Two low-priority cleanup items remain (#3 DMG/CARDS, #5 creatures/base.ts).
+**Status**: Active — one open bug: fight log sync (#15). Resolved: console history on reconnect (#16), event ring buffer gap detection (#17), quick actions emission (#18), engine timing/sync/multi-step crashes (#20), and the engine half of deck equip batch flakiness (#19 — batch RPC / UI flicker work still open). Two low-priority cleanup items remain (#3 DMG/CARDS, #5 creatures/base.ts).
 
 ## Active Bugs
 
@@ -23,44 +23,34 @@ The UI-side query (`queryRecentFights` in `analytics-queries.ts`) is simple and 
 
 ---
 
-### 16. Console pane missing historical data after returning — HIGH
+### 16 & 17. Reconnect replay dropped across restarts / gap not signalled — FIXED
 
-When a player navigates away from the web app and returns (or reconnects after a disconnect), the console pane is empty — it only shows events that arrive after reconnection. Events that occurred while the player was absent are not replayed.
+Both bugs had the same root cause, and it was on the **server**, not the client. The web panes were already correct: each tracks the last received event id (skipping `handshake`/`heartbeat` frames) and re-subscribes with it as `lastEventId` on error, and both `system.gap` and DB-backed history queries were already handled in the UI.
 
-The reconnection-with-replay path was planned in `06a-web-app.md` (Phase 1: "reconnection with replay") but is apparently not delivering historical events in practice.
+`RoomEventBus.getEventsSince()` returned `{ truncated: false }` whenever its in-memory ring buffer was **empty**, with the comment "Fresh room after restart … do not treat as buffer truncation." But an empty buffer is exactly the state after a server restart or an idle-room eviction — the single most common reason a player returns to a stale pane. Because `truncated` was false, `ringFeed`'s durable-storage fallback (`getEventsSinceForRingFeed`) never ran, so the client silently received **nothing** for the entire period it was away, and no gap marker either.
 
-Likely causes:
-- The replay cursor (last-seen event ID or timestamp) is not being sent on reconnect, so the server doesn't know what to replay
-- Or the server-side replay query is not being triggered when a WebSocket/SSE client reconnects
-- The tRPC subscription for room events may start from "now" rather than from the last-received event
+**Fixed** by separating "can memory resolve this cursor?" from "should we warn the user?". `EventsSinceResult` now carries a `status` of `found` / `ahead` / `evicted` / `cold`:
 
-**Investigation path**: Check the WebSocket reconnect handler in the web app — does it send a `since` parameter? Check the tRPC subscription procedure — does it accept and honor a `since` cursor? If both exist, check that they are wired together.
+- `cold` (buffer empty after restart/eviction) → `truncated: true`, so the DB replay runs. An empty DB result is *not* reported as a gap — an idle room is why it was evicted, and warning there would fire on every deploy.
+- `evicted` (cursor aged out while the room stayed loaded) → DB replay runs, and an empty result **does** emit `system.gap`, because events demonstrably passed through the buffer.
 
-**Status**: Open.
+Also hardened: the synthetic frames the router yields but never persists (`handshake`, `heartbeat`, the gap marker) now use the same `${epochMs}-${suffix}` id shape as real events. The old `system-gap-…` / `heartbeat-…` ids put the timestamp in the second segment, so if a client ever echoed one back as its cursor, both the in-memory timestamp parse and the DB's lexicographic `event_id` comparison would fail to resolve it — producing a permanent no-replay-plus-gap-warning loop on every subsequent reconnect.
 
----
+Covered by tests in `packages/engine/src/events/room-event-bus.test.ts` (status per outcome) and `packages/server/src/trpc/router.test.ts` (all three replay paths end-to-end through the subscription).
 
-### 17. Event ring buffer gap not signalled — MEDIUM
-
-When a client reconnects with a `lastEventId` that has been evicted from the in-memory ring buffer (200-event cap, `packages/engine/src/events/room-event-bus.ts`), `getEventsSince()` returns an empty array silently. The client presents an incomplete replay with no indication that events were missed.
-
-This is a direct contributing cause of bug #16 — for short disconnects the buffer is sufficient, but for longer absences (buffer evicted) the fallback to DB never fires.
-
-**Fix needed**: When `lastEventId` is not found in the ring buffer, fall back to querying `room_events` in the database for the events since that ID. If the database also doesn't have them (older than retention window), emit a synthetic gap event so the client can show "some events were missed while you were away" rather than silently presenting a truncated stream.
-
-**Status**: Open. Related to #16.
+**Status**: Fixed.
 
 ---
 
-### 18. Quick actions suggestions not emitted after commands — MEDIUM
+### 18. Quick actions suggestions not emitted after commands — FIXED
 
-A TODO comment in `packages/server/src/trpc/router.ts` marks an unimplemented path: contextual `quick_actions` events should be emitted after each game command completes, populating the suggestions strip in the web console. Currently no `quick_actions` events arrive from the server after commands complete.
+The web console's chip strip was fully wired (`quick_actions` → `setQuickActions` → clickable chips that dispatch the command) but the server never emitted the event; only a TODO sat in `router.ts`.
 
-The web app already handles `quick_actions` events correctly — the suggestions strip is wired up — but it stays empty because the server never sends suggestions.
+**Fixed**: added `packages/server/src/quick-actions.ts` — a pure, defensively-typed `buildQuickActions(game, userId)` that reads character/monster/ring state and returns up to four `{ label, command }` suggestions ordered by likely next move: spawn (no monsters) → look at the ring (own monster fighting) → send an idle monster → revive a dead one → equip when unequipped cards exist → look at monsters / visit the shop. Commands are drawn from `COMMAND_CATALOG` syntax so every chip dispatches a command the parser actually accepts, and equip/send are only offered for monsters outside the ring (the engine rejects equipping a fighting monster).
 
-**Fix needed**: After `game.handleCommand` + action resolves, determine contextual suggestions (e.g. "look at ring", "look at monsters", "buy") based on game state and emit a `quick_actions` event to the requesting user's private channel.
+Emitted after the command action settles — success *or* failure — so suggestions reflect the state the user is looking at; wrapped in try/catch so a suggestion bug can never break the command pipeline. `quick_actions` was added to the event persister's `EPHEMERAL_TYPES`: suggestions describe one instant, and replaying a stale set would surface chips that no longer apply. 11 unit tests in `quick-actions.test.ts`.
 
-**Status**: Open.
+**Status**: Fixed.
 
 ---
 
@@ -196,9 +186,9 @@ When a fight reaches round 10 without a winner, the draw/stalemate announcement 
 ## Tasks
 
 - [ ] Fix fight log not updating after new fights complete (#15)
-- [ ] Fix console pane not replaying history on reconnect (#16)
-- [ ] Fix event ring buffer gap not signalled on reconnect (#17, contributes to #16)
-- [ ] Wire quick actions event emission after game commands (#18)
+- [x] ~~Fix console pane not replaying history on reconnect~~ (done — cold-buffer DB fallback, #16/#17)
+- [x] ~~Fix event ring buffer gap not signalled on reconnect~~ (done — `EventsSinceResult.status`, #17)
+- [x] ~~Wire quick actions event emission after game commands~~ (done — `server/src/quick-actions.ts`, #18)
 - [ ] Audit and differentiate `DMG.md` vs `CARDS.md`; add how-to-run section (upstream #265) — build headers differentiated, full content pass still todo
 - [ ] Continue incremental decomposition of `creatures/base.ts`
 - [x] ~~Fix "barely blocked" threshold~~ (already correct in TS migration)

--- a/docs/roadmap/10-bug-fixes.md
+++ b/docs/roadmap/10-bug-fixes.md
@@ -98,7 +98,7 @@ Three long-standing complaints traced to root causes and fixed together:
 
 3. **Complex multi-step commands crash/abort** — two compounding bugs: (a) cancelling a flow resolved pending prompts with the literal string `'__cancelled__'`, which no game code recognized, so it was parsed as a card/item selection; (b) `items/helpers/choose.ts` only accepted numeric indices — typing a card *name* produced `Number(name) → NaN` and aborted the entire flow via `Promise.reject(channel(...))` (rejecting with a Promise, so even the log was `[object Promise]`). **Fixed**: the engine exports `PROMPT_CANCELLED` + `PromptCancelledError`; the server channel wrapper translates the sentinel into a clean abort (suppressed in logs like prompt timeouts); `chooseItems` accepts indices **or** case-insensitive item names, skips invalid entries with an announce instead of aborting, and re-prompts via the existing flow when nothing valid was selected.
 
-**Status**: Fixed.
+**Status**: Fixed. The full mental model of how pacing, serialization lanes, `activeFlows`, and the prompt lifecycle interact is documented in [`docs/engine-concurrency-and-timing.md`](../engine-concurrency-and-timing.md) — read it before changing any of these systems.
 
 ---
 

--- a/docs/roadmap/10-bug-fixes.md
+++ b/docs/roadmap/10-bug-fixes.md
@@ -2,7 +2,7 @@
 
 **Category**: Bug / Tech Debt  
 **Priority**: High (fix before major new development)  
-**Status**: Active — original bugs #15–#18 and #20 all resolved. Newly recorded during the fix pass: #21–#24 (see below). Previously resolved: console history on reconnect (#16), event ring buffer gap detection (#17), quick actions emission (#18), engine timing/sync/multi-step crashes (#20), and the engine half of deck equip batch flakiness (#19 — batch RPC / UI flicker work still open). Two low-priority cleanup items remain (#3 DMG/CARDS, #5 creatures/base.ts).
+**Status**: Active — #15–#18 and #20–#25 all resolved, including a critical cross-room reward-duplication bug (#25) found and fixed while wiring up #23. One new item recorded but not yet fixed: #26 (card shop is a process-wide singleton, needs a design decision). #19's engine-side bugs are fixed; its batch-RPC/UI-flicker UX work is still open. Two low-priority cleanup items remain (#3 DMG/CARDS, #5 creatures/base.ts).
 
 ## Active Bugs
 
@@ -96,23 +96,71 @@ Three long-standing complaints traced to root causes and fixed together:
 
 ## Newly Recorded (code-reading pass, 2026-07-31)
 
-Spotted while fixing #15/#16/#17/#18/#20 — recorded for triage, not yet fixed unless noted.
+Spotted while fixing #15/#16/#17/#18/#20. #21–#24 were logged for later triage and are now fixed. Fixing #23 required chasing down two more serious bugs it would otherwise have exposed/interacted with — #25 (a real cross-room reward-duplication bug, unrelated to #23 itself) and a reentrancy hazard in the room-scoping guard used by #23's fix — both described below and fixed in the same pass.
 
-### 21. Idle-room sweep can orphan an in-progress fight — MEDIUM
+### 21. Idle-room sweep can orphan an in-progress fight — FIXED
 
-`RoomManager.sweepIdleRooms` → `unloadRoom` never checks `ring.inEncounter`. `Game.dispose()` clears `fightTimer`/`bossTimer`, but the fight loop itself (`doAction` in `ring/index.ts`) advances via untracked anonymous `setTimeout` chains — so a fight in progress at sweep time keeps running to completion against an event bus whose DB subscribers were just detached: announcements, stats, and the fight summary all vanish, while the game object continues mutating state after its final flush. Narrow window in practice (`lastActivityAt` is touched by every command, and fights start 60s after the last ring change), but boss spawns plus a watching-only audience can hit it. **Suggested fix**: skip unloading rooms where `ring.inEncounter` is true (re-sweep later), and/or give `doAction` a disposal flag the chain checks between steps.
+`RoomManager.sweepIdleRooms` → `unloadRoom` never checked `ring.inEncounter`. `Game.dispose()` clears `fightTimer`/`bossTimer`, but the fight loop itself (`doAction` in `ring/index.ts`) advances via untracked anonymous `setTimeout` chains — so a fight in progress at sweep time kept running to completion against an event bus whose DB subscribers had just been detached: announcements, stats, and the fight summary would all be lost.
 
-### 22. Boss despawn timer is never tracked or disposed — LOW
+**Fixed**: `unloadRoom` now checks `entry.game.ring.inEncounter` first and leaves the room active (no dispose, no cache eviction) when a fight is running, logging that the unload was skipped. Since `unloadRoom`'s only production caller is the 10-minute idle sweep (`packages/server/src/index.ts`), the room simply gets retried on the next sweep — ample time for any fight to finish. Covered by a new test in `room-manager.test.ts`.
 
-`Ring.spawnBoss()` arms a 10-minute `setTimeout(removeBoss)` that is not stored on the instance, so `Ring.dispose()` cannot clear it. After a room unloads, the orphaned timer fires against the disposed ring (harmless state-wise since `removeBoss` re-checks, but it publishes to a detached bus and keeps harness/test processes alive). Store the handle and clear it in `dispose()` alongside `fightTimer`/`bossTimer`.
+**Status**: Fixed.
 
-### 23. Cross-room stateChange save amplification — LOW (perf)
+### 22. Boss despawn timer is never tracked or disposed — FIXED
 
-`Game` passes the process-wide `globalSemaphore` to `BaseClass`, so `this.on('stateChange', …)` in `initializeEvents` hears **every** `stateChange` from **every** room and creature in the process. Each fires `scheduleSave()` in *all* loaded games. Correctness holds (each game serializes only its own state, debounced 30s), but on a busy multi-room server this is O(rooms × changes) redundant save scheduling. The announcements module already solves this exact problem with `createRoomScopedEventGuard` — the save listener should be wrapped the same way.
+`Ring.spawnBoss()` arms a 10-minute `setTimeout(removeBoss)` on a 50/50 coin flip, but the handle was never stored, so `Ring.dispose()` couldn't clear it — an orphaned timer would fire against an already-disposed ring after the room unloaded.
 
-### 24. Direct mutations bypass the stateChange persistence signal — LOW
+**Fixed**: pending despawn timers are tracked in a `bossDespawnTimers` Set on the `Ring` instance, added when scheduled and removed when they fire; `dispose()` now clears all of them alongside `fightTimer`/`bossTimer`. Also hardened the despawn callback with `.catch(() => {})` — `removeBoss` → `removeMonster` rejects if the boss is no longer in the ring (e.g. cleared by an intervening fight), which was an unhandled-rejection risk before. Covered by a new test that forces the despawn branch via retry (not by pinning `Math.random`, which breaks the recursive card-probability retry in `cards/helpers/draw.ts` — see the test's comment for why).
 
-Two spots mutate `options`-backed structures in place instead of via `setOptions`, so no `stateChange` fires from the mutation itself: `Game.getCharacter` (`game.characters[id] = character`) and `Ring.removeMonster` (`contestants.splice`). In practice a save is usually scheduled soon after by adjacent activity (and #23 currently papers over it process-wide), but if #23 is ever fixed these become real "lost on restart" windows. Emit `stateChange` explicitly at both sites.
+**Status**: Fixed.
+
+### 23. Cross-room stateChange save amplification — FIXED
+
+`Game` passes the process-wide `globalSemaphore` to `BaseClass`, so `this.on('stateChange', …)` in `initializeEvents` heard **every** `stateChange` from **every** room and creature in the process and rescheduled *this* room's 30s save debounce each time. Beyond wasted work, this was a real correctness risk on a busy server: another room's continuous activity could keep resetting a quiet room's debounce indefinitely, delaying its actual flush well past 30s.
+
+**Fixed**: `setOptions()` now passes the mutating instance to the broadcast (`globalSemaphore.emit('stateChange', this)`, previously zero args), and `Game.initializeEvents()` wraps the `stateChange` listener with `createRoomScopedEventGuard` (now exported from `announcements/index.ts`) exactly like every other cross-cutting `creature.*` listener already was — **except it wasn't**, see #25. Covered by a new test proving 25 seconds of another room's activity does not delay this room's own save past its original 30s mark.
+
+Fixing this exposed two further bugs, both fixed in the same pass — see #25 and the reentrancy note below.
+
+**Status**: Fixed.
+
+### 24. Direct mutations bypass the stateChange persistence signal — FIXED
+
+Two spots mutated `options`-backed structures in place instead of via `setOptions`, so no `stateChange` fired from the mutation itself — harmless while #23 made *every* mutation anywhere trigger *every* room's save regardless, but a real "lost/resurrected on restart" risk once #23 scopes saves correctly:
+
+- **`Game.getCharacter`** — `game.characters[id] = character` for a newly created character. **Fixed**: an explicit `game.emit('stateChange')` after the assignment.
+- **`Ring.removeMonster`** — `this.contestants.splice(...)` mutated the live array in place; a monster withdrawn from a still-populated ring (not emptying it, so `clearRing()` never ran either) left the last-persisted `ringContestantRefs` unchanged, meaning **the withdrawn monster could be resurrected into the ring on the next restart**. **Fixed**: builds a new array and assigns through the `contestants` setter, matching the pattern `addMonster` already used.
+- **Found while auditing the rest of the codebase for the same pattern**: `creatures/items.ts`'s `removeItem` had the identical bug (`self.items.splice(...)` in place, unlike its sibling `addItem` which already went through the setter) — a removed item could similarly reappear after a restart. **Fixed** the same way. A broader sweep of `.splice()`/`.push()` call sites across the engine (`characters/beastmaster.ts`'s equip/move/reorder/preset paths, `items/helpers/transfer.ts`, `items/helpers/use.ts`) found only local-copy patterns (`[...creature.field]` before mutating) — no other instances.
+
+**Status**: Fixed.
+
+### 25. Cross-room reward duplication via unscoped `creature.win`/`loss`/`permaDeath`/`fled` listeners — FIXED (CRITICAL, found while fixing #23)
+
+While wiring the room-scoping guard onto `stateChange` (#23), the same `Game.initializeEvents()` method turned out to already have **four** listeners with the identical unscoped-`globalSemaphore` problem, pre-dating this work and far more severe: `creature.win` → `handleWinner`, `creature.loss` → `handleLoser`, `creature.permaDeath` → `handlePermaDeath`, `creature.fled` → `handleFled`. These were the *only* `creature.*` listeners in the whole engine that skipped the `createRoomScopedEventGuard` wrapping every other cross-cutting listener in `announcements/index.ts` already uses.
+
+**Impact**: `Ring.handleWinner()` calls `contestant.monster.emit('win', {contestant})`, which — via `BaseClass.emit`'s `${eventPrefix}.${event}` broadcast — fires on the single process-wide `globalSemaphore`. Every currently-loaded `Game` instance's `handleWinner` ran against the *same* `contestant` object. On a server with N active rooms, a single fight's outcome in any one room granted its owner's character XP, coins, **and drew and appended N separate cards to their deck** — once per other loaded room, not once. The more concurrent rooms a deployment has, the worse the multiplication. This is likely the single most severe correctness bug found in this whole pass, and it had zero test coverage (no existing test ever constructed two simultaneous `Game` instances and checked a reward outcome).
+
+**Fixed**: wrapped all four listeners (plus `stateChange`) with the same `wrapGameEvent`/`isRoomScopedEvent` guard in `Game.initializeEvents()`. Covered by two new end-to-end tests in `game.test.ts` that construct two rooms, fire a real `monster.emit('win'|'permaDeath', …)`, and assert the reward applied exactly once to the owning room's character.
+
+**Bonus find in the same area**: `Ring.handlePermaDeath()` was missing the `contestant.monster.emit('permaDeath', {contestant})` call that its win/loss/fled siblings all have — a plain omission. Since `Game.handlePermaDeath` only listens for that broadcast, this meant **a permanently destroyed monster granted its owner no reward at all**, not even the ordinary loss amount, let alone the intended double "consolation" XP/coins for a permanent death. **Fixed**: added the missing emit, mirroring the sibling handlers exactly. Covered by a new `ring/index.test.ts` test asserting the emit now happens, plus the `game.test.ts` end-to-end permaDeath-reward test above (which would have failed with zero reward before this fix, and double reward before the #23/#25 guard fix).
+
+**Status**: Fixed.
+
+### Reentrancy hazard exposed by the #23 guard — FIXED
+
+Wiring `createRoomScopedEventGuard` onto `stateChange` (the most frequently-fired event in the engine — it fires on *every* `setOptions()` call, including from inside other objects' constructors) surfaced a latent bug in the guard itself: `ownsDirectly()` checked ownership by reading `character.deck`/`character.monsters`/`character.items`/`monster.cards`/`monster.items` — **live getters**, several of which (`BaseCharacter.cards`/`.deck` specifically) lazily initialize themselves on first read by calling `this.deck = getInitialDeck()`, which itself calls `setOptions()`, which broadcasts another `stateChange` **synchronously, mid-computation**. If the guard's ownership check for *that* re-entrant broadcast reads the *same still-uninitialized* `character.deck` again, it retriggers the lazy init again before the outer call ever finishes — unbounded recursion ending in a stack overflow. This was reachable in production any time a brand-new character's first card draw happened while any `Game` instance's guarded `stateChange` listener was active (i.e. always, once #23 shipped) — caught immediately by the new #25 reward tests, which construct exactly this scenario (a freshly-built character whose deck has never been read).
+
+**Fixed**: `ownsDirectly()` now reads straight from each instance's raw `optionsStore` (`(value as {optionsStore}).optionsStore?.[key]`) instead of the public getters — a pure, side-effect-free lookup that can never re-enter anything, and behaviorally equivalent for matching purposes (an array that's still unset genuinely cannot contain whatever is being checked against it either way). Applied to all five reads in `ownsDirectly` plus `game.characters`'s own (self-limiting, but fixed for consistency).
+
+**Status**: Fixed. This is exactly the kind of side-effecting-getter trap that's easy to reintroduce — see the new doc comment on `rawArray` in `announcements/index.ts` before adding any new ownership checks there.
+
+### 26. Card shop is a single process-wide singleton shared by every room — RECORDED, not fixed
+
+`packages/engine/src/items/store/shop.ts`'s `getShop()` is a module-level `throttle()`-wrapped function with a single `currentShop` variable, regenerated once per 8 hours **for the entire process**, not per room. Every room on a multi-room server currently shares the exact same shop inventory, closing time, and prices — one room buying out an item affects every other room's shop simultaneously. This directly conflicts with `CLAUDE.md`'s "Critical Architecture Rule: Room-Level Scoping" ("All game state … must be scoped to a room … treat this as a hard constraint, not a guideline").
+
+Likely a leftover from the original single-workspace Slack bot design, never revisited during the multi-room revival. Not fixed here — it needs a design decision (per-room shop keyed by `roomId`? shared shop but per-room purchase tracking? intentionally shared as a "world event"?) rather than a mechanical patch, and touches `buy.ts`/`sell.ts`'s call sites plus whatever surfaces the shop to connectors.
+
+**Status**: Open — needs a design decision before implementation.
 
 ### Smaller observations / streamlining suggestions
 
@@ -120,6 +168,7 @@ Two spots mutate `options`-backed structures in place instead of via `setOptions
 - **`Promise.reject(channel({ announce }))` idiom** (store buy, `game.ts` look-ups, equip preconditions): rejects with a *Promise* as the reason, which stringifies as `[object Promise]` in any error log. Prefer announcing first, then rejecting with a real `Error`. (Already fixed in `chooseItems` — #20.)
 - **`fight()` error path drops history**: see #15 residual note — if cancelled fights should appear in the fight log as `cancelled`, publish a terminal event from the `.catch` path.
 - **`activeFlows` rejection message** can mislead: when a user's command is *queued* (not prompting), the "answer the current prompt first" message returns `pendingPrompt: null`. Consider a distinct "still processing your previous command" message when there is no pending prompt.
+- **Test-tooling gotcha, not a product bug**: mixing a static top-level import and a dynamic `await import()` of the *same* module within one `tsx`-transformed mocha run can silently produce two separate module instances (confirmed for `helpers/semaphore.ts` — its module body evaluated twice, yielding two different `globalSemaphore` `EventEmitter`s). A test that relies on `someDynamicallyImportedInstance.emit(...)` reaching a statically-imported listener can fail with the event simply vanishing. Fix is to import consistently (prefer static imports for classes whose own `BaseClass.emit()` needs to reach engine-wide listeners in a test). Not reachable in the real compiled build — only ever an artifact of the test transform.
 - Fixed in passing: unused `or` import in `analytics-queries.ts` (was the only lint warning in the server package).
 
 ## Known Bugs (original list)
@@ -216,7 +265,12 @@ When a fight reaches round 10 without a winner, the draw/stalemate announcement 
 ## Tasks
 
 - [x] ~~Fix fight log not updating after new fights complete~~ (done — pending-snapshot race + retries, #15)
-- [ ] Triage newly recorded #21–#24 (idle-sweep orphaned fights, boss timer disposal, save amplification, missed stateChange)
+- [x] ~~Fix idle-sweep orphaning in-progress fights~~ (done — `unloadRoom` checks `ring.inEncounter`, #21)
+- [x] ~~Dispose pending boss despawn timers~~ (done — `bossDespawnTimers` Set, #22)
+- [x] ~~Fix cross-room stateChange save amplification~~ (done — room-scoped guard on the listener, #23)
+- [x] ~~Fix direct mutations bypassing stateChange~~ (done — `getCharacter`, `Ring.removeMonster`, `removeItem`, #24)
+- [x] ~~Fix cross-room reward duplication (creature.win/loss/permaDeath/fled)~~ (done — CRITICAL, found while fixing #23, #25)
+- [ ] Decide on and implement per-room (or intentionally shared) card shop scoping (#26)
 - [x] ~~Fix console pane not replaying history on reconnect~~ (done — cold-buffer DB fallback, #16/#17)
 - [x] ~~Fix event ring buffer gap not signalled on reconnect~~ (done — `EventsSinceResult.status`, #17)
 - [x] ~~Wire quick actions event emission after game commands~~ (done — `server/src/quick-actions.ts`, #18)

--- a/docs/roadmap/10-bug-fixes.md
+++ b/docs/roadmap/10-bug-fixes.md
@@ -2,24 +2,26 @@
 
 **Category**: Bug / Tech Debt  
 **Priority**: High (fix before major new development)  
-**Status**: Active — one open bug: fight log sync (#15). Resolved: console history on reconnect (#16), event ring buffer gap detection (#17), quick actions emission (#18), engine timing/sync/multi-step crashes (#20), and the engine half of deck equip batch flakiness (#19 — batch RPC / UI flicker work still open). Two low-priority cleanup items remain (#3 DMG/CARDS, #5 creatures/base.ts).
+**Status**: Active — original bugs #15–#18 and #20 all resolved. Newly recorded during the fix pass: #21–#24 (see below). Previously resolved: console history on reconnect (#16), event ring buffer gap detection (#17), quick actions emission (#18), engine timing/sync/multi-step crashes (#20), and the engine half of deck equip batch flakiness (#19 — batch RPC / UI flicker work still open). Two low-priority cleanup items remain (#3 DMG/CARDS, #5 creatures/base.ts).
 
 ## Active Bugs
 
-### 15. Fights not being written to fight_summaries — HIGH
+### 15. Fights not being written to fight_summaries — FIXED
 
-New fights are not appearing in the fight log at all — the problem is on the **write side**, not the UI refresh side. The `FightSummaryWriter` subscribes to `ring.fightResolved` and performs a DB insert, but there are several places where the insert can fail silently and the fight is lost permanently.
+Of the four failure paths originally documented, two had already been addressed in a prior hardening pass (per-room write serialization; `profileUuidOrNull` guard for non-UUID owner ids such as Discord snowflakes) and two remained:
 
-**Confirmed failure paths (in `packages/server/src/fight-summary-writer.ts`):**
+1. **Cross-fight pending race (path 4, only half-fixed)** — writes were serialized, but `pendingByRoom` was still *read inside* the queued async write and deleted after it. If fight B's `fightBegins` arrived while fight A's write was queued (slow transaction, retry backoff, boss fights), A picked up B's `startedAt` (wrong duration) and A's post-write cleanup deleted B's pending — so B then wrote with zero duration and a spurious warning. **Fixed**: the pending snapshot is captured and cleared *synchronously* at `ring.fightResolved` delivery time and passed into the queued write, so each fight is permanently paired with its own start.
+2. **No retry (path 2, partially addressed)** — failures were logged with a metric but the row was still dropped forever on any transient DB hiccup. **Fixed**: bounded retries with short backoff (default 1s, 5s; injectable for tests). The failure metric and error log now fire only when retries are exhausted — i.e. when a row is actually lost.
 
-1. **Data deleted before write** (line ~69): `pendingByRoom.delete(roomId)` runs synchronously before the async DB transaction completes. If the transaction throws, the `startedAt` timestamp and pending data are permanently lost.
-2. **Errors silently swallowed** (line ~44): `void onFightResolved(...).catch(log)` — any DB error (constraint violation, connection failure, type mismatch) is only logged, never retried or escalated. The fight disappears without a trace beyond a log line.
-3. **Possible UUID type mismatch**: `winnerOwnerUserId` / `loserOwnerUserId` are UUID columns in Postgres. If `ownerUserId` in the ring event payload is a non-UUID string (e.g. a Discord snowflake ID), the insert fails with a type error — silently swallowed per point 2.
-4. **Concurrent fight race**: `pendingByRoom` is a plain `Map`. If two fights in the same room finish in close succession, the second `fightBegins` can overwrite the first's `startedAt`, and both `fightResolved` handlers operate on the same map entry.
+Also fixed: the module-level `pendingByRoom` / `fightSummaryWriteQueues` maps were never cleaned when rooms unloaded, growing one entry per room ever seen for the life of the server. The detach function returned by `attachFightSummaryWriter` now clears both.
 
-The UI-side query (`queryRecentFights` in `analytics-queries.ts`) is simple and correct — if rows exist, they appear. The issue is that rows are not being created.
+Verified along the way: the `ring.cardDrop` enrichment chain is sound — `announceCardDrop` publishes with the exact type/scope/payload key the writer matches, and card drops are emitted synchronously during the `fightConcludes` contestant loop, *before* `ring.fightResolved` is published, so the snapshot always contains them.
 
-**Status**: Open. See GitHub issue for full plan.
+Covered by 7 new tests in `fight-summary-writer.test.ts` (happy path, UUID guard, the cross-fight race, retry-then-success, retry exhaustion, restart-mid-fight, fightConcludes filtering).
+
+**Known residual gap (accepted)**: a fight that errors mid-combat takes `Ring.fight()`'s `.catch` path, which clears the ring without publishing `ring.fightResolved` — cancelled fights intentionally never reach history. A server restart mid-fight likewise loses that fight.
+
+**Status**: Fixed.
 
 ---
 
@@ -91,6 +93,34 @@ Three long-standing complaints traced to root causes and fixed together:
 **Status**: Fixed. The full mental model of how pacing, serialization lanes, `activeFlows`, and the prompt lifecycle interact is documented in [`docs/engine-concurrency-and-timing.md`](../engine-concurrency-and-timing.md) — read it before changing any of these systems.
 
 ---
+
+## Newly Recorded (code-reading pass, 2026-07-31)
+
+Spotted while fixing #15/#16/#17/#18/#20 — recorded for triage, not yet fixed unless noted.
+
+### 21. Idle-room sweep can orphan an in-progress fight — MEDIUM
+
+`RoomManager.sweepIdleRooms` → `unloadRoom` never checks `ring.inEncounter`. `Game.dispose()` clears `fightTimer`/`bossTimer`, but the fight loop itself (`doAction` in `ring/index.ts`) advances via untracked anonymous `setTimeout` chains — so a fight in progress at sweep time keeps running to completion against an event bus whose DB subscribers were just detached: announcements, stats, and the fight summary all vanish, while the game object continues mutating state after its final flush. Narrow window in practice (`lastActivityAt` is touched by every command, and fights start 60s after the last ring change), but boss spawns plus a watching-only audience can hit it. **Suggested fix**: skip unloading rooms where `ring.inEncounter` is true (re-sweep later), and/or give `doAction` a disposal flag the chain checks between steps.
+
+### 22. Boss despawn timer is never tracked or disposed — LOW
+
+`Ring.spawnBoss()` arms a 10-minute `setTimeout(removeBoss)` that is not stored on the instance, so `Ring.dispose()` cannot clear it. After a room unloads, the orphaned timer fires against the disposed ring (harmless state-wise since `removeBoss` re-checks, but it publishes to a detached bus and keeps harness/test processes alive). Store the handle and clear it in `dispose()` alongside `fightTimer`/`bossTimer`.
+
+### 23. Cross-room stateChange save amplification — LOW (perf)
+
+`Game` passes the process-wide `globalSemaphore` to `BaseClass`, so `this.on('stateChange', …)` in `initializeEvents` hears **every** `stateChange` from **every** room and creature in the process. Each fires `scheduleSave()` in *all* loaded games. Correctness holds (each game serializes only its own state, debounced 30s), but on a busy multi-room server this is O(rooms × changes) redundant save scheduling. The announcements module already solves this exact problem with `createRoomScopedEventGuard` — the save listener should be wrapped the same way.
+
+### 24. Direct mutations bypass the stateChange persistence signal — LOW
+
+Two spots mutate `options`-backed structures in place instead of via `setOptions`, so no `stateChange` fires from the mutation itself: `Game.getCharacter` (`game.characters[id] = character`) and `Ring.removeMonster` (`contestants.splice`). In practice a save is usually scheduled soon after by adjacent activity (and #23 currently papers over it process-wide), but if #23 is ever fixed these become real "lost on restart" windows. Emit `stateChange` explicitly at both sites.
+
+### Smaller observations / streamlining suggestions
+
+- **`equip.ts` fire-and-forget announces**: in the typed-selection path (`cardSelection` reduce), rejection notices are sent via unawaited `channel({ announce })` calls, so their ordering relative to the surrounding flow messages is not guaranteed. Harmless today; worth awaiting if message order ever matters.
+- **`Promise.reject(channel({ announce }))` idiom** (store buy, `game.ts` look-ups, equip preconditions): rejects with a *Promise* as the reason, which stringifies as `[object Promise]` in any error log. Prefer announcing first, then rejecting with a real `Error`. (Already fixed in `chooseItems` — #20.)
+- **`fight()` error path drops history**: see #15 residual note — if cancelled fights should appear in the fight log as `cancelled`, publish a terminal event from the `.catch` path.
+- **`activeFlows` rejection message** can mislead: when a user's command is *queued* (not prompting), the "answer the current prompt first" message returns `pendingPrompt: null`. Consider a distinct "still processing your previous command" message when there is no pending prompt.
+- Fixed in passing: unused `or` import in `analytics-queries.ts` (was the only lint warning in the server package).
 
 ## Known Bugs (original list)
 
@@ -185,7 +215,8 @@ When a fight reaches round 10 without a winner, the draw/stalemate announcement 
 
 ## Tasks
 
-- [ ] Fix fight log not updating after new fights complete (#15)
+- [x] ~~Fix fight log not updating after new fights complete~~ (done — pending-snapshot race + retries, #15)
+- [ ] Triage newly recorded #21–#24 (idle-sweep orphaned fights, boss timer disposal, save amplification, missed stateChange)
 - [x] ~~Fix console pane not replaying history on reconnect~~ (done — cold-buffer DB fallback, #16/#17)
 - [x] ~~Fix event ring buffer gap not signalled on reconnect~~ (done — `EventsSinceResult.status`, #17)
 - [x] ~~Wire quick actions event emission after game commands~~ (done — `server/src/quick-actions.ts`, #18)

--- a/packages/engine/src/announcements/index.ts
+++ b/packages/engine/src/announcements/index.ts
@@ -57,7 +57,7 @@ type RoomScopedCharacter = {
 	deck?: unknown[];
 };
 
-type RoomScopedGame = {
+export type RoomScopedGame = {
 	eventBus: RoomEventBus;
 	ring: {
 		on: (event: string, listener: (...args: any[]) => void) => (...args: any[]) => void;
@@ -69,35 +69,59 @@ type RoomScopedGame = {
 	off: (event: string, listener: (...args: any[]) => void) => void;
 };
 
-function createRoomScopedEventGuard(game: RoomScopedGame): (...args: any[]) => boolean {
+/**
+ * Reads a possibly-array property straight from a BaseClass instance's raw
+ * `optionsStore`, bypassing its public getter entirely.
+ *
+ * Several getters here (notably `BaseCharacter.cards`/`.deck`) lazily
+ * initialize themselves on first read when the backing option is still
+ * unset — e.g. `get cards() { if (deck is empty) this.deck = getInitialDeck() }`.
+ * That assignment itself calls `setOptions()`, which broadcasts `stateChange`
+ * globally and synchronously. If this guard's ownership check reads one of
+ * those getters *while already inside* that same lazy-init (e.g. because one
+ * of the newly-constructed starter cards' own constructor just fired another
+ * `stateChange`), the still-unset backing field re-triggers the lazy init
+ * again before the outer call ever gets to finish it — unbounded recursion
+ * ending in a stack overflow. Reading the raw store is a pure, side-effect-free
+ * lookup, so it can never re-enter anything. It also is not merely equivalent to
+ * the getter but strictly safer for this use: while genuinely unset the array
+ * is empty either way, so returning `[]` here is exactly as correct as
+ * triggering the lazy default.
+ */
+const rawArray = (value: unknown, key: string): unknown[] => {
+	const store = (value as { optionsStore?: Record<string, unknown> } | undefined)?.optionsStore;
+	const arr = store?.[key];
+	return Array.isArray(arr) ? arr : [];
+};
+
+export function createRoomScopedEventGuard(game: RoomScopedGame): (...args: any[]) => boolean {
 	const ownsDirectly = (value: unknown): boolean => {
 		if (!value || typeof value !== 'object') return false;
 		if (value === game || value === game.ring || value === game.exploration) return true;
 
-		const characters = Object.values(game.characters ?? {});
+		// `game.characters` itself lazily initializes on first read too, but that
+		// path is self-limiting (only fires once); the deck/cards reads below are
+		// not, so all five reads here consistently avoid the live getters.
+		const characters = Object.values(
+			(game as unknown as { optionsStore?: Record<string, unknown> }).optionsStore?.['characters'] ?? {}
+		);
 		for (const character of characters as Array<RoomScopedCharacter | undefined>) {
 			if (value === character) return true;
 
-			const monsters: unknown[] = Array.isArray(character?.monsters) ? character.monsters : [];
+			const monsters = rawArray(character, 'monsters');
 			if (monsters.includes(value)) return true;
 
-			const charItems: unknown[] = Array.isArray(character?.items) ? character.items : [];
+			const charItems = rawArray(character, 'items');
 			if (charItems.includes(value)) return true;
 
-			const deck: unknown[] = Array.isArray(character?.deck) ? character.deck : [];
+			const deck = rawArray(character, 'deck');
 			if (deck.includes(value)) return true;
 
 			for (const monster of monsters) {
-				const cards: unknown[] =
-					monster && typeof monster === 'object' && Array.isArray((monster as any).cards)
-						? (monster as any).cards
-						: [];
+				const cards = rawArray(monster, 'cards');
 				if (cards.includes(value)) return true;
 
-				const items: unknown[] =
-					monster && typeof monster === 'object' && Array.isArray((monster as any).items)
-						? (monster as any).items
-						: [];
+				const items = rawArray(monster, 'items');
 				if (items.includes(value)) return true;
 			}
 		}

--- a/packages/engine/src/creatures/items.ts
+++ b/packages/engine/src/creatures/items.ts
@@ -54,7 +54,12 @@ export function removeItem (self: BaseCreature, itemToRemove: ItemInstance): Ite
 	const itemIndex = self.items.findIndex((item: ItemInstance) => _isMatchingItem(item, itemToRemove));
 
 	if (itemIndex >= 0) {
-		const foundItem = self.items.splice(itemIndex, 1)[0];
+		// Go through the `items` setter (setOptions) like addItem does — an in-place
+		// splice on the live array never emits `stateChange`, so a removed item could
+		// still show up after a restart if nothing else changed the creature's state.
+		const remaining = [...self.items];
+		const foundItem = remaining.splice(itemIndex, 1)[0]!;
+		self.items = remaining;
 
 		if (foundItem.onRemoved) foundItem.onRemoved(self);
 

--- a/packages/engine/src/events/index.ts
+++ b/packages/engine/src/events/index.ts
@@ -1,2 +1,2 @@
-export { RoomEventBus } from './room-event-bus.js';
+export { RoomEventBus, PROMPT_CANCELLED, PromptCancelledError } from './room-event-bus.js';
 export type { GameEvent, EventType, EventScope, EventSubscriber, EventsSinceResult } from './types.js';

--- a/packages/engine/src/events/room-event-bus.test.ts
+++ b/packages/engine/src/events/room-event-bus.test.ts
@@ -212,11 +212,25 @@ describe('RoomEventBus getEventsSince', () => {
 		expect(r.upToDate).to.equal(true);
 	});
 
-	it('does not mark truncated when the buffer is empty (fresh bus)', () => {
+	it('requests durable-storage fallback when the buffer is empty (cold bus)', () => {
+		// A cold buffer means the room was reloaded after a restart/eviction. The
+		// cursor is unresolvable from memory, so callers must consult the DB rather
+		// than silently replaying nothing.
 		const bus = new RoomEventBus(ROOM_ID);
 		const r = bus.getEventsSince('any-cursor');
 		expect(r.events).to.have.length(0);
-		expect(r.truncated).to.equal(false);
+		expect(r.truncated).to.equal(true);
 		expect(r.upToDate).to.equal(false);
+		expect(r.status).to.equal('cold');
+	});
+
+	it('reports status for each cursor resolution outcome', () => {
+		const bus = new RoomEventBus(ROOM_ID);
+		const a = bus.publish({ type: 'announce', scope: 'public', text: 'a', payload: {} });
+		bus.publish({ type: 'announce', scope: 'public', text: 'b', payload: {} });
+
+		expect(bus.getEventsSince(a.id).status).to.equal('found');
+		expect(bus.getEventsSince('9999999999999-zzzzzzzz').status).to.equal('ahead');
+		expect(bus.getEventsSince('1-aaaaaaaa').status).to.equal('evicted');
 	});
 });

--- a/packages/engine/src/events/room-event-bus.ts
+++ b/packages/engine/src/events/room-event-bus.ts
@@ -84,11 +84,21 @@ export class RoomEventBus {
 	getEventsSince(eventId: string): EventsSinceResult {
 		const idx = this.eventLog.findIndex(e => e.id === eventId);
 		if (idx !== -1) {
-			return { events: this.eventLog.slice(idx + 1), truncated: false, upToDate: false };
+			return {
+				events: this.eventLog.slice(idx + 1),
+				truncated: false,
+				upToDate: false,
+				status: 'found',
+			};
 		}
-		// Fresh room after restart (or no events yet): do not treat as buffer truncation.
+		// Cold buffer: the room was loaded fresh (server restart or idle eviction),
+		// so memory cannot resolve the cursor. Callers must consult durable storage —
+		// returning `truncated: false` here silently dropped every reconnect replay
+		// across a restart, which is the single most common way to "return and see
+		// nothing". `status` lets callers skip the gap warning when storage is empty,
+		// since an idle room is exactly why it was evicted in the first place.
 		if (this.eventLog.length === 0) {
-			return { events: [], truncated: false, upToDate: false };
+			return { events: [], truncated: true, upToDate: false, status: 'cold' };
 		}
 		const parseTs = (id: string): number => {
 			const dash = id.indexOf('-');
@@ -100,13 +110,13 @@ export class RoomEventBus {
 		const newest = this.eventLog[this.eventLog.length - 1]!;
 		const cursorTs = parseTs(eventId);
 		if (cursorTs > parseTs(newest.id)) {
-			return { events: [], truncated: false, upToDate: true };
+			return { events: [], truncated: false, upToDate: true, status: 'ahead' };
 		}
 		if (cursorTs < parseTs(oldest.id)) {
-			return { events: [], truncated: true, upToDate: false };
+			return { events: [], truncated: true, upToDate: false, status: 'evicted' };
 		}
 		// Missing id whose timestamp falls inside the retained window — treat as eviction.
-		return { events: [], truncated: true, upToDate: false };
+		return { events: [], truncated: true, upToDate: false, status: 'evicted' };
 	}
 
 	getRecentEvents(count: number): GameEvent[] {

--- a/packages/engine/src/events/room-event-bus.ts
+++ b/packages/engine/src/events/room-event-bus.ts
@@ -4,6 +4,22 @@ import type { GameEvent, EventSubscriber, EventScope, EventType, EventsSinceResu
 
 const RING_BUFFER_SIZE = 200;
 
+/**
+ * Sentinel answer used to resolve a pending prompt when the user cancels the
+ * flow. Consumers (connector channel wrappers, choice helpers) must translate
+ * this into a `PromptCancelledError` so it never leaks into game flows as a
+ * literal answer string.
+ */
+export const PROMPT_CANCELLED = '__cancelled__';
+
+/** Thrown by channel wrappers when the user cancels an interactive flow. */
+export class PromptCancelledError extends Error {
+	constructor(message = 'Prompt cancelled by user') {
+		super(message);
+		this.name = 'PromptCancelledError';
+	}
+}
+
 type PublishInput = {
 	type: EventType;
 	scope: EventScope;
@@ -169,7 +185,7 @@ export class RoomEventBus {
 					text: 'Action cancelled.',
 					payload: { requestId },
 				});
-				pending.resolve('__cancelled__');
+				pending.resolve(PROMPT_CANCELLED);
 			}
 		}
 	}
@@ -187,7 +203,7 @@ export class RoomEventBus {
 				text: 'Action cancelled.',
 				payload: { requestId },
 			});
-			pending.resolve('__cancelled__');
+			pending.resolve(PROMPT_CANCELLED);
 		}
 	}
 

--- a/packages/engine/src/events/types.ts
+++ b/packages/engine/src/events/types.ts
@@ -48,14 +48,31 @@ export interface EventSubscriber {
 	deliver: (event: GameEvent) => void;
 }
 
+/**
+ * How a replay cursor resolved against the in-memory ring buffer.
+ *
+ * - `found`   — cursor is in the buffer; `events` holds everything after it.
+ * - `ahead`   — cursor is newer than the buffer tail; the client is caught up.
+ * - `evicted` — cursor fell out of the 200-event buffer while the room stayed
+ *               loaded. Real events almost certainly happened in the gap, so an
+ *               empty durable-storage result should be surfaced to the user.
+ * - `cold`    — the buffer is empty because the room was (re)loaded from scratch
+ *               after a server restart or idle eviction. Durable storage is the
+ *               only source of truth; an empty result there is the normal case
+ *               (the room was idle) and must NOT be reported as a gap.
+ */
+export type EventsSinceStatus = 'found' | 'ahead' | 'evicted' | 'cold';
+
 /** Result of resolving missed events relative to an in-memory ring buffer cursor. */
 export interface EventsSinceResult {
 	events: GameEvent[];
-	/** `lastEventId` was evicted from the buffer — callers should fall back to durable storage. */
+	/** Cursor is unresolvable from memory — callers MUST fall back to durable storage. */
 	truncated: boolean;
 	/**
 	 * Cursor is newer than anything still in the buffer (client already caught up).
 	 * When true with an empty `events` array, this is not a truncation miss.
 	 */
 	upToDate: boolean;
+	/** Precise reason, for deciding whether an empty replay is worth warning about. */
+	status: EventsSinceStatus;
 }

--- a/packages/engine/src/game.test.ts
+++ b/packages/engine/src/game.test.ts
@@ -9,6 +9,10 @@ import Ring from './ring/index.js';
 import { RoomEventBus } from './events/index.js';
 import { engineReady } from './helpers/engine-ready.js';
 import { globalSemaphore } from './helpers/semaphore.js';
+import { XP_PER_VICTORY, XP_PER_DEFEAT } from './helpers/experience.js';
+import { COINS_PER_VICTORY, COINS_PER_DEFEAT } from './constants/coins.js';
+import Basilisk from './monsters/basilisk.js';
+import Beastmaster from './characters/beastmaster.js';
 
 describe('game.ts', () => {
 	afterEach(() => {
@@ -155,6 +159,111 @@ describe('game.ts', () => {
 		} finally {
 			roomA.dispose();
 			roomB.dispose();
+		}
+	});
+
+	it('does not double-award XP, coins, or a card drop from another room\'s win (creature.win cross-room leakage)', () => {
+		// Regression: Game.initializeEvents() bound handleWinner/handleLoser/
+		// handlePermaDeath/handleFled directly to `creature.*` — the ONLY
+		// creature.* listeners in the engine that skipped the room-scoping guard
+		// applied everywhere else in announcements/index.ts. Every loaded Game
+		// instance shares one process-wide semaphore for these events, so a single
+		// win anywhere used to grant its reward once per currently-loaded room.
+		//
+		// Basilisk/Beastmaster are imported statically (module top-level) here
+		// rather than via dynamic import(): under this test runner's on-the-fly TS
+		// transform, a dynamically-imported class's own module graph is a
+		// SEPARATE instance from one reached via a static import, so its BaseClass
+		// methods bind to a different (duplicate) globalSemaphore EventEmitter
+		// than Game's listeners are registered on — the emitted event would
+		// never reach them at all. That split is a test-tooling artifact of
+		// mixing static and dynamic ESM imports of the same file within one
+		// process, not something that can happen in the real compiled build.
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+
+		try {
+			const monster = new Basilisk({ name: 'Winner' });
+			const character = new Beastmaster({ name: 'Room A Trainer' });
+			character.addMonster(monster);
+			roomA.characters = { ...roomA.characters, 'room-a-user': character };
+
+			const xpBefore = character.xp;
+			const coinsBefore = character.coins;
+			const deckLengthBefore = character.deck.length;
+
+			const contestant = { character, monster, userId: 'room-a-user' };
+			monster.emit('win', { contestant });
+
+			expect(character.xp).to.equal(xpBefore + XP_PER_VICTORY);
+			expect(character.coins).to.equal(coinsBefore + COINS_PER_VICTORY);
+			expect(character.deck.length).to.equal(deckLengthBefore + 1);
+		} finally {
+			roomA.dispose();
+			roomB.dispose();
+		}
+	});
+
+	it('awards the permaDeath consolation reward exactly once, scoped to the owning room', () => {
+		// Regression, two bugs in one: (1) Ring.handlePermaDeath never called
+		// `contestant.monster.emit('permaDeath', ...)` like its win/loss/fled
+		// siblings do, so Game.handlePermaDeath's listener never fired at all —
+		// a permanently destroyed monster granted its owner no reward whatsoever.
+		// (2) once reachable, the same cross-room leakage as the win test above
+		// would double-award it per loaded room without the guard.
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+
+		try {
+			const monster = new Basilisk({ name: 'Destroyed' });
+			const character = new Beastmaster({ name: 'Room A Trainer' });
+			character.addMonster(monster);
+			roomA.characters = { ...roomA.characters, 'room-a-user': character };
+
+			const xpBefore = character.xp;
+			const coinsBefore = character.coins;
+
+			const contestant = { character, monster, userId: 'room-a-user' };
+			monster.emit('permaDeath', { contestant });
+
+			expect(character.xp).to.equal(xpBefore + XP_PER_DEFEAT * 2);
+			expect(character.coins).to.equal(coinsBefore + COINS_PER_DEFEAT * 2);
+		} finally {
+			roomA.dispose();
+			roomB.dispose();
+		}
+	});
+
+	it('does not let another room\'s activity reset this room\'s save debounce timer', () => {
+		// Regression: setOptions() broadcast `stateChange` on the process-wide
+		// globalSemaphore with zero arguments, so Game's listener (also bound on
+		// globalSemaphore) could not tell which room changed and rescheduled its
+		// own save on every mutation anywhere in the process. On a busy multi-room
+		// server this could keep resetting a quiet room's debounce indefinitely.
+		const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		const roomA = new Game({ roomId: 'room-a' });
+		const roomB = new Game({ roomId: 'room-b' });
+		const saveA = sinon.stub();
+
+		try {
+			roomA.saveState = saveA;
+
+			roomA.emit('stateChange'); // schedules room A's save for t=30s
+
+			// Room B mutates state every second for 25 seconds — if this leaked
+			// across rooms it would keep resetting room A's 30s debounce timer.
+			for (let i = 0; i < 25; i += 1) {
+				clock.tick(1_000);
+				roomB.emit('stateChange');
+			}
+
+			clock.tick(6_000); // t=31s: room A's own t=0 change should have flushed
+			expect(saveA.calledOnce).to.equal(true);
+		} finally {
+			roomA.saveState = undefined;
+			roomB.dispose();
+			roomA.dispose();
+			clock.restore();
 		}
 	});
 
@@ -354,6 +463,34 @@ describe('game.ts', () => {
 			const char2 = await game.getCharacter({ channel, id: 'user-2', name: 'RealName' });
 			// 'Custom Hero' !== 'Player', so no override should happen
 			expect((char2 as any).givenName).to.equal('Custom Hero'); // unchanged
+		});
+
+		it('emits stateChange when a brand-new character is created, so a save is scheduled', async () => {
+			// Regression: `game.characters[id] = character` is a direct mutation of
+			// the options-backed characters map, bypassing setOptions() — no
+			// stateChange fired from the assignment itself. The new character's own
+			// constructor does emit a global stateChange, but at that point it isn't
+			// in game.characters yet, so the room-scoped guard (added alongside this
+			// fix) would not attribute it to this game either way. Without the
+			// explicit emit added to getCharacter, a freshly created character could
+			// be silently lost if the server restarted before anything else in the
+			// room changed.
+			const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+			const game = new Game();
+			const saveStateStub = sinon.stub();
+			const channel = sinon.stub().resolves('0');
+
+			try {
+				game.saveState = saveStateStub;
+
+				await game.getCharacter({ channel, id: 'user-3', name: 'Player' });
+
+				clock.tick(31_000);
+				expect(saveStateStub.calledOnce).to.equal(true);
+			} finally {
+				game.saveState = undefined;
+				clock.restore();
+			}
 		});
 	});
 });

--- a/packages/engine/src/game.ts
+++ b/packages/engine/src/game.ts
@@ -10,7 +10,7 @@ import { globalSemaphore } from './helpers/semaphore.js';
 import { listen, loadHandlers } from './commands/index.js';
 import { sortByXP } from './helpers/sort.js';
 import { XP_PER_VICTORY, XP_PER_DEFEAT } from './helpers/experience.js';
-import { initialize as initializeAnnouncements } from './announcements/index.js';
+import { initialize as initializeAnnouncements, createRoomScopedEventGuard } from './announcements/index.js';
 import { BaseClass } from './shared/baseClass.js';
 import cardOdds from './card-odds.json' with { type: 'json' };
 import { dungeonMasterGuide } from './build/dungeon-master-guide.js';
@@ -198,11 +198,34 @@ export class Game extends BaseClass {
 	initializeEvents(): void {
 		const disposeAnnouncements = initializeAnnouncements(this);
 
-		const boundWin = this.on('creature.win', this.handleWinner.bind(this));
-		const boundLoss = this.on('creature.loss', this.handleLoser.bind(this));
-		const boundPermaDeath = this.on('creature.permaDeath', this.handlePermaDeath.bind(this));
-		const boundFled = this.on('creature.fled', this.handleFled.bind(this));
-		const boundStateChange = this.on('stateChange', () => this.scheduleSave());
+		// `creature.win` / `creature.loss` / `creature.permaDeath` / `creature.fled`
+		// and `stateChange` are all broadcast on the process-wide globalSemaphore
+		// (see BaseClass.emit / setOptions) — not scoped to any one room. Without
+		// this guard, one room's fight outcome would double-award XP/coins/card
+		// drops on every OTHER loaded Game instance's identical listener (this was
+		// a real, previously-unguarded bug: reward-granting handlers here were the
+		// only creature.* listeners in the engine that skipped the room-scoping
+		// applied everywhere else in announcements/index.ts), and any unrelated
+		// room's state change would reset every other room's save debounce timer.
+		const isRoomScopedEvent = createRoomScopedEventGuard(this);
+		const wrapGameEvent =
+			<F extends (...args: any[]) => void>(fn: F): F =>
+				((...args: any[]) => {
+					if (!isRoomScopedEvent(...args)) return;
+					fn(...args);
+				}) as F;
+
+		const boundWin = this.on('creature.win', wrapGameEvent(this.handleWinner.bind(this)));
+		const boundLoss = this.on('creature.loss', wrapGameEvent(this.handleLoser.bind(this)));
+		const boundPermaDeath = this.on(
+			'creature.permaDeath',
+			wrapGameEvent(this.handlePermaDeath.bind(this))
+		);
+		const boundFled = this.on('creature.fled', wrapGameEvent(this.handleFled.bind(this)));
+		const boundStateChange = this.on(
+			'stateChange',
+			wrapGameEvent(() => this.scheduleSave())
+		);
 
 		this._disposeListeners = [
 			disposeAnnouncements,
@@ -338,6 +361,15 @@ export class Game extends BaseClass {
 				}).then((character: any) => {
 					game.characters[id] = character;
 
+					// Direct mutation of the options-backed characters map: bypasses
+					// setOptions(), so no `stateChange` fires from this assignment alone.
+					// The new character's own constructor already triggers a `stateChange`
+					// globally, but at that point it isn't in `game.characters` yet, so
+					// the room-scoped guard added above would not attribute it to this
+					// game — without this explicit emit, a freshly created character
+					// could be silently lost if the server restarts before any other
+					// state in this room changes.
+					game.emit('stateChange');
 					game.emit('characterCreated', { character });
 
 					return character;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -5,10 +5,10 @@ import { gameStateSchema } from './schemas/state.js';
 import Game from './game.js';
 import type { ChannelCallback } from './channel/index.js';
 import { ConnectorAdapter } from './channel/index.js';
-import { RoomEventBus } from './events/index.js';
+import { RoomEventBus, PROMPT_CANCELLED, PromptCancelledError } from './events/index.js';
 import type { GameEvent, EventType, EventScope, EventSubscriber, EventsSinceResult } from './events/index.js';
 
-export { Game, ConnectorAdapter, RoomEventBus };
+export { Game, ConnectorAdapter, RoomEventBus, PROMPT_CANCELLED, PromptCancelledError };
 export type { GameAnalyticsCallbacks, LeaderboardSortKey } from './game.js';
 export type { ChannelCallback, GameEvent, EventType, EventScope, EventSubscriber, EventsSinceResult };
 export type { StateStore } from './types/state-store.js';

--- a/packages/engine/src/items/helpers/choose.test.ts
+++ b/packages/engine/src/items/helpers/choose.test.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 import { helpersReady } from '../../characters/helpers/random.js';
 import { chooseItems } from './choose.js';
+// Static import — a dynamic `await import()` here can resolve to a duplicate
+// module instance under the tsx test transform, breaking `instanceof` against
+// the class choose.ts itself uses. See the test-tooling note in bug doc #26's
+// "Smaller observations" section.
+import { PROMPT_CANCELLED, PromptCancelledError } from '../../events/index.js';
 
 describe('chooseItems passes structured choices to channel', () => {
 	before(async () => {
@@ -30,5 +35,85 @@ describe('chooseItems passes structured choices to channel', () => {
 		const promptCall = channelCalls.find(c => c.choices !== undefined);
 		expect(promptCall, 'channel should be called with a choices array').to.exist;
 		expect(promptCall!.choices).to.be.an('array').with.length.greaterThan(0);
+	});
+});
+
+describe('chooseItems answer parsing', () => {
+	type FakeItem = { itemType: string; cost: number };
+
+	const makeItems = (): FakeItem[] => [
+		{ itemType: 'Potion', cost: 5 },
+		{ itemType: 'Potion', cost: 5 },
+		{ itemType: 'Scroll', cost: 10 },
+	];
+
+	/**
+	 * Channel double: answers the first `question` with `answer`, records every
+	 * `announce` for assertions.
+	 */
+	const makeChannel = (answer: unknown) => {
+		const announcements: string[] = [];
+		const channel = (opts: { question?: string; announce?: string }): Promise<unknown> => {
+			if (opts.question) return Promise.resolve(answer);
+			if (opts.announce) announcements.push(opts.announce);
+			return Promise.resolve();
+		};
+		return { channel, announcements };
+	};
+
+	it('selects by displayed numeric index', async () => {
+		const { channel } = makeChannel('0');
+		const selected = await chooseItems({ items: makeItems(), channel } as never);
+
+		expect(selected).to.have.length(1);
+		expect((selected[0] as FakeItem).itemType).to.equal('Potion');
+	});
+
+	it('selects by item name, case-insensitively', async () => {
+		const { channel } = makeChannel('scroll');
+		const selected = await chooseItems({ items: makeItems(), channel } as never);
+
+		expect(selected).to.have.length(1);
+		expect((selected[0] as FakeItem).itemType).to.equal('Scroll');
+	});
+
+	it('selects multiple copies by repeating the same token', async () => {
+		const { channel } = makeChannel('0, 0');
+		const selected = await chooseItems({ items: makeItems(), channel } as never);
+
+		expect(selected).to.have.length(2);
+		expect(selected.every((item) => (item as FakeItem).itemType === 'Potion')).to.equal(true);
+	});
+
+	it('skips invalid tokens with a notice instead of aborting the whole selection', async () => {
+		// Regression (bug doc #20): an unrecognized token used to reject the
+		// entire flow via Promise.reject(channel(...)), aborting a multi-step
+		// command on a single typo — and logging '[object Promise]' to boot.
+		const { channel, announcements } = makeChannel('Potion, Bad Name');
+		const selected = await chooseItems({ items: makeItems(), channel } as never);
+
+		expect(selected).to.have.length(1);
+		expect((selected[0] as FakeItem).itemType).to.equal('Potion');
+		expect(announcements.some((text) => text.includes('Bad Name'))).to.equal(true);
+	});
+
+	it('returns an empty selection (not a rejection) when nothing valid was chosen', async () => {
+		const { channel, announcements } = makeChannel('Nonsense');
+		const selected = await chooseItems({ items: makeItems(), channel } as never);
+
+		expect(selected).to.have.length(0);
+		expect(announcements.some((text) => text.includes('no items'))).to.equal(true);
+	});
+
+	it('throws PromptCancelledError when the answer is the cancel sentinel', async () => {
+		// Regression (bug doc #20): cancelling a flow resolves the pending prompt
+		// with PROMPT_CANCELLED; before this guard the literal sentinel string was
+		// parsed as a selection.
+		const { channel } = makeChannel(PROMPT_CANCELLED);
+
+		const err = await chooseItems({ items: makeItems(), channel } as never).catch(
+			(e: unknown) => e
+		);
+		expect(err).to.be.instanceOf(PromptCancelledError);
 	});
 });

--- a/packages/engine/src/items/helpers/choose.ts
+++ b/packages/engine/src/items/helpers/choose.ts
@@ -1,6 +1,6 @@
 import { getItemChoices, getItemChoicesWithPrice, getFinalItemChoices } from '../../helpers/choices.js';
 import { getArray } from '../../helpers/get-array.js';
-import { reduceSeries } from '../../helpers/promise.js';
+import { PROMPT_CANCELLED, PromptCancelledError } from '../../events/index.js';
 
 import { getItemCounts, getItemCountsWithPrice, getItemKey } from './counts.js';
 
@@ -46,31 +46,60 @@ const chooseItems = ({
 			choices: Object.keys(itemCatalog),
 		}))
 		.then((answer: unknown) => {
-			const selectedItemIndexes = getArray(answer) ?? [];
+			// A cancelled flow resolves the prompt with a sentinel — abort cleanly
+			// instead of treating it as a selection.
+			if (answer === PROMPT_CANCELLED) {
+				throw new PromptCancelledError();
+			}
+
+			const selectedTokens = getArray(answer) ?? [];
+			const catalogKeys = Object.keys(itemCatalog);
 			const remainingItems = [...items];
+			const selectedItems: any[] = [];
+			const invalidTokens: string[] = [];
 
-			return reduceSeries(selectedItemIndexes, (selection: any[], index: string) => {
-				const itemType = Object.keys(itemCatalog)[Number(index)];
-				const itemIndex = remainingItems.findIndex(
-					(potentialItem: any) => getItemKey(potentialItem) === itemType
-				);
+			// Selections may be the displayed numeric indices or the item names
+			// themselves (case-insensitive). Invalid entries are skipped with a
+			// notice rather than aborting the whole flow.
+			selectedTokens.forEach((token: unknown) => {
+				const trimmed = String(token).trim();
+				if (!trimmed) return;
 
-				if (itemIndex >= 0) {
-					const selectedItem = remainingItems.splice(itemIndex, 1)[0];
-					selection.push(selectedItem);
-				} else {
-					return Promise.reject(channel({
-						announce: `Invalid selection: ${itemType || index}`
-					}));
+				let itemType: string | undefined = /^\d+$/.test(trimmed)
+					? catalogKeys[Number(trimmed)]
+					: undefined;
+				if (itemType === undefined) {
+					itemType = catalogKeys.find(key => key.toLowerCase() === trimmed.toLowerCase());
 				}
 
-				return selection;
-			}, [])
-				.then((selectedItems: any[]) =>
+				const itemIndex = itemType === undefined
+					? -1
+					: remainingItems.findIndex(
+						(potentialItem: any) => getItemKey(potentialItem) === itemType
+					);
+
+				if (itemIndex >= 0) {
+					selectedItems.push(remainingItems.splice(itemIndex, 1)[0]);
+				} else {
+					invalidTokens.push(trimmed);
+				}
+			});
+
+			return Promise.resolve()
+				.then(() => {
+					if (invalidTokens.length > 0) {
+						return channel({
+							announce: `Skipped ${invalidTokens.length > 1 ? 'invalid selections' : 'an invalid selection'}: ${invalidTokens.join(', ')}`
+						});
+					}
+					return undefined;
+				})
+				.then(() =>
 					channel({
 						announce: getResult({ selectedItems })
-					}).then(() => selectedItems)
-				);
+					})
+				)
+				.then(() => selectedItems);
 		});
 };
 

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -547,6 +547,42 @@ describe('ring/index.ts', () => {
 			expect(caughtError, 'fight() should not throw').to.be.undefined;
 		});
 
+		it('runs a full fight through the real (non-skipped) pacing path', async function () {
+			// Regression (bug doc #20): the normal card-play path used to pace with
+			// subEventDelay instead of the configured veryShortDelay, and — because
+			// the whole test suite runs with DECK_MONSTERS_SKIP_DELAYS=1 — the
+			// non-skip branches had zero coverage, so the wrong delay call could not
+			// be caught by any test. This exercises the real timer path end to end
+			// with midpoints shrunk to a few milliseconds so it stays fast.
+			this.timeout(10_000);
+
+			const prevSkip = process.env.DECK_MONSTERS_SKIP_DELAYS;
+			delete process.env.DECK_MONSTERS_SKIP_DELAYS;
+			process.env.DECK_MONSTERS_VERY_SHORT_DELAY_MIDPOINT_MS = '3';
+			process.env.DECK_MONSTERS_SHORT_DELAY_MIDPOINT_MS = '3';
+			process.env.DECK_MONSTERS_SUB_EVENT_DELAY_MIDPOINT_MS = '2';
+
+			const game = new Game();
+			try {
+				const ring = game.getRing();
+
+				ring.addMonster(randomContestant({ isBoss: false, battles: { total: 5, wins: 3, losses: 2 } }));
+				ring.addMonster(randomContestant({ isBoss: false, battles: { total: 5, wins: 3, losses: 2 } }));
+
+				await ring.fight();
+
+				// A completed fight clears the ring and ends the encounter.
+				expect(ring.inEncounter).to.equal(false);
+				expect(ring.contestants.length).to.equal(0);
+			} finally {
+				process.env.DECK_MONSTERS_SKIP_DELAYS = prevSkip;
+				delete process.env.DECK_MONSTERS_VERY_SHORT_DELAY_MIDPOINT_MS;
+				delete process.env.DECK_MONSTERS_SHORT_DELAY_MIDPOINT_MS;
+				delete process.env.DECK_MONSTERS_SUB_EVENT_DELAY_MIDPOINT_MS;
+				game.dispose();
+			}
+		});
+
 		it('cards on monsters spawned via randomContestant all have play() methods', () => {
 			const contestant = randomContestant({ isBoss: false });
 

--- a/packages/engine/src/ring/index.test.ts
+++ b/packages/engine/src/ring/index.test.ts
@@ -67,6 +67,37 @@ describe('ring/index.ts', () => {
 				.then(() => expect(ring.monsterIsInRing(monster)).to.equal(false));
 		});
 
+		it('removes one of several contestants via the setter, not an in-place splice', () => {
+			// Regression: removeMonster used to `.splice()` the array returned by the
+			// `contestants` getter directly, so partial removals (ring not emptied)
+			// never went through `setOptions()` and so never emitted `stateChange` —
+			// a monster withdrawn from a still-populated ring could still be listed in
+			// the last-persisted ringContestantRefs and get resurrected on restart.
+			const game = new Game();
+			const ring = game.getRing();
+
+			const character1 = new Beastmaster();
+			const monster1 = new Basilisk();
+			character1.addMonster(monster1);
+			const character2 = new Beastmaster();
+			const monster2 = new Basilisk();
+			character2.addMonster(monster2);
+
+			ring.addMonster({ monster: monster1, character: character1, userId: 'user-1' });
+			ring.addMonster({ monster: monster2, character: character2, userId: 'user-2' });
+			expect(ring.contestants.length).to.equal(2);
+
+			const contestantsBeforeRemoval = ring.contestants;
+
+			return ring
+				.removeMonster({ monster: monster1, character: character1, userId: 'user-1' })
+				.then(() => {
+					expect(ring.contestants.length).to.equal(1);
+					expect(ring.contestants).to.not.equal(contestantsBeforeRemoval);
+					expect(ring.monsterIsInRing(monster2)).to.equal(true);
+				});
+		});
+
 		it('cannot be removed while an encounter is in progress', async () => {
 			const game = new Game();
 			const ring = game.getRing();
@@ -111,6 +142,44 @@ describe('ring/index.ts', () => {
 			return ring.removeBoss(contestant).then(() =>
 				expect(ring.contestants.length).to.equal(0)
 			);
+		});
+
+		it('cancels pending boss despawn timers on dispose', () => {
+			// Regression: the despawn setTimeout scheduled in spawnBoss() was never
+			// stored anywhere, so Ring.dispose() could not cancel it — an orphaned
+			// timer would fire against an already-disposed ring after the room
+			// unloaded.
+			//
+			// spawnBoss() only schedules a despawn timer on a 50/50 coin flip
+			// (`random(1)`), so we retry rather than pinning Math.random — pinning it
+			// globally breaks the recursive probability-retry loop in
+			// cards/helpers/draw.ts (`if (!Card) return draw(...)`), which never
+			// terminates once every card's probability check returns the same fixed
+			// result. clearRing() between attempts doesn't touch bossDespawnTimers
+			// (only dispose() does), so any attempt landing heads is enough — the
+			// ~2^-50 chance every one of 50 flips misses is negligible.
+			const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+			try {
+				const game = new Game();
+				const ring = game.getRing();
+				const removeBossSpy = sinon.spy(ring, 'removeBoss');
+
+				for (let attempt = 0; attempt < 50; attempt += 1) {
+					ring.clearRing();
+					ring.spawnBoss();
+				}
+				expect((ring as any).bossDespawnTimers.size).to.be.greaterThan(0);
+
+				game.dispose();
+
+				// Well past BOSS_DESPAWN_DELAY_MS (10 minutes) — if any timer survived
+				// dispose(), removeBoss would fire here.
+				clock.tick(11 * 60 * 1000);
+
+				expect(removeBossSpy.called).to.equal(false);
+			} finally {
+				clock.restore();
+			}
 		});
 
 		it('will not spawn a boss if an encounter is in progress', () => {
@@ -308,6 +377,30 @@ describe('ring/index.ts', () => {
 			expect(midBoss).to.not.be.undefined;
 			expect(midBoss!.monster.level).to.be.at.most(3);
 			capThreeStub.restore();
+		});
+	});
+
+	describe('outcome handlers', () => {
+		it('handlePermaDeath emits creature.permaDeath on the monster, like its win/loss/fled siblings', () => {
+			// Regression: handlePermaDeath was missing the `contestant.monster.emit(...)`
+			// call that handleWinner/handleLoser/handleFled all have. Game listens for
+			// the global `creature.permaDeath` broadcast (via BaseClass.emit's
+			// `${eventPrefix}.${event}` convention) to award the permaDeath consolation
+			// XP/coins — without this emit, that listener never fired, so a
+			// permanently destroyed monster granted its owner no reward at all.
+			const game = new Game();
+			const ring = game.getRing();
+
+			const character = new Beastmaster();
+			const monster = new Basilisk();
+			character.addMonster(monster);
+
+			const emitSpy = sinon.spy(monster, 'emit');
+			const contestant = { character, monster, userId: 'user-1' };
+
+			ring.handlePermaDeath({ contestant });
+
+			expect(emitSpy.calledWith('permaDeath', { contestant })).to.equal(true);
 		});
 	});
 

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -652,9 +652,12 @@ export class Ring extends BaseClass {
 							if (delaysAreSkipped()) {
 								return subEventDelay().then(() => next());
 							}
-							return new Promise<void>(r => setTimeout(r, 0))
-								.then(() => subEventDelay())
-								.then(() => next());
+							// Pace card-to-card transitions with the configured very-short
+							// delay (2–4s) so live feeds can be followed; sub-events within
+							// a card already pace themselves via subEventDelay().
+							return new Promise<void>(r => setTimeout(r, veryShortDelay(round))).then(() =>
+								next()
+							);
 						}
 
 						return Promise.resolve().then(() => resolve(playerContestant));

--- a/packages/engine/src/ring/index.ts
+++ b/packages/engine/src/ring/index.ts
@@ -86,6 +86,8 @@ export class Ring extends BaseClass {
 	encounter?: Record<string, any>;
 	fightTimer?: ReturnType<typeof setTimeout>;
 	bossTimer?: ReturnType<typeof setTimeout>;
+	/** Pending per-boss despawn timers, so `dispose()` can cancel all of them. */
+	private readonly bossDespawnTimers = new Set<ReturnType<typeof setTimeout>>();
 	/** Epoch ms when the next boss will enter the ring (including the 2-min announcement window), or null if no timer is running. */
 	nextBossSpawnAt: number | null = null;
 	/** Epoch ms when the next fight will start, or null if no fight timer is active. */
@@ -230,9 +232,15 @@ export class Ring extends BaseClass {
 				return contestant;
 			})
 			.then((contestant: Contestant) => {
-				const contestantIndex = this.contestants.indexOf(contestant);
-
-				this.contestants.splice(contestantIndex, 1);
+				// Go through the `contestants` setter (setOptions) rather than mutating
+				// the live array in place: an in-place splice never emits `stateChange`,
+				// so a monster withdrawn without any other room activity afterward could
+				// still be listed in the last-persisted `ringContestantRefs` and get
+				// re-hydrated back into the ring on the next restart.
+				const updated = [...this.contestants];
+				const contestantIndex = updated.indexOf(contestant);
+				updated.splice(contestantIndex, 1);
+				this.contestants = updated;
 
 				if (this.contestants.length < 1) {
 					this.clearRing();
@@ -456,6 +464,10 @@ export class Ring extends BaseClass {
 	dispose(): void {
 		clearTimeout(this.fightTimer);
 		clearTimeout(this.bossTimer);
+		for (const timer of this.bossDespawnTimers) {
+			clearTimeout(timer);
+		}
+		this.bossDespawnTimers.clear();
 		this.fightTimer = undefined;
 		this.bossTimer = undefined;
 		this.nextFightAt = null;
@@ -940,6 +952,13 @@ export class Ring extends BaseClass {
 		contestant.character.dropMonster(contestant.monster);
 		contestant.character.addLoss();
 		this.emit('permaDeath', { contestant });
+		// Unlike the win/loss/fled siblings above, this call was previously missing —
+		// Game.initializeEvents() listens for the global `creature.permaDeath`
+		// broadcast (emitted via BaseClass.emit's `${eventPrefix}.${event}` naming) to
+		// award the player's permaDeath consolation XP/coins in Game.handlePermaDeath.
+		// Without this line that listener never fired, so a permanently destroyed
+		// monster granted its owner no reward at all — not even a normal loss amount.
+		contestant.monster.emit('permaDeath', { contestant });
 	}
 
 	handleTied({ contestant }: { contestant: Contestant }): void {
@@ -1069,9 +1088,14 @@ export class Ring extends BaseClass {
 
 			if (random(1)) {
 				const ring = this;
-				setTimeout(() => {
-					ring.removeBoss(contestant);
+				const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+					ring.bossDespawnTimers.delete(timer);
+					// removeMonster() (called via removeBoss) rejects if the boss is no
+					// longer in the ring (e.g. the ring was cleared by a fight) — that is
+					// expected here since this timer isn't cancelled on clearRing().
+					ring.removeBoss(contestant).catch(() => {});
 				}, BOSS_DESPAWN_DELAY_MS);
+				this.bossDespawnTimers.add(timer);
 			}
 
 			return contestant;

--- a/packages/engine/src/shared/baseClass.ts
+++ b/packages/engine/src/shared/baseClass.ts
@@ -82,7 +82,13 @@ export class BaseClass<TOptions extends BaseClassOptions = BaseClassOptions> {
 		this.optionsStore = optionsStore;
 
 		this.emit('updated');
-		globalSemaphore.emit('stateChange');
+		// Broadcast globally (not via `this.emit`, which would only reach same-prefix
+		// listeners) so any BaseClass instance's mutation can trigger a save on its
+		// owning Game — nested creature/card/item state has no other way to signal
+		// "the enclosing game needs a save". Pass `this` so room-scoped listeners
+		// (see Game.initializeEvents / createRoomScopedEventGuard) can tell whether
+		// this particular mutation belongs to them before reacting to it.
+		globalSemaphore.emit('stateChange', this);
 	}
 
 	emit(event: string, ...args: unknown[]): void {

--- a/packages/server/src/analytics-queries.ts
+++ b/packages/server/src/analytics-queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, lte, lt, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, lte, lt, sql } from 'drizzle-orm';
 
 import type { Db } from './db/index.js';
 import {

--- a/packages/server/src/event-persister.ts
+++ b/packages/server/src/event-persister.ts
@@ -26,7 +26,14 @@ export function attachEventPersister(
 
 	// Event types that are transient state-sync signals and should not be
 	// persisted to the history table — they have no replay value.
-	const EPHEMERAL_TYPES = new Set(['ring.state', 'handshake', 'system.gap']);
+	// `quick_actions` is included because suggestions describe the game state at
+	// one instant; replaying an old set would surface chips that no longer apply.
+	const EPHEMERAL_TYPES = new Set([
+		'ring.state',
+		'handshake',
+		'system.gap',
+		'quick_actions',
+	]);
 
 	return eventBus.subscribe(subscriberId, {
 		deliver(event: GameEvent) {

--- a/packages/server/src/fight-summary-writer.test.ts
+++ b/packages/server/src/fight-summary-writer.test.ts
@@ -1,0 +1,216 @@
+import { expect } from 'chai';
+
+import { RoomEventBus } from '@deck-monsters/engine';
+import { attachFightSummaryWriter } from './fight-summary-writer.js';
+
+const ROOM_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const USER_UUID = '11111111-2222-3333-4444-555555555555';
+
+type InsertedRow = {
+	roomId: string;
+	startedAt: Date;
+	endedAt: Date;
+	outcome: string;
+	winnerOwnerUserId: string | null;
+	cardDropName: string | null;
+	fightNumber: number;
+};
+
+/**
+ * Minimal Db double for the writer's transaction shape. `failuresRemaining`
+ * makes the next N transactions throw, to exercise the retry path.
+ */
+function makeDb(): { db: unknown; inserted: InsertedRow[]; state: { failuresRemaining: number } } {
+	const inserted: InsertedRow[] = [];
+	const state = { failuresRemaining: 0 };
+	let fightCounter = 0;
+
+	const db = {
+		async transaction(fn: (tx: unknown) => Promise<void>) {
+			if (state.failuresRemaining > 0) {
+				state.failuresRemaining -= 1;
+				throw new Error('simulated db failure');
+			}
+			const tx = {
+				update: () => ({
+					set: () => ({
+						where: () => ({
+							returning: async () => [{ fightCounter: ++fightCounter }],
+						}),
+					}),
+				}),
+				insert: () => ({
+					values: async (row: InsertedRow) => {
+						inserted.push(row);
+					},
+				}),
+			};
+			await fn(tx);
+		},
+	};
+
+	return { db, inserted, state };
+}
+
+/** Poll until `done()` returns true (or ~1s passes) — robust against retry backoff timers. */
+const settle = async (done: () => boolean = () => false): Promise<void> => {
+	for (let i = 0; i < 200; i++) {
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+		if (done()) return;
+	}
+};
+
+const publishFightBegins = (bus: RoomEventBus) =>
+	bus.publish({
+		type: 'ring.fight',
+		scope: 'public',
+		text: 'begins',
+		payload: { eventName: 'fightBegins' },
+	});
+
+const publishFightResolved = (bus: RoomEventBus, outcome = 'win') =>
+	bus.publish({
+		type: 'ring.fightResolved',
+		scope: 'public',
+		text: 'resolved',
+		payload: {
+			rounds: 3,
+			deaths: 1,
+			outcome,
+			participants: [
+				{ monsterId: 'm1', outcome: 'win', xpGained: 12 },
+				{ monsterId: 'm2', outcome: 'loss', xpGained: 3 },
+			],
+			winnerOwnerUserId: USER_UUID,
+			loserOwnerUserId: 'discord-snowflake-123456789',
+		},
+	});
+
+describe('fight summary writer', () => {
+	it('writes a summary with duration from the recorded fight start', async () => {
+		const { db, inserted } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [] });
+
+		const begin = publishFightBegins(bus);
+		bus.publish({
+			type: 'ring.cardDrop',
+			scope: 'public',
+			text: 'drop',
+			payload: { cardDropName: 'Lucky Strike' },
+		});
+		publishFightResolved(bus);
+		await settle(() => inserted.length === 1);
+		detach();
+
+		expect(inserted).to.have.length(1);
+		const row = inserted[0]!;
+		expect(row.startedAt.getTime()).to.equal(begin.timestamp);
+		expect(row.cardDropName).to.equal('Lucky Strike');
+		expect(row.winnerOwnerUserId).to.equal(USER_UUID);
+		expect(row.fightNumber).to.equal(1);
+	});
+
+	it('nulls non-UUID owner ids instead of failing the insert', async () => {
+		const { db, inserted } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [] });
+
+		publishFightBegins(bus);
+		publishFightResolved(bus);
+		await settle(() => inserted.length === 1);
+		detach();
+
+		expect((inserted[0] as unknown as { loserOwnerUserId: string | null }).loserOwnerUserId).to.equal(null);
+	});
+
+	it('keeps each fight paired with its own start when a new fight begins before the write flushes', async () => {
+		// Regression for bug doc #15 path 4: pending was read inside the queued
+		// write, so fight B's begin clobbered A's startedAt and A's cleanup then
+		// deleted B's pending entirely.
+		const { db, inserted, state } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		// One retry so fight A's write is still pending when fight B begins.
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [1] });
+		state.failuresRemaining = 1;
+
+		const beginA = publishFightBegins(bus);
+		publishFightResolved(bus);
+		// Fight B starts while A's write is queued/retrying.
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+		const beginB = publishFightBegins(bus);
+		publishFightResolved(bus);
+		await settle(() => inserted.length === 2);
+		detach();
+
+		expect(inserted).to.have.length(2);
+		expect(inserted[0]!.startedAt.getTime()).to.equal(beginA.timestamp);
+		expect(inserted[1]!.startedAt.getTime()).to.equal(beginB.timestamp);
+	});
+
+	it('retries transient failures and still writes the row', async () => {
+		const { db, inserted, state } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [1, 1] });
+		state.failuresRemaining = 2;
+
+		publishFightBegins(bus);
+		publishFightResolved(bus);
+		await settle(() => inserted.length === 1);
+		detach();
+
+		expect(inserted).to.have.length(1);
+	});
+
+	it('gives up after exhausting retries without throwing into the event bus', async () => {
+		const { db, inserted, state } = makeDb();
+		const errors: unknown[] = [];
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, (err) => errors.push(err), {
+			retryDelaysMs: [1],
+		});
+		state.failuresRemaining = 5;
+
+		publishFightBegins(bus);
+		publishFightResolved(bus);
+		await settle(() => errors.length === 1);
+		detach();
+
+		expect(inserted).to.have.length(0);
+		expect(errors).to.have.length(1);
+	});
+
+	it('writes with zero duration when no fight start was seen (restart mid-fight)', async () => {
+		const { db, inserted } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [] });
+
+		const resolved = publishFightResolved(bus);
+		await settle(() => inserted.length === 1);
+		detach();
+
+		expect(inserted).to.have.length(1);
+		expect(inserted[0]!.startedAt.getTime()).to.equal(resolved.timestamp);
+		expect(inserted[0]!.endedAt.getTime()).to.equal(resolved.timestamp);
+	});
+
+	it('ignores fightConcludes ring.fight events when recording the start time', async () => {
+		const { db, inserted } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [] });
+
+		const begin = publishFightBegins(bus);
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+		bus.publish({
+			type: 'ring.fight',
+			scope: 'public',
+			text: 'concludes',
+			payload: { eventName: 'fightConcludes' },
+		});
+		publishFightResolved(bus);
+		await settle(() => inserted.length === 1);
+		detach();
+
+		expect(inserted[0]!.startedAt.getTime()).to.equal(begin.timestamp);
+	});
+});

--- a/packages/server/src/fight-summary-writer.test.ts
+++ b/packages/server/src/fight-summary-writer.test.ts
@@ -180,6 +180,27 @@ describe('fight summary writer', () => {
 		expect(errors).to.have.length(1);
 	});
 
+	it('detaching cancels a queued retry so no write lands after a room reset', async () => {
+		// Regression (review of #15): resetRoomState() detaches the writer, clears
+		// fight_summaries, and zeroes the fight counter — but a write sitting in
+		// its retry backoff used to survive detach and land afterwards, inserting
+		// a pre-reset fight and incrementing the fresh counter.
+		const { db, inserted, state } = makeDb();
+		const bus = new RoomEventBus(ROOM_ID);
+		const detach = attachFightSummaryWriter(bus, db as never, () => {}, { retryDelaysMs: [50] });
+		state.failuresRemaining = 1; // first attempt fails → 50ms backoff
+
+		publishFightBegins(bus);
+		publishFightResolved(bus);
+		// Let the first attempt fail, then detach during the backoff window.
+		await new Promise<void>((resolve) => setTimeout(resolve, 15));
+		detach();
+		// Wait well past the backoff — the retry must not fire.
+		await new Promise<void>((resolve) => setTimeout(resolve, 120));
+
+		expect(inserted).to.have.length(0);
+	});
+
 	it('writes with zero duration when no fight start was seen (restart mid-fight)', async () => {
 		const { db, inserted } = makeDb();
 		const bus = new RoomEventBus(ROOM_ID);

--- a/packages/server/src/fight-summary-writer.ts
+++ b/packages/server/src/fight-summary-writer.ts
@@ -64,8 +64,18 @@ export function attachFightSummaryWriter(
 	const roomId = eventBus.roomId;
 	const subscriberId = `fight-summary:${roomId}`;
 
+	// Set by the detach function. Queued/retrying writes check this between
+	// steps so no write can land after the room is unloaded or reset —
+	// `resetRoomState()` clears fight_summaries and zeroes the fight counter,
+	// and a retry surviving past that point would insert a pre-reset fight and
+	// increment the fresh counter. (A transaction already in flight at the
+	// moment of detach can still commit; the flag closes the retry-backoff
+	// window, which is the part that spans seconds.)
+	let detached = false;
+
 	const writeWithRetries = async (event: GameEvent, pending: Pending | undefined): Promise<void> => {
 		for (let attempt = 0; ; attempt++) {
+			if (detached) return;
 			try {
 				await onFightResolved(db, roomId, event, pending);
 				return;
@@ -128,10 +138,11 @@ export function attachFightSummaryWriter(
 
 	return () => {
 		unsubscribe();
-		// Drop per-room state so long-lived servers don't accumulate entries for
-		// every room ever loaded. An in-flight write chain settles on its own; a
-		// re-attach starts a fresh chain, which is safe because rooms are only
-		// unloaded when idle (no fight can be resolving at that moment).
+		// Cancel queued/retrying writes (see `detached` above) and drop per-room
+		// state so long-lived servers don't accumulate entries for every room
+		// ever loaded. A re-attach creates a fresh closure with its own flag, so
+		// only this attachment's writes are cancelled.
+		detached = true;
 		pendingByRoom.delete(roomId);
 		fightSummaryWriteQueues.delete(roomId);
 	};

--- a/packages/server/src/fight-summary-writer.ts
+++ b/packages/server/src/fight-summary-writer.ts
@@ -1,6 +1,16 @@
 /**
  * Assembles fight_summaries rows from ring.fight (start) + ring.fightResolved + ring.cardDrop.
- * Best-effort: errors are logged and counted in metrics; pending fight metadata is kept until a successful write.
+ *
+ * Reliability contract (bug doc #15):
+ * - Pending fight metadata (startedAt, cardDropName) is snapshotted and cleared
+ *   SYNCHRONOUSLY when ring.fightResolved is delivered. The DB write itself is
+ *   queued and retried asynchronously; reading `pendingByRoom` inside the queued
+ *   task allowed a next fight's `fightBegins` to clobber the pending entry (wrong
+ *   duration on fight A) and then have A's post-write cleanup delete B's entry
+ *   (zero duration + spurious warning on fight B).
+ * - Writes are serialized per room and retried on failure with short backoff, so
+ *   a transient DB hiccup no longer permanently drops the fight. Only exhausting
+ *   all retries counts as a write failure (metric + error log).
  */
 import { eq, sql } from 'drizzle-orm';
 
@@ -19,8 +29,10 @@ type Pending = {
 
 const pendingByRoom = new Map<string, Pending>();
 
-/** Serialize fight-summary writes per room so concurrent fightResolved handlers do not corrupt pending state. */
+/** Serialize fight-summary writes per room so concurrent fightResolved handlers do not interleave. */
 const fightSummaryWriteQueues = new Map<string, Promise<void>>();
+
+const DEFAULT_RETRY_DELAYS_MS = [1_000, 5_000];
 
 function enqueueFightSummaryWrite(roomId: string, fn: () => Promise<void>): void {
 	const prev = fightSummaryWriteQueues.get(roomId) ?? Promise.resolve();
@@ -41,15 +53,56 @@ function profileUuidOrNull(value: string | undefined): string | null {
 	return value;
 }
 
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
 export function attachFightSummaryWriter(
 	eventBus: RoomEventBus,
 	db: Db,
-	legacyLog: (err: unknown) => void = () => {}
+	legacyLog: (err: unknown) => void = () => {},
+	{ retryDelaysMs = DEFAULT_RETRY_DELAYS_MS }: { retryDelaysMs?: number[] } = {}
 ): () => void {
 	const roomId = eventBus.roomId;
 	const subscriberId = `fight-summary:${roomId}`;
 
-	return eventBus.subscribe(subscriberId, {
+	const writeWithRetries = async (event: GameEvent, pending: Pending | undefined): Promise<void> => {
+		for (let attempt = 0; ; attempt++) {
+			try {
+				await onFightResolved(db, roomId, event, pending);
+				return;
+			} catch (err) {
+				const stack = err instanceof Error ? err.stack : undefined;
+				const pgCode =
+					err && typeof err === 'object' && 'code' in err
+						? String((err as { code?: unknown }).code)
+						: undefined;
+
+				if (attempt < retryDelaysMs.length) {
+					log.warn('fight-summary-writer: write failed, retrying', {
+						err,
+						roomId,
+						attempt: attempt + 1,
+						nextDelayMs: retryDelaysMs[attempt],
+						pgCode,
+					});
+					await wait(retryDelaysMs[attempt]!);
+					continue;
+				}
+
+				fightSummaryWriteFailures.inc({ room_id: roomId });
+				legacyLog(err);
+				log.error('fight-summary-writer: failed to write fight summary after retries', {
+					err,
+					roomId,
+					attempts: attempt + 1,
+					stack,
+					pgCode,
+				});
+				return;
+			}
+		}
+	};
+
+	const unsubscribe = eventBus.subscribe(subscriberId, {
 		deliver(event: GameEvent) {
 			if (event.type === 'ring.fight') {
 				try {
@@ -65,27 +118,23 @@ export function attachFightSummaryWriter(
 				return;
 			}
 			if (event.type === 'ring.fightResolved') {
-				enqueueFightSummaryWrite(roomId, async () => {
-					try {
-						await onFightResolved(db, roomId, event);
-					} catch (err) {
-						fightSummaryWriteFailures.inc({ room_id: roomId });
-						const stack = err instanceof Error ? err.stack : undefined;
-						const pg =
-							err && typeof err === 'object' && 'code' in err
-								? String((err as { code?: unknown }).code)
-								: undefined;
-						log.error('fight-summary-writer: failed to write fight summary', {
-							err,
-							roomId,
-							stack,
-							pgCode: pg,
-						});
-					}
-				});
+				// Snapshot & clear synchronously — see the reliability contract above.
+				const pending = pendingByRoom.get(roomId);
+				pendingByRoom.delete(roomId);
+				enqueueFightSummaryWrite(roomId, () => writeWithRetries(event, pending));
 			}
 		},
 	});
+
+	return () => {
+		unsubscribe();
+		// Drop per-room state so long-lived servers don't accumulate entries for
+		// every room ever loaded. An in-flight write chain settles on its own; a
+		// re-attach starts a fresh chain, which is safe because rooms are only
+		// unloaded when idle (no fight can be resolving at that moment).
+		pendingByRoom.delete(roomId);
+		fightSummaryWriteQueues.delete(roomId);
+	};
 }
 
 function onRingFight(roomId: string, event: GameEvent): void {
@@ -105,9 +154,12 @@ function onCardDrop(roomId: string, event: GameEvent): void {
 	if (name) pending.cardDropName = name;
 }
 
-async function onFightResolved(db: Db, roomId: string, event: GameEvent): Promise<void> {
-	const pending = pendingByRoom.get(roomId);
-
+async function onFightResolved(
+	db: Db,
+	roomId: string,
+	event: GameEvent,
+	pending: Pending | undefined
+): Promise<void> {
 	const payload = event.payload as {
 		rounds: number;
 		deaths: number;
@@ -188,6 +240,4 @@ async function onFightResolved(db: Db, roomId: string, event: GameEvent): Promis
 			loser: payload.loserMonsterName,
 		});
 	});
-
-	pendingByRoom.delete(roomId);
 }

--- a/packages/server/src/quick-actions.test.ts
+++ b/packages/server/src/quick-actions.test.ts
@@ -1,0 +1,120 @@
+import { expect } from 'chai';
+
+import { buildQuickActions } from './quick-actions.js';
+
+const USER = 'user-1';
+
+const makeGame = (
+	character: Record<string, unknown> | undefined,
+	contestants: Array<{ userId?: string; monster?: unknown; isBoss?: boolean }> = []
+) => ({
+	characters: character ? { [USER]: character } : {},
+	ring: { contestants },
+});
+
+describe('buildQuickActions', () => {
+	it('suggests spawning when the player has no character yet', () => {
+		const actions = buildQuickActions(makeGame(undefined), USER);
+		expect(actions.map((a) => a.command)).to.deep.equal([
+			'spawn monster',
+			'look at the ring',
+		]);
+	});
+
+	it('suggests spawning when the character owns no monsters', () => {
+		const actions = buildQuickActions(makeGame({ monsters: [], deck: [] }), USER);
+		expect(actions[0]?.command).to.equal('spawn monster');
+	});
+
+	it('offers to send an idle monster into the ring', () => {
+		const monster = { givenName: 'Fluffy' };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.include('send Fluffy to the ring');
+	});
+
+	it('offers the ring view instead of a send for a monster already fighting', () => {
+		const monster = { givenName: 'Fluffy' };
+		const game = makeGame({ monsters: [monster], deck: [] }, [
+			{ userId: USER, monster },
+		]);
+		const commands = buildQuickActions(game, USER).map((a) => a.command);
+		expect(commands).to.include('look at the ring');
+		expect(commands).to.not.include('send Fluffy to the ring');
+	});
+
+	it('offers to revive a dead monster', () => {
+		const game = makeGame({
+			monsters: [{ givenName: 'Fluffy', dead: true }],
+			deck: [],
+		});
+		expect(buildQuickActions(game, USER).map((a) => a.command)).to.include('revive Fluffy');
+	});
+
+	it('does not offer to revive a permanently destroyed monster', () => {
+		const game = makeGame({
+			monsters: [{ givenName: 'Fluffy', dead: true, destroyed: true }],
+			deck: [],
+		});
+		expect(buildQuickActions(game, USER).map((a) => a.command)).to.not.include('revive Fluffy');
+	});
+
+	it('offers to equip only when unequipped cards exist', () => {
+		const monster = { givenName: 'Fluffy' };
+		const without = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(without.map((a) => a.command)).to.not.include('equip Fluffy');
+
+		const withCards = buildQuickActions(
+			makeGame({ monsters: [monster], deck: [{ cardType: 'Hit' }] }),
+			USER
+		);
+		expect(withCards.map((a) => a.command)).to.include('equip Fluffy');
+	});
+
+	it('does not offer to equip a monster that is in the ring', () => {
+		const monster = { givenName: 'Fluffy' };
+		const game = makeGame({ monsters: [monster], deck: [{ cardType: 'Hit' }] }, [
+			{ userId: USER, monster },
+		]);
+		expect(buildQuickActions(game, USER).map((a) => a.command)).to.not.include('equip Fluffy');
+	});
+
+	it('ignores ring contestants belonging to other players', () => {
+		const mine = { givenName: 'Fluffy' };
+		const theirs = { givenName: 'Rex' };
+		const game = makeGame({ monsters: [mine], deck: [] }, [
+			{ userId: 'someone-else', monster: theirs },
+		]);
+		const commands = buildQuickActions(game, USER).map((a) => a.command);
+		expect(commands).to.include('send Fluffy to the ring');
+		expect(commands).to.not.include('look at the ring');
+	});
+
+	it('caps suggestions and never emits duplicates', () => {
+		const game = makeGame(
+			{
+				monsters: [
+					{ givenName: 'InRing' },
+					{ givenName: 'Idle' },
+					{ givenName: 'Dead', dead: true },
+				],
+				deck: [{ cardType: 'Hit' }],
+			},
+			[]
+		);
+		const actions = buildQuickActions(game, USER);
+		expect(actions.length).to.be.at.most(4);
+		expect(new Set(actions.map((a) => a.command)).size).to.equal(actions.length);
+	});
+
+	it('tolerates malformed game state without throwing', () => {
+		expect(() => buildQuickActions({}, USER)).to.not.throw();
+		expect(() =>
+			buildQuickActions(makeGame({ monsters: 'nope', deck: null } as never), USER)
+		).to.not.throw();
+		const partial = buildQuickActions(
+			makeGame({ monsters: [{}, { givenName: '  ' }], deck: [] }),
+			USER
+		);
+		expect(partial[0]?.command).to.equal('spawn monster');
+	});
+});

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -1,0 +1,116 @@
+/**
+ * Builds the contextual command chips shown under the web console after a
+ * command completes (`quick_actions` events).
+ *
+ * Every emitted `command` string must be one the engine's parser actually
+ * accepts — these are dispatched verbatim when the user clicks a chip. Keep
+ * them aligned with `COMMAND_CATALOG` in the engine.
+ *
+ * The game object is intentionally typed loosely: engine entities are `any` at
+ * the package boundary and may be partially hydrated, so every field access
+ * here is defensive. Returning fewer suggestions is always preferable to
+ * throwing inside the command pipeline.
+ */
+
+export interface QuickAction {
+	label: string;
+	command: string;
+}
+
+const MAX_QUICK_ACTIONS = 4;
+
+type LooseRecord = Record<string, unknown>;
+
+type QuickActionsGame = {
+	characters?: Record<string, unknown>;
+	ring?: {
+		contestants?: Array<{ userId?: string; monster?: unknown; isBoss?: boolean }>;
+	};
+};
+
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const monsterName = (monster: unknown): string => {
+	const name = (monster as LooseRecord | undefined)?.givenName;
+	return typeof name === 'string' ? name.trim() : '';
+};
+
+const isDead = (monster: unknown): boolean =>
+	Boolean((monster as LooseRecord | undefined)?.dead);
+
+const isDestroyed = (monster: unknown): boolean =>
+	Boolean((monster as LooseRecord | undefined)?.destroyed);
+
+export function buildQuickActions(game: QuickActionsGame, userId: string): QuickAction[] {
+	const actions: QuickAction[] = [];
+	const add = (label: string, command: string): void => {
+		if (actions.some((action) => action.command === command)) return;
+		actions.push({ label, command });
+	};
+
+	const character = game?.characters?.[userId] as LooseRecord | undefined;
+
+	// No character yet — the only meaningful next step is to create a monster,
+	// which implicitly creates the character.
+	if (!character) {
+		return [
+			{ label: 'Spawn a monster', command: 'spawn monster' },
+			{ label: 'Look at the ring', command: 'look at the ring' },
+		];
+	}
+
+	const monsters = asArray(character.monsters).filter(
+		(monster) => monsterName(monster).length > 0
+	);
+
+	if (monsters.length === 0) {
+		return [
+			{ label: 'Spawn a monster', command: 'spawn monster' },
+			{ label: 'Look at the ring', command: 'look at the ring' },
+		];
+	}
+
+	const ringMonsters = new Set(
+		asArray(game?.ring?.contestants)
+			.filter((contestant) => {
+				const entry = contestant as LooseRecord;
+				return entry?.userId === userId && !entry?.isBoss;
+			})
+			.map((contestant) => (contestant as LooseRecord).monster)
+	);
+
+	const living = monsters.filter((monster) => !isDead(monster) && !isDestroyed(monster));
+	const deadRevivable = monsters.filter(
+		(monster) => isDead(monster) && !isDestroyed(monster)
+	);
+	const readyToSend = living.filter((monster) => !ringMonsters.has(monster));
+	const hasMonsterInRing = living.some((monster) => ringMonsters.has(monster));
+	const unequippedCards = asArray(character.deck).length;
+
+	// Ordered by how likely each is to be the player's actual next move.
+	if (hasMonsterInRing) {
+		add('Look at the ring', 'look at the ring');
+	}
+
+	const nextToSend = readyToSend[0];
+	if (nextToSend) {
+		add(`Send ${monsterName(nextToSend)} to the ring`, `send ${monsterName(nextToSend)} to the ring`);
+	}
+
+	const nextToRevive = deadRevivable[0];
+	if (nextToRevive) {
+		add(`Revive ${monsterName(nextToRevive)}`, `revive ${monsterName(nextToRevive)}`);
+	}
+
+	// Equipping is rejected while a monster is fighting, so only offer it for a
+	// monster that is out of the ring.
+	const nextToEquip = readyToSend[0];
+	if (unequippedCards > 0 && nextToEquip) {
+		add(`Equip ${monsterName(nextToEquip)}`, `equip ${monsterName(nextToEquip)}`);
+	}
+
+	add('Look at my monsters', 'look at monsters');
+	add('Visit the shop', 'visit the shop');
+
+	return actions.slice(0, MAX_QUICK_ACTIONS);
+}

--- a/packages/server/src/room-manager.test.ts
+++ b/packages/server/src/room-manager.test.ts
@@ -68,7 +68,7 @@ function makeEngineDeps() {
 		get stateStore() { return _stateStore; },
 		set stateStore(v: unknown) { _stateStore = v; },
 		eventBus: mockEventBus as never,
-		ring: { on: sinon.stub(), off: sinon.stub() } as never,
+		ring: { on: sinon.stub(), off: sinon.stub(), inEncounter: false } as never,
 		options: {} as Record<string, unknown>,
 		// saveState getter mirrors the real Game implementation
 		get saveState() { return saveStateFn; },
@@ -438,6 +438,25 @@ describe('RoomManager', () => {
 
 			// Should not throw
 			await expect(rm.unloadRoom('nonexistent-id')).to.be.fulfilled;
+		});
+
+		it('does not unload a room with a fight in progress, leaving it active for the next sweep', async () => {
+			// Regression: unloading mid-fight detaches this room's event bus
+			// subscribers (persister, fight-summary writer, stats) while the fight's
+			// own untracked setTimeout chain keeps running — the fight's
+			// announcements, stats, and summary row are silently lost.
+			const { deps, mockGame, saveStateFn } = makeEngineDeps();
+			const db = makeDbStub();
+			const rm = new RoomManager(db as never, () => {}, deps);
+			const { roomId } = await rm.createRoom(OWNER_ID, 'Room');
+
+			(mockGame.ring as unknown as { inEncounter: boolean }).inEncounter = true;
+
+			await rm.unloadRoom(roomId);
+
+			expect(saveStateFn.called).to.be.false;
+			expect(mockGame.dispose.called).to.be.false;
+			expect((rm as any).active.has(roomId)).to.be.true;
 		});
 	});
 

--- a/packages/server/src/room-manager.test.ts
+++ b/packages/server/src/room-manager.test.ts
@@ -539,7 +539,7 @@ describe('RoomManager', () => {
 			const { deps } = makeEngineDeps();
 			const rm = new RoomManager(db as never, () => {}, deps);
 
-			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '1999-anchor', 500);
+			const { events } = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '1999-anchor', 500);
 
 			expect(events).to.have.length(1);
 			expect(events[0]!.text).to.equal('after');
@@ -554,7 +554,7 @@ describe('RoomManager', () => {
 			const { deps } = makeEngineDeps();
 			const rm = new RoomManager(db as never, () => {}, deps);
 
-			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '2000-aaaaaaaa', 500);
+			const { events } = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '2000-aaaaaaaa', 500);
 
 			expect(events).to.have.length(1);
 			expect(events[0]!.id).to.equal('2001-bbbbbbbb');
@@ -568,7 +568,7 @@ describe('RoomManager', () => {
 			const { deps } = makeEngineDeps();
 			const rm = new RoomManager(db as never, () => {}, deps);
 
-			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '1998-cursorrr', 500);
+			const { events } = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '1998-cursorrr', 500);
 
 			expect(events).to.have.length(1);
 			expect(events[0]!.id).to.equal('1999-olddddd');
@@ -588,11 +588,62 @@ describe('RoomManager', () => {
 			const { deps } = makeEngineDeps();
 			const rm = new RoomManager(db as never, () => {}, deps);
 
-			const events = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '2000-aaaaaaaa', 500);
+			const { events } = await rm.getEventsSinceForRingFeed(USER_ID, ROOM_ID, '2000-aaaaaaaa', 500);
 
 			expect(events).to.have.length(1);
 			expect(events[0]!.scope).to.equal('private');
 			expect(events[0]!.targetUserId).to.equal(USER_ID);
+		});
+
+		it('paginates past a full first page, advancing the cursor to the last returned id', async () => {
+			// Regression (review of #16/#17): a single fixed-limit query silently
+			// dropped everything past the first page for long absences.
+			const db = makeDbStub({ selectResults: [memberRow] });
+			const { deps } = makeEngineDeps();
+			const rm = new RoomManager(db as never, () => {}, deps);
+
+			const page = (ids: string[]) =>
+				ids.map((id) => ({ id, type: 'announce', scope: 'public', text: id, payload: {}, timestamp: 1 }));
+			const cursors: string[] = [];
+			const pages = [page(['2001-a', '2002-b']), page(['2003-c', '2004-d']), page(['2005-e'])];
+			sinon.stub(rm, '_fetchRingFeedPage').callsFake(async (_u, _r, cursor: string) => {
+				cursors.push(cursor);
+				return pages.shift() as never;
+			});
+
+			const { events, limitReached } = await rm.getEventsSinceForRingFeed(
+				USER_ID,
+				ROOM_ID,
+				'2000-cursor',
+				2,
+				100
+			);
+
+			expect(events.map((e) => e.id)).to.deep.equal(['2001-a', '2002-b', '2003-c', '2004-d', '2005-e']);
+			expect(limitReached).to.equal(false);
+			// Each subsequent page anchors on the previous page's last event id.
+			expect(cursors).to.deep.equal(['2000-cursor', '2002-b', '2004-d']);
+		});
+
+		it('reports limitReached when the total cap is hit with rows still remaining', async () => {
+			const db = makeDbStub({ selectResults: [memberRow] });
+			const { deps } = makeEngineDeps();
+			const rm = new RoomManager(db as never, () => {}, deps);
+
+			const fullPage = (prefix: string) =>
+				[1, 2].map((n) => ({ id: `${prefix}-${n}`, type: 'announce', scope: 'public', text: '', payload: {}, timestamp: 1 }));
+			sinon.stub(rm, '_fetchRingFeedPage').callsFake(async () => fullPage(String(Date.now())) as never);
+
+			const { events, limitReached } = await rm.getEventsSinceForRingFeed(
+				USER_ID,
+				ROOM_ID,
+				'2000-cursor',
+				2,
+				4
+			);
+
+			expect(events).to.have.length(4);
+			expect(limitReached).to.equal(true);
 		});
 	});
 });

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -535,15 +535,45 @@ export class RoomManager {
 	 * Events after `lastEventId` for ringFeed replay when the in-memory ring buffer
 	 * no longer contains the cursor. Uses `room_events`; event ids are `${Date.now()}-…`
 	 * so lexicographic `event_id` ordering matches time order when the anchor row is missing.
+	 *
+	 * Paginates internally: a single fixed-limit query silently dropped everything
+	 * past the first `pageSize` rows for long absences. Each page's last event id is
+	 * a real row, so subsequent pages always resolve via the fast anchor path.
+	 * `limitReached` is true when `maxTotal` was hit with rows still remaining —
+	 * callers should surface a gap to the user rather than presenting the truncated
+	 * replay as complete.
 	 */
 	async getEventsSinceForRingFeed(
 		userId: string,
 		roomId: string,
 		lastEventId: string,
-		limit = 500
-	): Promise<GameEvent[]> {
+		pageSize = 500,
+		maxTotal = 2000
+	): Promise<{ events: GameEvent[]; limitReached: boolean }> {
 		await this.assertMember(userId, roomId);
 
+		const events: GameEvent[] = [];
+		let cursor = lastEventId;
+		for (;;) {
+			const page = await this._fetchRingFeedPage(userId, roomId, cursor, pageSize);
+			events.push(...page);
+			if (page.length < pageSize) {
+				return { events, limitReached: false };
+			}
+			if (events.length >= maxTotal) {
+				return { events, limitReached: true };
+			}
+			cursor = page[page.length - 1]!.id;
+		}
+	}
+
+	/** One page of the ringFeed replay query — see getEventsSinceForRingFeed. */
+	async _fetchRingFeedPage(
+		userId: string,
+		roomId: string,
+		lastEventId: string,
+		limit: number
+	): Promise<GameEvent[]> {
 		const visibility = or(
 			eq(roomEvents.scope, 'public'),
 			and(eq(roomEvents.scope, 'private'), eq(roomEvents.targetUserId, userId))

--- a/packages/server/src/room-manager.ts
+++ b/packages/server/src/room-manager.ts
@@ -445,6 +445,17 @@ export class RoomManager {
 	async unloadRoom(roomId: string): Promise<void> {
 		const entry = this.active.get(roomId);
 		if (entry) {
+			if (entry.game.ring.inEncounter) {
+				// A fight is running against this room's event bus subscribers (stats,
+				// fight-summary writer, persister). Unloading now would detach them
+				// mid-fight — announcements, stats, and the fight summary would be
+				// lost — while the untracked setTimeout chain inside Ring.fight()
+				// keeps running regardless of Game.dispose(). Leave the room active;
+				// the next sweep (10 min later, see index.ts SWEEP_INTERVAL_MS) will
+				// retry once the fight has ended.
+				log.debug('skipping idle unload — fight in progress, will retry next sweep', { roomId });
+				return;
+			}
 			log.debug('unloading room', { roomId, idleMs: Date.now() - entry.lastActivityAt });
 			// Stop persisting events for this room.
 			entry.unsubscribePersister();

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -287,3 +287,112 @@ describe('trpc/router card management procedures', () => {
 		});
 	});
 });
+
+describe('trpc/router ringFeed replay', () => {
+	type Frame = { id: string; data: { type: string; text: string } };
+
+	// `tracked(id, event)` surfaces as an [id, event] tuple through createCaller.
+	const unwrap = (frame: unknown): Frame['data'] =>
+		(Array.isArray(frame) ? frame[1] : frame) as Frame['data'];
+
+	const makeEvent = (id: string, text: string) => ({
+		id,
+		roomId: ROOM_ID,
+		timestamp: Date.now(),
+		type: 'announce',
+		scope: 'public',
+		text,
+		payload: {},
+	});
+
+	/**
+	 * Builds a roomManager whose in-memory cursor lookup returns `sinceResult` and
+	 * whose durable-storage fallback returns `storedEvents`. The live subscription
+	 * immediately delivers a sentinel so the frame after replay is deterministic.
+	 */
+	const makeRoomManager = (
+		sinceResult: Record<string, unknown>,
+		storedEvents: unknown[]
+	) =>
+		({
+			assertMember: async () => undefined,
+			getEventBus: async () => ({
+				getEventsSince: () => sinceResult,
+				getRecentEvents: () => [],
+				subscribe: (_id: string, sub: { deliver: (e: unknown) => void }) => {
+					sub.deliver(makeEvent('9999999999999-live', 'live'));
+					return () => {};
+				},
+			}),
+			getGame: async () => ({
+				ring: { nextFightAt: null, nextBossSpawnAt: null, contestants: [] },
+			}),
+			getEventsSinceForRingFeed: async () => storedEvents,
+		}) as unknown as Parameters<typeof createRouter>[0];
+
+	const collect = async (
+		roomManager: Parameters<typeof createRouter>[0],
+		frameCount: number
+	) => {
+		const router = createRouter(roomManager);
+		const caller = router.createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const iterator = (await caller.game.ringFeed({
+			roomId: ROOM_ID,
+			lastEventId: '1712835000000-cursor',
+		})) as AsyncGenerator<unknown>;
+
+		const frames: Array<Frame['data']> = [];
+		try {
+			for (let i = 0; i < frameCount; i++) {
+				const next = await iterator.next();
+				if (next.done) break;
+				frames.push(unwrap(next.value));
+			}
+		} finally {
+			await iterator.return?.(undefined);
+		}
+		return frames;
+	};
+
+	it('replays from durable storage when the buffer is cold after a restart', async () => {
+		// Regression: a cold buffer used to report truncated=false, so the DB
+		// fallback never ran and reconnects across a restart replayed nothing.
+		const roomManager = makeRoomManager(
+			{ events: [], truncated: true, upToDate: false, status: 'cold' },
+			[makeEvent('1712835000001-a', 'missed one'), makeEvent('1712835000002-b', 'missed two')]
+		);
+
+		const frames = await collect(roomManager, 3);
+
+		expect(frames[0]?.type).to.equal('handshake');
+		expect(frames.map((f) => f.text)).to.include('missed one');
+		expect(frames.map((f) => f.text)).to.include('missed two');
+		expect(frames.map((f) => f.type)).to.not.include('system.gap');
+	});
+
+	it('warns about a gap when events were evicted and storage has nothing', async () => {
+		const roomManager = makeRoomManager(
+			{ events: [], truncated: true, upToDate: false, status: 'evicted' },
+			[]
+		);
+
+		const frames = await collect(roomManager, 2);
+
+		expect(frames[0]?.type).to.equal('handshake');
+		expect(frames[1]?.type).to.equal('system.gap');
+	});
+
+	it('does not warn about a gap when a cold buffer has nothing to replay', async () => {
+		// The common case after a deploy: the room was idle, so an empty replay is
+		// expected and must not surface a "you missed events" banner.
+		const roomManager = makeRoomManager(
+			{ events: [], truncated: true, upToDate: false, status: 'cold' },
+			[]
+		);
+
+		const frames = await collect(roomManager, 2);
+
+		expect(frames[0]?.type).to.equal('handshake');
+		expect(frames[1]?.text).to.equal('live');
+	});
+});

--- a/packages/server/src/trpc/router.test.ts
+++ b/packages/server/src/trpc/router.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TRPCError } from '@trpc/server';
 
-import { createRouter } from './router.js';
+import { createRouter, activeFlows } from './router.js';
 
 const ROOM_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 const USER_ID = '11111111-2222-3333-4444-555555555555';
@@ -327,7 +327,7 @@ describe('trpc/router ringFeed replay', () => {
 			getGame: async () => ({
 				ring: { nextFightAt: null, nextBossSpawnAt: null, contestants: [] },
 			}),
-			getEventsSinceForRingFeed: async () => storedEvents,
+			getEventsSinceForRingFeed: async () => ({ events: storedEvents, limitReached: false }),
 		}) as unknown as Parameters<typeof createRouter>[0];
 
 	const collect = async (
@@ -394,5 +394,252 @@ describe('trpc/router ringFeed replay', () => {
 
 		expect(frames[0]?.type).to.equal('handshake');
 		expect(frames[1]?.text).to.equal('live');
+	});
+});
+
+describe('trpc/router command dispatch and flow locking', () => {
+	const flowKey = `${ROOM_ID}:${USER_ID}`;
+
+	function deferred<T = void>() {
+		let resolve!: (value: T) => void;
+		const promise = new Promise<T>((res) => {
+			resolve = res;
+		});
+		return { promise, resolve };
+	}
+
+	/**
+	 * roomManager double for the `command` mutation. `action` is what
+	 * game.handleCommand returns; `lanes` records every runSerializedEngineWork
+	 * key; `published` records every eventBus.publish.
+	 */
+	function makeCommandRoomManager(action: (opts: unknown) => Promise<unknown>) {
+		const lanes: string[] = [];
+		const published: Array<{ type: string }> = [];
+		const roomManager = {
+			assertMember: async () => undefined,
+			getMemberRole: async () => 'member',
+			getDisplayName: async () => 'Player',
+			getGame: async () => ({
+				handleCommand: () => action,
+				characters: {},
+				ring: { contestants: [] },
+			}),
+			getEventBus: async () => ({
+				publish: (event: { type: string }) => published.push(event),
+				getPendingPromptForUser: () => null,
+				cancelAllUserPrompts: () => undefined,
+			}),
+			runSerializedEngineWork: async (laneKey: string, fn: () => Promise<unknown>) => {
+				lanes.push(laneKey);
+				return fn();
+			},
+		} as unknown as Parameters<typeof createRouter>[0];
+		return { roomManager, lanes, published };
+	}
+
+	const settleTicks = async (count = 4) => {
+		for (let i = 0; i < count; i++) {
+			await new Promise<void>((resolve) => setImmediate(resolve));
+		}
+	};
+
+	afterEach(() => {
+		activeFlows.clear();
+	});
+
+	it('serializes command actions in a per-user lane, not room-wide', async () => {
+		// Regression (bug doc #20): a room-wide lane let one user's minutes-long
+		// interactive flow starve every other member's commands.
+		const { roomManager, lanes } = makeCommandRoomManager(async () => undefined);
+		const caller = createRouter(roomManager).createCaller({ userId: USER_ID, serviceTokenValid: false });
+
+		const result = await caller.game.command({ roomId: ROOM_ID, command: 'look at ring' });
+		await settleTicks();
+
+		expect(result.ok).to.equal(true);
+		expect(lanes).to.deep.equal([`${ROOM_ID}:${USER_ID}`]);
+	});
+
+	it('emits quick_actions to the user after the command action settles', async () => {
+		const { roomManager, published } = makeCommandRoomManager(async () => undefined);
+		const caller = createRouter(roomManager).createCaller({ userId: USER_ID, serviceTokenValid: false });
+
+		await caller.game.command({ roomId: ROOM_ID, command: 'look at ring' });
+		await settleTicks();
+
+		expect(published.some((event) => event.type === 'quick_actions')).to.equal(true);
+	});
+
+	it('rejects workshop mutations while the caller has a console flow in progress', async () => {
+		// Regression (bug doc #20): workshop mutations used to queue behind the
+		// flow (hanging the HTTP request for minutes) instead of failing fast.
+		const unequipCard = async () => ({ removedCount: 1, monsterName: 'Stonefang' });
+		const roomManager = {
+			assertMember: async () => undefined,
+			getGame: async () => ({ characters: { [USER_ID]: { unequipCard } } }),
+			getEventBus: async () => ({ publish: () => undefined }),
+			runSerializedEngineWork: async (_key: string, fn: () => Promise<unknown>) => fn(),
+		} as unknown as Parameters<typeof createRouter>[0];
+		const caller = createRouter(roomManager).createCaller({ userId: USER_ID, serviceTokenValid: false });
+
+		activeFlows.set(flowKey, 'some-flow');
+
+		const err = await caller.game
+			.unequipCard({ roomId: ROOM_ID, monsterName: 'Stonefang', cardName: 'Hit' })
+			.catch((e: unknown) => e);
+
+		expect(err).to.be.instanceOf(TRPCError);
+		expect((err as TRPCError).code).to.equal('PRECONDITION_FAILED');
+	});
+
+	it('a cancelled flow settling late does not release a newer flow\'s lock', async () => {
+		// Regression (review of #20): cancelFlow deletes the key immediately; if
+		// command B starts before cancelled command A's promise chain settles,
+		// A's unconditional .finally() used to delete B's freshly-taken lock,
+		// letting a third command run concurrently with B.
+		const flowA = deferred();
+		const flowB = deferred();
+		const { roomManager: rmA } = makeCommandRoomManager(() => flowA.promise);
+		const callerA = createRouter(rmA).createCaller({ userId: USER_ID, serviceTokenValid: false });
+
+		const dispatchA = await callerA.game.command({ roomId: ROOM_ID, command: 'spawn monster' });
+		expect(dispatchA.ok).to.equal(true);
+		expect(activeFlows.has(flowKey)).to.equal(true);
+
+		// User cancels flow A (the router's cancelFlow force-clears the lock).
+		await callerA.game.cancelFlow({ roomId: ROOM_ID });
+		expect(activeFlows.has(flowKey)).to.equal(false);
+
+		// Command B starts while A's action promise is still unsettled.
+		const { roomManager: rmB } = makeCommandRoomManager(() => flowB.promise);
+		const callerB = createRouter(rmB).createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const dispatchB = await callerB.game.command({ roomId: ROOM_ID, command: 'spawn monster' });
+		expect(dispatchB.ok).to.equal(true);
+		const tokenB = activeFlows.get(flowKey);
+		expect(tokenB).to.be.a('string');
+
+		// A finally settles — its cleanup must NOT release B's lock.
+		flowA.resolve();
+		await settleTicks();
+		expect(activeFlows.get(flowKey)).to.equal(tokenB);
+
+		// When B settles, its own cleanup releases the lock normally.
+		flowB.resolve();
+		await settleTicks();
+		expect(activeFlows.has(flowKey)).to.equal(false);
+	});
+});
+
+describe('trpc/router ringFeed live-subscription race', () => {
+	const unwrapFrame = (frame: unknown): { id: string; type: string; text: string } =>
+		(Array.isArray(frame) ? frame[1] : frame) as { id: string; type: string; text: string };
+
+	const makeEvent = (id: string, text: string) => ({
+		id,
+		roomId: ROOM_ID,
+		timestamp: Date.now(),
+		type: 'announce',
+		scope: 'public',
+		text,
+		payload: {},
+	});
+
+	it('subscribes before replaying and dedups events captured by both', async () => {
+		// Regression (review of #16/#17): the live subscriber used to attach only
+		// after the replay finished, so events published during the (async) DB
+		// replay were lost. Now the subscriber attaches first and buffered
+		// duplicates of replayed events are dropped on drain.
+		const order: string[] = [];
+		const replayed = makeEvent('1712835000005-replayed', 'covered by replay');
+		const inBetween = makeEvent('1712835000006-between', 'published during replay');
+
+		const roomManager = {
+			assertMember: async () => undefined,
+			getEventBus: async () => ({
+				getEventsSince: () => {
+					order.push('getEventsSince');
+					return { events: [], truncated: true, upToDate: false, status: 'cold' };
+				},
+				getRecentEvents: () => [],
+				subscribe: (_id: string, sub: { deliver: (e: unknown) => void }) => {
+					order.push('subscribe');
+					// Simulate events arriving while the replay is being assembled:
+					// one that the replay will also return, one that only the live
+					// subscription sees.
+					sub.deliver(replayed);
+					sub.deliver(inBetween);
+					return () => {};
+				},
+			}),
+			getGame: async () => ({
+				ring: { nextFightAt: null, nextBossSpawnAt: null, contestants: [] },
+			}),
+			getEventsSinceForRingFeed: async () => ({ events: [replayed], limitReached: false }),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const caller = createRouter(roomManager).createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const iterator = (await caller.game.ringFeed({
+			roomId: ROOM_ID,
+			lastEventId: '1712835000000-cursor',
+		})) as AsyncGenerator<unknown>;
+
+		const frames: Array<{ id: string; type: string; text: string }> = [];
+		try {
+			for (let i = 0; i < 3; i++) {
+				const next = await iterator.next();
+				if (next.done) break;
+				frames.push(unwrapFrame(next.value));
+			}
+		} finally {
+			await iterator.return?.(undefined);
+		}
+
+		expect(order[0]).to.equal('subscribe');
+		expect(order).to.include('getEventsSince');
+		expect(frames[0]?.type).to.equal('handshake');
+		// The replayed event appears exactly once, then the in-between live event.
+		expect(frames.filter((f) => f.id === replayed.id)).to.have.length(1);
+		expect(frames.some((f) => f.id === inBetween.id)).to.equal(true);
+	});
+
+	it('emits a gap marker when the DB replay hits its hard cap', async () => {
+		const events = [makeEvent('1712835000001-a', 'one'), makeEvent('1712835000002-b', 'two')];
+		const roomManager = {
+			assertMember: async () => undefined,
+			getEventBus: async () => ({
+				getEventsSince: () => ({ events: [], truncated: true, upToDate: false, status: 'evicted' }),
+				getRecentEvents: () => [],
+				subscribe: () => () => {},
+			}),
+			getGame: async () => ({
+				ring: { nextFightAt: null, nextBossSpawnAt: null, contestants: [] },
+			}),
+			getEventsSinceForRingFeed: async () => ({ events, limitReached: true }),
+		} as unknown as Parameters<typeof createRouter>[0];
+
+		const caller = createRouter(roomManager).createCaller({ userId: USER_ID, serviceTokenValid: false });
+		const iterator = (await caller.game.ringFeed({
+			roomId: ROOM_ID,
+			lastEventId: '1712835000000-cursor',
+		})) as AsyncGenerator<unknown>;
+
+		const frames: Array<{ type: string }> = [];
+		try {
+			for (let i = 0; i < 4; i++) {
+				const next = await iterator.next();
+				if (next.done) break;
+				frames.push(unwrapFrame(next.value));
+			}
+		} finally {
+			await iterator.return?.(undefined);
+		}
+
+		expect(frames.map((f) => f.type)).to.deep.equal([
+			'handshake',
+			'announce',
+			'announce',
+			'system.gap',
+		]);
 	});
 });

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -246,15 +246,22 @@ export type AppRouter = ReturnType<typeof createRouter>;
 const PROTOCOL_VERSION = 1;
 const BUILD_VERSION = process.env['BUILD_VERSION'] ?? 'dev';
 
-// Per-user active-flow lock.  Key = `${roomId}:${userId}`.
-// While a command flow is in progress for a given user+room, further commands
-// are rejected with a friendly message so users know to answer the prompt first.
-// Exported so it can be inspected in unit tests.
+// Per-user active-flow lock.  Key = `${roomId}:${userId}`, value = the owning
+// flow's commandId. While a command flow is in progress for a given user+room,
+// further commands are rejected with a friendly message so users know to
+// answer the prompt first. Exported so it can be inspected in unit tests.
 //
-// Engine work is additionally serialized **per room** via
-// `RoomManager.runSerializedEngineWork` so two users cannot interleave commands
-// on the same Game (see packages/engine/src/helpers/room-engine-queue.ts).
-export const activeFlows = new Set<string>();
+// The value is an ownership token, not just presence: a flow's `.finally()`
+// only clears the lock if it still owns it. Without that check there is a
+// cancellation race — `cancelFlow` deletes the key immediately, so if command
+// B starts before cancelled command A's promise chain settles, A's
+// unconditional cleanup would delete B's freshly-taken lock and let a third
+// command run concurrently with B.
+//
+// Engine work is additionally serialized per `${roomId}:${userId}` lane via
+// `RoomManager.runSerializedEngineWork` (see the `command` mutation below and
+// packages/engine/src/helpers/room-engine-queue.ts).
+export const activeFlows = new Map<string, string>();
 
 const sortBySchema = z.enum(['xp', 'wins', 'winRate', 'coins']);
 
@@ -523,10 +530,11 @@ export function createRouter(roomManager: RoomManager) {
 					commandsTotal.inc({ room_id: input.roomId, result: 'rejected' });
 					return { ok: false, message: 'Command not recognized' };
 				}
-				activeFlows.add(flowKey);
-				log.debug('command dispatched', { roomId: input.roomId, userId: ctx.userId, isAdmin });
-
 				const commandId = randomUUID();
+				// The commandId doubles as the flow-lock ownership token — see the
+				// activeFlows declaration for why cleanup must be ownership-checked.
+				activeFlows.set(flowKey, commandId);
+				log.debug('command dispatched', { roomId: input.roomId, userId: ctx.userId, isAdmin });
 
 				// Persist a user-input echo event so console history can show
 				// previously submitted commands after reload.
@@ -638,7 +646,12 @@ export function createRouter(roomManager: RoomManager) {
 						}
 					})
 					.finally(() => {
-						activeFlows.delete(flowKey);
+						// Only clear the lock this flow still owns. After a cancelFlow,
+						// a newer command may hold the key with its own token — deleting
+						// unconditionally here would release that newer flow's lock.
+						if (activeFlows.get(flowKey) === commandId) {
+							activeFlows.delete(flowKey);
+						}
 					});
 
 
@@ -1284,67 +1297,12 @@ export function createRouter(roomManager: RoomManager) {
 			};
 			yield tracked(handshakeId, handshakeEvent);
 
-				// Deliver any missed events since the last received event ID.
-				if (input.lastEventId) {
-					const { events: buffered, truncated, upToDate, status } = eventBus.getEventsSince(
-						input.lastEventId
-					);
-					let missed: GameEvent[] = buffered;
-					if (truncated && !upToDate) {
-						missed = await roomManager.getEventsSinceForRingFeed(
-							ctx.userId,
-							input.roomId,
-							input.lastEventId
-						);
-						log.debug('ringFeed replaying from durable storage', {
-							roomId: input.roomId,
-							userId: ctx.userId,
-							status,
-							replayed: missed.length,
-						});
-						if (missed.length > 0) {
-							ringFeedReplayFromDbTotal.inc({ room_id: input.roomId });
-						} else if (status === 'evicted') {
-							// Only warn when events demonstrably passed through the buffer
-							// while the room stayed loaded. A cold buffer with no stored
-							// events means the room was simply idle (the usual case after a
-							// deploy) — warning there would cry wolf on every restart.
-							ringFeedReplayGapTotal.inc({ room_id: input.roomId });
-							const gapId = `${Date.now()}-gap-${randomUUID().slice(0, 8)}`;
-							const gapEvent: GameEvent = {
-								id: gapId,
-								roomId: input.roomId,
-								timestamp: Date.now(),
-								type: 'system.gap' as EventType,
-								scope: 'private' as EventScope,
-								targetUserId: ctx.userId,
-								text: '── Some events were missed while you were away. ──',
-								payload: { reason: 'buffer_or_retention' },
-							};
-							yield tracked(gapId, gapEvent);
-						}
-					}
-					for (const event of missed) {
-						if (
-							event.scope === 'public' ||
-							event.targetUserId === ctx.userId
-						) {
-							yield tracked(event.id, event);
-						}
-					}
-				} else {
-					const recent = eventBus.getRecentEvents(100);
-					for (const event of recent) {
-						if (
-							event.scope === 'public' ||
-							event.targetUserId === ctx.userId
-						) {
-							yield tracked(event.id, event);
-						}
-					}
-				}
-
-				// Stream live events until the client disconnects.
+				// Attach the live subscriber BEFORE computing the replay. Events
+				// published while the replay is being assembled (the DB fallback is
+				// async) buffer into `queue`; anything the replay also covers is
+				// dropped from the buffer via `replayedIds` when the live loop drains.
+				// Subscribing after the replay snapshot left a window where those
+				// in-between events were simply lost.
 				const queue: GameEvent[] = [];
 				let resolve: (() => void) | null = null;
 
@@ -1360,11 +1318,100 @@ export function createRouter(roomManager: RoomManager) {
 					}
 				);
 
+				// Ids yielded during replay — bounded by the replay caps below, so this
+				// set stays small for the life of the subscription.
+				const replayedIds = new Set<string>();
+
+				// The try/finally must open before the replay: the subscriber is now
+				// attached, so a throw during the (async) replay has to reach the
+				// finally's unsubscribe() or the subscriber would leak.
 				wsConnectionsActive.inc({ room_id: input.roomId });
 				try {
+
+				const emitGapEvent = function* (reason: string) {
+					ringFeedReplayGapTotal.inc({ room_id: input.roomId });
+					const gapId = `${Date.now()}-gap-${randomUUID().slice(0, 8)}`;
+					const gapEvent: GameEvent = {
+						id: gapId,
+						roomId: input.roomId,
+						timestamp: Date.now(),
+						type: 'system.gap' as EventType,
+						scope: 'private' as EventScope,
+						targetUserId: ctx.userId,
+						text: '── Some events were missed while you were away. ──',
+						payload: { reason },
+					};
+					yield tracked(gapId, gapEvent);
+				};
+
+				// Deliver any missed events since the last received event ID.
+				if (input.lastEventId) {
+					const { events: buffered, truncated, upToDate, status } = eventBus.getEventsSince(
+						input.lastEventId
+					);
+					let missed: GameEvent[] = buffered;
+					let replayLimitReached = false;
+					if (truncated && !upToDate) {
+						const replay = await roomManager.getEventsSinceForRingFeed(
+							ctx.userId,
+							input.roomId,
+							input.lastEventId
+						);
+						missed = replay.events;
+						replayLimitReached = replay.limitReached;
+						log.debug('ringFeed replaying from durable storage', {
+							roomId: input.roomId,
+							userId: ctx.userId,
+							status,
+							replayed: missed.length,
+							limitReached: replayLimitReached,
+						});
+						if (missed.length > 0) {
+							ringFeedReplayFromDbTotal.inc({ room_id: input.roomId });
+						} else if (status === 'evicted') {
+							// Only warn when events demonstrably passed through the buffer
+							// while the room stayed loaded. A cold buffer with no stored
+							// events means the room was simply idle (the usual case after a
+							// deploy) — warning there would cry wolf on every restart.
+							yield* emitGapEvent('buffer_or_retention');
+						}
+					}
+					for (const event of missed) {
+						if (
+							event.scope === 'public' ||
+							event.targetUserId === ctx.userId
+						) {
+							replayedIds.add(event.id);
+							yield tracked(event.id, event);
+						}
+					}
+					if (replayLimitReached) {
+						// The replay hit its hard cap, so events between the last replayed
+						// row and "now" were silently skipped — say so rather than
+						// presenting a truncated stream as complete.
+						yield* emitGapEvent('replay_limit');
+					}
+				} else {
+					const recent = eventBus.getRecentEvents(100);
+					for (const event of recent) {
+						if (
+							event.scope === 'public' ||
+							event.targetUserId === ctx.userId
+						) {
+							replayedIds.add(event.id);
+							yield tracked(event.id, event);
+						}
+					}
+				}
+
+					// Stream live events until the client disconnects.
 					while (!signal?.aborted) {
 						while (queue.length > 0) {
 							const event = queue.shift()!;
+							// Events published while the replay was being assembled were
+							// captured by both the subscriber and (possibly) the replay
+							// itself — skip the buffered copy of anything already yielded.
+							if (replayedIds.has(event.id)) continue;
 							log.trace('ringFeed delivering event', {
 								roomId: input.roomId,
 								userId: ctx.userId,

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -8,6 +8,7 @@ const log = createLogger('router');
 
 import type { GameEvent, EventType, EventScope } from '@deck-monsters/engine';
 import { PROMPT_CANCELLED, PromptCancelledError } from '@deck-monsters/engine';
+import { buildQuickActions } from '../quick-actions.js';
 import { t } from './trpc.js';
 import { protectedProcedure, serviceProcedure } from './middleware.js';
 import type { RoomManager } from '../room-manager.js';
@@ -616,11 +617,30 @@ export function createRouter(roomManager: RoomManager) {
 							roomManager['log']?.(err);
 						}
 					})
+					.then(() => {
+						// Contextual suggestions for the console chip strip. Emitted after
+						// the flow settles (success or failure) so they reflect the state
+						// the user is actually looking at. Never let this throw into the
+						// pipeline — suggestions are a nicety, not part of the command.
+						try {
+							const actions = buildQuickActions(game, ctx.userId);
+							if (actions.length > 0) {
+								eventBus.publish({
+									type: 'quick_actions' as EventType,
+									scope: 'private',
+									targetUserId: ctx.userId,
+									text: '',
+									payload: { actions, causedByCommandId: commandId },
+								});
+							}
+						} catch (err: unknown) {
+							roomManager['log']?.(err);
+						}
+					})
 					.finally(() => {
 						activeFlows.delete(flowKey);
 					});
 
-				// TODO: emit quick_actions event after command completes with contextual suggestions
 
 				void touchMemberLastSeen(db, input.roomId, ctx.userId).catch(() => {});
 
@@ -1237,7 +1257,11 @@ export function createRouter(roomManager: RoomManager) {
 			// without needing a separate HTTP poll.
 			// Use a unique id per subscription invocation so no dedup layer (tRPC
 			// client, seenRef, etc.) can swallow the handshake on reconnect.
-			const handshakeId = `handshake-${Date.now()}`;
+			// Synthetic (non-persisted) frames still use the `${epochMs}-${suffix}` id
+			// shape that real events use. Cursor resolution parses that leading
+			// timestamp, so a client that echoes one of these ids back as its
+			// `lastEventId` still resolves by time instead of becoming unmatchable.
+			const handshakeId = `${Date.now()}-handshake`;
 			const handshakeEvent: GameEvent = {
 				id: handshakeId,
 				roomId: input.roomId,
@@ -1262,7 +1286,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				// Deliver any missed events since the last received event ID.
 				if (input.lastEventId) {
-					const { events: buffered, truncated, upToDate } = eventBus.getEventsSince(
+					const { events: buffered, truncated, upToDate, status } = eventBus.getEventsSince(
 						input.lastEventId
 					);
 					let missed: GameEvent[] = buffered;
@@ -1272,11 +1296,21 @@ export function createRouter(roomManager: RoomManager) {
 							input.roomId,
 							input.lastEventId
 						);
+						log.debug('ringFeed replaying from durable storage', {
+							roomId: input.roomId,
+							userId: ctx.userId,
+							status,
+							replayed: missed.length,
+						});
 						if (missed.length > 0) {
 							ringFeedReplayFromDbTotal.inc({ room_id: input.roomId });
-						} else {
+						} else if (status === 'evicted') {
+							// Only warn when events demonstrably passed through the buffer
+							// while the room stayed loaded. A cold buffer with no stored
+							// events means the room was simply idle (the usual case after a
+							// deploy) — warning there would cry wolf on every restart.
 							ringFeedReplayGapTotal.inc({ room_id: input.roomId });
-							const gapId = `system-gap-${Date.now()}-${randomUUID().slice(0, 8)}`;
+							const gapId = `${Date.now()}-gap-${randomUUID().slice(0, 8)}`;
 							const gapEvent: GameEvent = {
 								id: gapId,
 								roomId: input.roomId,
@@ -1369,7 +1403,7 @@ export function createRouter(roomManager: RoomManager) {
 						// If the queue is still empty after the wait it was a 20-s timeout —
 						// yield a private heartbeat frame so the TCP/WS connection stays alive.
 						if (queue.length === 0 && !signal?.aborted) {
-							const hbId = `heartbeat-${Date.now()}-${ctx.userId}`;
+							const hbId = `${Date.now()}-heartbeat`;
 							yield tracked(hbId, {
 								id: hbId,
 								roomId: input.roomId,

--- a/packages/server/src/trpc/router.ts
+++ b/packages/server/src/trpc/router.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../logger.js';
 const log = createLogger('router');
 
 import type { GameEvent, EventType, EventScope } from '@deck-monsters/engine';
+import { PROMPT_CANCELLED, PromptCancelledError } from '@deck-monsters/engine';
 import { t } from './trpc.js';
 import { protectedProcedure, serviceProcedure } from './middleware.js';
 import type { RoomManager } from '../room-manager.js';
@@ -294,7 +295,17 @@ function createSilentChannel({
 }
 
 export function createRouter(roomManager: RoomManager) {
-	const runSerializedMutation = async <T>(roomId: string, fn: () => Promise<T>): Promise<T> => {
+	const runSerializedMutation = async <T>(roomId: string, userId: string, fn: () => Promise<T>): Promise<T> => {
+		// Interactive console flows run in a per-user lane (see the `command`
+		// mutation) and can wait minutes on prompt answers. Workshop mutations
+		// must not interleave with that user's in-flight flow — fail fast with
+		// a clear message instead of silently mutating shared state mid-flow.
+		if (activeFlows.has(`${roomId}:${userId}`)) {
+			throw new TRPCError({
+				code: 'PRECONDITION_FAILED',
+				message: 'A console command is in progress — answer or cancel its prompt first.',
+			});
+		}
 		try {
 			return await roomManager.runSerializedEngineWork(roomId, fn);
 		} catch (err) {
@@ -549,7 +560,14 @@ export function createRouter(roomManager: RoomManager) {
 								? choices
 								: Object.keys(choices)
 							: [];
-						return eventBus.sendPrompt(ctx.userId, question, choiceKeys);
+						const answer = await eventBus.sendPrompt(ctx.userId, question, choiceKeys);
+						// Cancelled flows resolve with a sentinel — abort the action
+						// chain instead of handing '__cancelled__' to game code as an
+						// answer (it would be parsed as a card/monster selection).
+						if (answer === PROMPT_CANCELLED) {
+							throw new PromptCancelledError();
+						}
+						return answer;
 					}
 
 					if (announce) {
@@ -571,10 +589,14 @@ export function createRouter(roomManager: RoomManager) {
 				// HTTP connection open until the entire flow completes or times out.
 				// Instead, we return immediately; all output arrives via ringFeed.
 				//
-				// Serialize all engine work per room so two users cannot interleave
-				// handleCommand / ring combat on the same Game (fixes out-of-order ring feed).
+				// Serialize per room AND user. A room-wide lane would let one user's
+				// interactive flow (which can wait minutes on prompt answers) starve
+				// every other member's commands in the room. Same-user ordering is
+				// what actually matters for state consistency here: `activeFlows`
+				// already prevents concurrent flows for one user, and workshop
+				// mutations fail fast while the user has a flow in progress.
 				void roomManager
-					.runSerializedEngineWork(input.roomId, () =>
+					.runSerializedEngineWork(`${input.roomId}:${ctx.userId}`, () =>
 						action({
 							channel,
 							channelName: input.channelName,
@@ -584,9 +606,13 @@ export function createRouter(roomManager: RoomManager) {
 						})
 					)
 					.catch((err: unknown) => {
-						// Prompt timeouts are expected when users abandon a flow.
+						// Prompt timeouts and cancellations are expected when users
+						// abandon or cancel a flow — not errors.
+						const isCancelled =
+							err instanceof PromptCancelledError ||
+							(err instanceof Error && err.name === 'PromptCancelledError');
 						const msg = err instanceof Error ? err.message : String(err);
-						if (!msg.includes('Prompt timed out')) {
+						if (!isCancelled && !msg.includes('Prompt timed out')) {
 							roomManager['log']?.(err);
 						}
 					})
@@ -747,7 +773,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.unequipCard({
 						channel,
 						cardName: input.cardName,
@@ -808,7 +834,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.unequipAll({
 						channel,
 						monsterName: input.monsterName,
@@ -869,7 +895,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.equipCards({
 						channel,
 						monsterName: input.monsterName,
@@ -944,7 +970,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.moveCard({
 						channel,
 						cardName: input.cardName,
@@ -1022,7 +1048,7 @@ export function createRouter(roomManager: RoomManager) {
 
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const rawResult = await runSerializedMutation(input.roomId, () =>
+				const rawResult = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.reorderCards({
 						channel,
 						monsterName: input.monsterName,
@@ -1073,7 +1099,7 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.savePreset({
 						channel,
 						monsterName: input.monsterName,
@@ -1103,7 +1129,7 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.loadPreset({
 						channel,
 						monsterName: input.monsterName,
@@ -1157,7 +1183,7 @@ export function createRouter(roomManager: RoomManager) {
 				}
 				const commandId = randomUUID();
 				const channel = createSilentChannel({ eventBus, userId: ctx.userId, commandId });
-				const result = await runSerializedMutation(input.roomId, () =>
+				const result = await runSerializedMutation(input.roomId, ctx.userId, () =>
 					character.deletePreset({
 						channel,
 						monsterName: input.monsterName,


### PR DESCRIPTION
Resolves bug-doc items **#15, #16, #17, #18, #20, #21, #22, #23, #24, #25** (see `docs/roadmap/10-bug-fixes.md` for full write-ups of each), plus all four points from the requested-changes review. Records **#26** (process-wide shop singleton) for a design decision without fixing it.

## Engine

- **#20 — fight pacing**: `Ring.fight()`'s normal card-play path paced with `subEventDelay` (~1s) instead of the configured `veryShortDelay` (2–4s) every other fight path uses, so live fights scrolled by too fast to follow. `DECK_MONSTERS_SKIP_DELAYS` behavior unchanged.
- **#20 — multi-step command crashes**: cancelling a flow resolved prompts with the literal `'__cancelled__'` string that game code parsed as a selection, and `chooseItems` only accepted numeric indices (a typed card name became `NaN` and aborted the whole flow). The engine now exports `PROMPT_CANCELLED`/`PromptCancelledError`; `chooseItems` accepts indices or case-insensitive names and skips invalid entries instead of aborting.
- **#25 — CRITICAL, cross-room reward duplication**: `Game`'s `creature.win`/`loss`/`permaDeath`/`fled` listeners sat unscoped on the process-wide semaphore, so one fight's outcome granted XP, coins, and a drawn card **once per currently-loaded room**. Now wrapped with the room-scoping guard. Also: `Ring.handlePermaDeath` was missing the emit its siblings have, so perma-death owners previously got *no* reward at all.
- **#22/#23/#24**: boss despawn timers are now tracked and disposed; `stateChange` save scheduling is room-scoped (one room's activity can no longer reset another's save debounce); direct in-place mutations in `getCharacter`, `Ring.removeMonster`, and `removeItem` now go through setters so they persist across restarts. The room-scoping guard itself was hardened against a reentrancy stack-overflow (it now reads raw `optionsStore`, never live lazy-initializing getters).

## Server

- **#16/#17 — reconnect replay**: a cold ring buffer (the state after every restart/idle eviction) reported `truncated: false`, suppressing the durable-storage fallback entirely — returning players silently got nothing. `EventsSinceResult` now carries a `found/ahead/evicted/cold` status; cold replays hit the DB without false gap warnings, evicted-and-empty warns. Synthetic frame ids (`handshake`/`heartbeat`/gap) now use the standard `${epochMs}-` shape so a stray cursor stays resolvable.
- **#15 — fight summaries**: the pending-fight snapshot is captured synchronously at `fightResolved` delivery (fixing the cross-fight clobber race), writes retry with backoff instead of dropping rows on transient DB errors, and per-room maps are cleaned on detach.
- **#18 — quick actions**: new `buildQuickActions` emits up to four contextual command chips after each command settles, using real `COMMAND_CATALOG` syntax; excluded from event persistence.
- **#20 — command starvation**: interactive command actions moved from the room-wide serialized lane to per-`roomId:userId` lanes; workshop mutations fail fast with `PRECONDITION_FAILED` while the caller has an active console flow instead of hanging behind it.
- **#21 — idle sweep**: `unloadRoom` no longer unloads a room mid-fight (retries next sweep), so in-progress fights can't lose their announcements/stats/summary.

## Review fixes (requested changes)

1. **Replay race**: the ringFeed live subscriber now attaches *before* the replay is assembled (buffered duplicates dropped by id on drain; try/finally opens before the replay so a throw can't leak the subscriber), and `getEventsSinceForRingFeed` paginates past the old single-query 500-row cliff, surfacing `limitReached` so a `system.gap` marker is emitted instead of a silently truncated stream.
2. **Retry-after-reset**: detaching the fight-summary writer now cancels queued/backoff retries, so no write can land after `resetRoomState()` clears summaries and resets the counter.
3. **Flow-lock race**: `activeFlows` is now a Map keyed by flow token; a cancelled flow's late-settling cleanup only clears a lock it still owns, so it can no longer release a newer command's lock. `cancelFlow`'s force-clear stays unconditional.
4. **Doc drift**: `CLAUDE.md` and `AGENTS.md` no longer list #15/#16 as active; both point at the actual root causes and the still-open #26.

## Testing

680 tests pass across all packages (480 engine / 105 server / 71 web / 20 discord / 4 harness); build and lint clean. New coverage includes: per-user command lanes, workshop fail-fast, the cancellation-overlap scenario, quick-action emission, subscribe-before-replay ordering + dedup, replay pagination and the replay-cap gap marker, retry cancellation on detach, named/cancelled/invalid item-selection parsing, cross-room reward isolation, and a full fight through the real non-skipped pacing path (previously zero coverage on the non-skip branches).

Architecture notes for future maintainers are in `docs/engine-concurrency-and-timing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnewFgP4nZXktp3iqj9NVJ