### PR TITLE
fix(engine): look at the ring produces no console response

### DIFF
--- a/docs/superpowers/plans/2026-08-03-fix-look-at-the-ring-report.md
+++ b/docs/superpowers/plans/2026-08-03-fix-look-at-the-ring-report.md
@@ -1,0 +1,82 @@
+# Report: Fix `look at the ring` silent no-op
+
+**Date:** 2026-08-03  
+**Branch:** `cursor/fix-look-at-the-ring-42d2`  
+**Plan:** [`2026-08-03-fix-look-at-the-ring.md`](./2026-08-03-fix-look-at-the-ring.md)
+
+## Summary
+
+`look at the ring` (and related `monsters in` / `cards in` ring look commands) published private `announce` events with `targetUserId` set to the **channel function** instead of the user's string id. Subscribers filter by string `userId`, so no output reached the web console.
+
+**Fix:** Pass `user?.id` to `game.lookAtRing` / `game.lookAtRingCards` in `packages/engine/src/commands/look-at.ts`.
+
+## TDD — RED
+
+Added `describe('look at the ring', …)` to `packages/server/src/integration/command-flow.test.ts` with two cases subscribing to `game.eventBus` (not `channel.announces`).
+
+### Run (before fix)
+
+```text
+$ pnpm --filter @deck-monsters/engine build
+$ cd packages/server && pnpm exec mocha --config .mocharc.yml 'src/integration/command-flow.test.ts' --grep 'look at the ring'
+
+  integration: command flow
+    look at the ring
+      1) announces an empty ring to the requesting user via the event bus
+      2) announces ring contestants to the requesting user via the event bus
+
+  0 passing (121ms)
+  2 failing
+
+  1) ... should publish private announces to USER_A
+      + expected - actual
+
+  2) ... should mention contestants: expected '\n\n' to match /contestant/i
+```
+
+**Interpretation:** With the bug, `Ring.look` called `pub(..., channel)` where `channel` is a function. Private announces were emitted with `targetUserId` equal to that function object, so `events.filter(e => e.targetUserId === USER_A)` matched nothing (test 1) or only unrelated bus traffic (test 2).
+
+## TDD — GREEN
+
+### Code change
+
+`packages/engine/src/commands/look-at.ts`:
+
+- Destructure `user` in `lookAtAction`.
+- For `ring`, `monsters in`, and `cards in` cases: pass `user?.id` instead of `channel`.
+
+### Test assertion fix
+
+Ring `pub()` sets message text on `GameEvent.text`, not `payload.text`. Tests updated to use `e.text`.
+
+### Run (after fix)
+
+```text
+$ pnpm --filter @deck-monsters/engine build
+$ cd packages/server && pnpm exec mocha --config .mocharc.yml 'src/integration/command-flow.test.ts' --grep 'look at the ring'
+
+  integration: command flow
+    look at the ring
+      ✔ announces an empty ring to the requesting user via the event bus
+      ✔ announces ring contestants to the requesting user via the event bus
+
+  2 passing (56ms)
+```
+
+### Broader verification
+
+```text
+$ pnpm --filter @deck-monsters/engine test
+  657 passing (3s)
+
+$ cd packages/server && pnpm exec mocha --config .mocharc.yml 'src/integration/command-flow.test.ts'
+  134 passing (2s)
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `packages/engine/src/commands/look-at.ts` | Pass `user?.id` for ring look commands |
+| `packages/server/src/integration/command-flow.test.ts` | New integration tests for empty and non-empty ring |
+| `docs/superpowers/plans/2026-08-03-fix-look-at-the-ring-report.md` | This report |

--- a/docs/superpowers/plans/2026-08-03-fix-look-at-the-ring.md
+++ b/docs/superpowers/plans/2026-08-03-fix-look-at-the-ring.md
@@ -1,0 +1,29 @@
+# Fix: `look at the ring` silent no-op
+
+## Root cause
+
+`packages/engine/src/commands/look-at.ts` passes the **channel function** into `game.lookAtRing` / `lookAtRingCards`, which expect a **string `userId`**. `Ring.look` publishes private events with that value as `targetUserId`. A Function never matches any subscriber's string `userId`, so announces are undelivered. The web console still shows the command echo (server-published separately) but no response.
+
+## Approach
+
+Pass `user?.id` (string) instead of `channel` for the three ring look cases. Match the pattern used by `sendMonsterToTheRing({ userId: user?.id })`.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/engine/src/commands/look-at.ts` | Destructure `user`; pass `user?.id` to `lookAtRing` / `lookAtRingCards` |
+| `packages/server/src/integration/command-flow.test.ts` | Add integration tests: empty ring + ring with contestant |
+
+## TDD
+
+1. RED: Add test that runs `look at the ring` via `runCommand`, subscribes to event bus with `userId`, asserts private `announce` with correct `targetUserId` and text containing "empty" (empty ring) / contestant info (non-empty).
+2. Confirm failure (no announces with matching targetUserId, or wrong target).
+3. GREEN: Fix `look-at.ts`.
+4. Re-run tests.
+
+## Out of scope
+
+- Refactoring `Ring.look` to use channel callbacks
+- Web UI changes (filtering is correct)
+- Docs roadmap archive (optional follow-up)

