### PR TITLE
Fix Cloud Agent environment startup

### DIFF
--- a/.cursor/cloud-agent-install.sh
+++ b/.cursor/cloud-agent-install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Docker without starting it. Environment builds preserve packages and
+# configuration, but not running processes; startup belongs in the start phase.
+sudo install -m 0755 -d /etc/apt/keyrings
+curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg |
+  sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+docker_arch="$(dpkg --print-architecture)"
+. /etc/os-release
+echo "deb [arch=${docker_arch} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" |
+  sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y \
+  containerd.io \
+  docker-buildx-plugin \
+  docker-ce \
+  docker-ce-cli \
+  docker-compose-plugin \
+  fuse-overlayfs \
+  iptables
+sudo rm -rf /var/lib/apt/lists/*
+
+sudo install -m 0755 -d /etc/docker
+printf '%s\n' '{' '  "storage-driver": "fuse-overlayfs"' '}' |
+  sudo tee /etc/docker/daemon.json >/dev/null
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+
+# Install Railway in the NVM-managed Node prefix so it remains on the agent PATH.
+npm install --global @railway/cli@5.30.3
+
+pnpm install --frozen-lockfile
+pnpm build

--- a/.cursor/cloud-agent-start.sh
+++ b/.cursor/cloud-agent-start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A daemon started during an environment build does not survive the snapshot.
+# Reconcile Docker on every pod boot and wait for the socket to become usable.
+if ! sudo docker info >/dev/null 2>&1; then
+  sudo service docker start || true
+fi
+
+for _attempt in $(seq 1 30); do
+  if sudo test -S /var/run/docker.sock; then
+    sudo chmod 666 /var/run/docker.sock
+  fi
+
+  if docker info >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  sleep 1
+done
+
+echo "Docker did not become ready within 30 seconds." >&2
+sudo service docker status || true
+exit 1

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://www.cursor.com/schemas/environment.schema.json",
+  "name": "Deck Monsters",
+  "install": "bash .cursor/cloud-agent-install.sh",
+  "start": "bash .cursor/cloud-agent-start.sh"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ node_modules/
 *.sw*
 .idea/
 .vscode/
-.cursor/
+.cursor/*
+!.cursor/environment.json
+!.cursor/cloud-agent-install.sh
+!.cursor/cloud-agent-start.sh
 
 # FILESYSTEM
 .DS_Store


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the recurring Cloud Agent warning **"Install script failed"** / `sh: Bad substitution` after Railway’s `curl | sh` installer, and moves Docker daemon startup out of the snapshot-only `install` phase.

This environment is currently **Personal / DB-managed**. Until the dashboard install script is updated (or this lands on the revision agents use), new JIT agents can still run the old broken Personal install.

## Root cause
The saved Personal install:
1. installs Railway via `curl … | sudo sh`, which fails with `sh: 146: Bad substitution` (nonzero install status)
2. starts `dockerd` during `install`, which does not survive environment-build snapshots

## Changes
- add repository-managed `.cursor/environment.json`
- `.cursor/cloud-agent-install.sh` — Docker packages/config only, Railway via `npm i -g @railway/cli@5.30.3`, `pnpm install --frozen-lockfile`, `pnpm build`
- `.cursor/cloud-agent-start.sh` — idempotent Docker start + socket readiness poll
- allow-list those `.cursor` files in `.gitignore`

## Validation evidence
| Check | Result |
| --- | --- |
| Unchanged Personal config build | succeeded, but still had `Bad substitution` noise and install-time `dockerd` |
| Branch build [`bld-20260803-81784813-305f-4f6e-91bc-93e3ae9cd617`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260803-81784813-305f-4f6e-91bc-93e3ae9cd617) | **SUCCEEDED**, install exit 0, no Bad substitution, no dockerd in install |
| Inline fixed-config build [`bld-20260803-be90069b-d071-4d97-bc1f-1eb047fedce5`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260803-be90069b-d071-4d97-bc1f-1eb047fedce5) | **SUCCEEDED**, install exit 0 |
| Fresh agent from fixed build | install skipped; `node`/`pnpm`/`railway` present; engine demo + 24 experience tests pass |
| Automatic user `start` on draft-build boots | **not executed** by platform (only system starts); Docker start command validated manually (`hello-world`, Docker 29.7.1, `fuse-overlayfs`, idempotent) |

## Required follow-up (dashboard)
Because this env is Personal/DB-managed, **also replace the dashboard Install/Start scripts** with the same content as the new shell scripts (or point them at `bash .cursor/cloud-agent-*.sh` after merge). Otherwise JIT agents keep using the broken Railway `curl|sh` install.

After that: merge this PR, then [Enable builds](https://cursor.com/dashboard/cloud-agents/environments/e/6df579cf-8c8c-11f1-a7d1-d6b4613131ce#builds).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e629f9c3-f49b-49eb-b02d-c983dab9db92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e629f9c3-f49b-49eb-b02d-c983dab9db92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