--- a/packages/engine/src/commands/look-at.ts
+++ b/packages/engine/src/commands/look-at.ts
@@ -20,17 +20,17 @@ function lookAtAction({ channel, character, game, results, user }: any): Promise
 					return character.lookAtInventory(channel);
 				case 'ring': {
 					const summary = thing === 'summary';
-					return game.lookAtRing(user?.id, undefined, true, summary);
+					return game.lookAtRing(user.id, undefined, true, summary);
 				}
 				case 'monsters in': {
 					thing = thing.replace(/the /i, '');
 					const ringName = thing === 'ring' ? undefined : thing;
-					return game.lookAtRing(user?.id, ringName, false);
+					return game.lookAtRing(user.id, ringName, false);
 				}
 				case 'cards in': {
 					thing = thing.replace(/the /i, '');
 					const ringName = thing === 'ring' ? undefined : thing;
-					return game.lookAtRingCards(user?.id, ringName);
+					return game.lookAtRingCards(user.id, ringName);
 				}
 				case 'monsters': {
 					const inDetail = thing === 'in detail';

--- a/packages/engine/src/commands/look-at.ts
+++ b/packages/engine/src/commands/look-at.ts
@@ -3,7 +3,7 @@ import type { registerHandler } from './index.js';
 const LOOK_AT_REGEX =
 	/look (?:at )?(?:the )?(monster(?:s)? manual|player(?:s)? handbook|(?:dungeon master(?:s)|dm)? guide|monsters in|monsters|monster|character|cards in|card inventory|all cards|inventory|cards|card|deck|item|items|ring|dmg)?( .+)?$/i;
 
-function lookAtAction({ channel, character, game, results }: any): Promise<unknown> {
+function lookAtAction({ channel, character, game, results, user }: any): Promise<unknown> {
 	return Promise.resolve()
 		.then(() => {
 			const type = (results[1] || '').trim().toLowerCase();
@@ -20,17 +20,17 @@ function lookAtAction({ channel, character, game, results }: any): Promise<unkno
 					return character.lookAtInventory(channel);
 				case 'ring': {
 					const summary = thing === 'summary';
-					return game.lookAtRing(channel, undefined, true, summary);
+					return game.lookAtRing(user?.id, undefined, true, summary);
 				}
 				case 'monsters in': {
 					thing = thing.replace(/the /i, '');
 					const ringName = thing === 'ring' ? undefined : thing;
-					return game.lookAtRing(channel, ringName, false);
+					return game.lookAtRing(user?.id, ringName, false);
 				}
 				case 'cards in': {
 					thing = thing.replace(/the /i, '');
 					const ringName = thing === 'ring' ? undefined : thing;
-					return game.lookAtRingCards(channel, ringName);
+					return game.lookAtRingCards(user?.id, ringName);
 				}
 				case 'monsters': {
 					const inDetail = thing === 'in detail';

--- a/packages/server/src/integration/command-flow.test.ts
+++ b/packages/server/src/integration/command-flow.test.ts
@@ -18,6 +18,7 @@ import {
 	createRoomCommandRunner,
 } from '../shared/test-helpers.js';
 import { BOSS_SUMMON_LIMIT, summonAllowance, allMonsters } from '@deck-monsters/engine';
+import type { GameEvent } from '@deck-monsters/engine';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -330,6 +331,65 @@ describe('integration: command flow', function () {
 			const cancelEvent = events.find(e => e.type === 'prompt.cancel');
 			expect(cancelEvent, 'prompt.cancel event should be published').to.exist;
 			expect(cancelEvent?.targetUserId).to.equal(USER_A);
+		});
+	});
+
+	describe('look at the ring', () => {
+		const ringLookAnnounces = (events: GameEvent[]) =>
+			events.filter(
+				(e) =>
+					e.type === 'announce' &&
+					e.scope === 'private' &&
+					e.targetUserId === USER_A,
+			);
+
+		it('announces an empty ring to the requesting user via the event bus', async () => {
+			const game = createTestGame();
+			const events: GameEvent[] = [];
+
+			const unsub = game.eventBus.subscribe('look-ring-empty', {
+				userId: USER_A,
+				deliver: (e) => events.push(e),
+			});
+
+			const responder = createAutoResponder(game.eventBus, USER_A, NEW_CHARACTER_ANSWERS);
+			await runCommand(game, { command: 'look at the ring', userId: USER_A, isDM: true });
+			responder.unsubscribe();
+			unsub();
+
+			const announces = ringLookAnnounces(events);
+			expect(announces.length, 'should publish private announces to USER_A').to.be.above(0);
+			const text = announces.map((e) => e.text).join('\n');
+			expect(text, 'empty ring message').to.match(/empty/i);
+		});
+
+		it('announces ring contestants to the requesting user via the event bus', async () => {
+			const game = createTestGame();
+			const events: GameEvent[] = [];
+
+			const unsub = game.eventBus.subscribe('look-ring-contestants', {
+				userId: USER_A,
+				deliver: (e) => events.push(e),
+			});
+
+			// Character + monster, then seed the ring (same pattern as summon-a-boss tests).
+			const spawnAnswers = [...NEW_CHARACTER_ANSWERS, ...SPAWN_ANSWERS];
+			const spawner = createAutoResponder(game.eventBus, USER_A, spawnAnswers);
+			await runCommand(game, { command: 'spawn a monster', userId: USER_A, isDM: true });
+			spawner.unsubscribe();
+
+			const character = game.characters[USER_A];
+			const monster = character.monsters[0];
+			game.ring.addMonster({ monster, character, userId: USER_A });
+
+			await runCommand(game, { command: 'look at the ring', userId: USER_A, isDM: true });
+			unsub();
+
+			const announces = ringLookAnnounces(events);
+			expect(announces.length, 'should publish private announces to USER_A').to.be.above(0);
+			const text = announces.map((e) => e.text).join('\n');
+			expect(text, 'should mention contestants').to.match(/contestant/i);
+			expect(text, 'should mention the monster name').to.include('Fang');
 		});
 	});
 

--- a/packages/server/src/integration/command-flow.test.ts
+++ b/packages/server/src/integration/command-flow.test.ts
@@ -345,31 +345,54 @@ describe('integration: command flow', function () {
 
 		it('announces an empty ring to the requesting user via the event bus', async () => {
 			const game = createTestGame();
-			const events: GameEvent[] = [];
+			const eventsA: GameEvent[] = [];
+			const eventsB: GameEvent[] = [];
 
-			const unsub = game.eventBus.subscribe('look-ring-empty', {
+			const unsubA = game.eventBus.subscribe('look-ring-empty-a', {
 				userId: USER_A,
-				deliver: (e) => events.push(e),
+				deliver: (e) => eventsA.push(e),
+			});
+			const unsubB = game.eventBus.subscribe('look-ring-empty-b', {
+				userId: USER_B,
+				deliver: (e) => eventsB.push(e),
 			});
 
 			const responder = createAutoResponder(game.eventBus, USER_A, NEW_CHARACTER_ANSWERS);
 			await runCommand(game, { command: 'look at the ring', userId: USER_A, isDM: true });
 			responder.unsubscribe();
-			unsub();
+			unsubA();
+			unsubB();
 
-			const announces = ringLookAnnounces(events);
+			const announces = ringLookAnnounces(eventsA);
 			expect(announces.length, 'should publish private announces to USER_A').to.be.above(0);
+			for (const ev of announces) {
+				expect(ev.scope).to.equal('private');
+				expect(ev.targetUserId).to.equal(USER_A);
+			}
 			const text = announces.map((e) => e.text).join('\n');
 			expect(text, 'empty ring message').to.match(/empty/i);
+
+			const leakedToB = eventsB.filter(
+				(e) =>
+					e.scope === 'private' &&
+					e.type === 'announce' &&
+					e.text?.toLowerCase().includes('empty'),
+			);
+			expect(leakedToB, 'USER_B must not receive private ring look announces').to.have.length(0);
 		});
 
 		it('announces ring contestants to the requesting user via the event bus', async () => {
 			const game = createTestGame();
-			const events: GameEvent[] = [];
+			const eventsA: GameEvent[] = [];
+			const eventsB: GameEvent[] = [];
 
-			const unsub = game.eventBus.subscribe('look-ring-contestants', {
+			const unsubA = game.eventBus.subscribe('look-ring-contestants-a', {
 				userId: USER_A,
-				deliver: (e) => events.push(e),
+				deliver: (e) => eventsA.push(e),
+			});
+			const unsubB = game.eventBus.subscribe('look-ring-contestants-b', {
+				userId: USER_B,
+				deliver: (e) => eventsB.push(e),
 			});
 
 			// Character + monster, then seed the ring (same pattern as summon-a-boss tests).
@@ -382,14 +405,25 @@ describe('integration: command flow', function () {
 			const monster = character.monsters[0];
 			game.ring.addMonster({ monster, character, userId: USER_A });
 
-			await runCommand(game, { command: 'look at the ring', userId: USER_A, isDM: true });
-			unsub();
+			// Ignore spawn/add public traffic; only assert look-at-ring delivery.
+			eventsA.length = 0;
+			eventsB.length = 0;
 
-			const announces = ringLookAnnounces(events);
+			await runCommand(game, { command: 'look at the ring', userId: USER_A, isDM: true });
+			unsubA();
+			unsubB();
+
+			const announces = ringLookAnnounces(eventsA);
 			expect(announces.length, 'should publish private announces to USER_A').to.be.above(0);
+			for (const ev of announces) {
+				expect(ev.scope).to.equal('private');
+				expect(ev.targetUserId).to.equal(USER_A);
+			}
 			const text = announces.map((e) => e.text).join('\n');
 			expect(text, 'should mention contestants').to.match(/contestant/i);
 			expect(text, 'should mention the monster name').to.include('Fang');
+
+			expect(eventsB, 'USER_B must not receive look-at-ring events').to.have.length(0);
 		});
 	});
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`look at the ring` (top quick-action suggestion) showed the command echo in the Console tab but no response text — matching the production screenshot where prior commands (`send … to the ring`, `summon a boss`) worked.

## Root cause

`packages/engine/src/commands/look-at.ts` passed the **channel callback** into `game.lookAtRing` / `lookAtRingCards`, which expect a **string `userId`**. `Ring.look` publishes private `announce` events with that value as `targetUserId`. A Function never matches any subscriber’s string id, so events were undeliverable.

The server still published the command echo correctly (`consoleInput` with the real user id), which is why the console showed `> look at the ring` with nothing after it.

Same bug affected `look at monsters in the ring` and `look at cards in the ring`.

## Fix

Pass `user.id` for the three ring-look cases, matching how other ring APIs receive `userId`.

## Tests

Integration coverage in `command-flow.test.ts`:

- Empty ring → private announce containing “empty” for the requesting user
- Non-empty ring → private announces mentioning contestants / monster name
- Privacy: another user’s subscriber receives no look-at-ring events

TDD plan/report: `docs/superpowers/plans/2026-08-03-fix-look-at-the-ring*.md`

## Verification

- `pnpm --filter @deck-monsters/engine build`
- `mocha … command-flow.test.ts --grep 'look at the ring'` → 2 passing
- Full `command-flow.test.ts` → 134 passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7abbdb97-de50-4a23-86ec-dd4852fe42d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7abbdb97-de50-4a23-86ec-dd4852fe42d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

