### PR TITLE
fix(server): stop suggesting send-to-ring when it will fail

### DIFF
--- a/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room-report.md
+++ b/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room-report.md
@@ -1,0 +1,63 @@
+# Report: Fix send-to-ring quick-action false failures
+
+**Date:** 2026-08-03  
+**Branch:** `cursor/fix-send-to-ring-quick-actions-42d2`  
+**Plan:** [`2026-08-03-fix-send-to-ring-room.md`](./2026-08-03-fix-send-to-ring-room.md)
+
+## Summary
+
+Quick-action chips no longer suggest `send {name} to the ring` unless the monster has a full deck (`cards.length >= cardSlots`, default 9). Equip is offered for idle out-of-ring monsters when unequipped cards exist. Send/call-out-of-ring paths now use `user.id` instead of `user?.id`.
+
+## RED (before fix)
+
+Command:
+
+```bash
+pnpm --filter @deck-monsters/server exec mocha --config .mocharc.yml 'src/quick-actions.test.ts'
+```
+
+Result: **3 failing** (of 136 total in suite run)
+
+```
+1) does not suggest send when the monster has no cards equipped
+   AssertionError: expected [ 'send Fluffy to the ring', …(2) ] to not include 'send Fluffy to the ring'
+
+2) does not suggest send when the monster has fewer cards than slots
+   AssertionError: expected [ 'send Fluffy to the ring', …(2) ] to not include 'send Fluffy to the ring'
+
+3) suggests equip instead of send when idle monsters are not deck-ready but unequipped cards exist
+   AssertionError: expected [ 'send Fluffy to the ring', …(3) ] to not include 'send Fluffy to the ring'
+```
+
+## GREEN (after fix)
+
+Command:
+
+```bash
+pnpm --filter @deck-monsters/engine build
+pnpm --filter @deck-monsters/server exec mocha --config .mocharc.yml 'src/quick-actions.test.ts'
+```
+
+Result: **136 passing** (2s)
+
+Engine smoke:
+
+```bash
+node --input-type=module -e "import { Game } from './packages/engine/dist/index.js'; const g = new Game({}, console.log); console.log('Engine OK'); g.dispose();"
+# → Engine OK
+```
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `packages/server/src/quick-actions.ts` | `isDeckReady()` helper; `readyToSend` gated on deck readiness; `idleOutOfRing` for equip targeting |
+| `packages/server/src/quick-actions.test.ts` | New deck-readiness cases; flipped send-with-empty-deck expectations |
+| `packages/engine/src/commands/monster.ts` | `user?.id` → `user.id` on send-to-ring and call-out-of-ring |
+
+## Test coverage added
+
+- No send when `cards: []` or insufficient cards vs default 9 slots
+- Send when 9 cards or `cardSlots: 2` with 2 cards
+- Equip (not Send) when living idle monster lacks deck but `character.deck` has cards
+- Existing ring/other-player tests updated to use deck-ready monsters where Send is expected

--- a/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room.md
+++ b/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room.md
@@ -1,0 +1,31 @@
+# Fix: send-to-ring fails after working in other rooms
+
+## Context
+
+User: `"send monster to the ring" failed in one of my rooms too even after completing in two other rooms`.
+
+Characters are room-scoped — each room needs its own spawn/equip. Investigation also found a real suggestion bug that produces false failures.
+
+## Root causes (ranked)
+
+1. **Quick actions suggest Send without a full deck** (`packages/server/src/quick-actions.ts`)
+   - `readyToSend` only checks living + not already in ring
+   - Engine refuses with: `Only an evil master would send their monster into battle without enough cards.`
+   - Existing tests encode the bad behavior (send suggested with `deck: []` and no cards on monster)
+   - Chip order can put Send above Equip
+
+2. **Expected room-local state** (not a code bug): no monsters / incomplete equip / already in ring / mid-fight in that room only
+
+3. **`user?.id` optional** on send path — if ever undefined, private countdown/full-ring announces become public and the Console tab drops them (echo only)
+
+## Fix scope
+
+1. `buildQuickActions`: only offer Send when `monster.cards.length >= cardSlots` (default 9)
+2. Prefer Equip over Send when living monsters exist but none are deck-ready and unequipped cards exist
+3. Update unit tests (TDD)
+4. Harden send / call-out paths to `user.id` like the look-at-ring fix
+
+## Out of scope
+
+- Changing room-scoped character design
+- Console showing public `ring.add` events

--- a/packages/engine/src/commands/monster.ts
+++ b/packages/engine/src/commands/monster.ts
@@ -64,7 +64,7 @@ function callMonsterOutOfTheRingAction({
 		const { monsterName } = cleanArgs({ monsterName: results[1] });
 
 		return character
-			.callMonsterOutOfTheRing({ monsterName, ring: game.getRing(), channel, channelName, userId: user?.id })
+			.callMonsterOutOfTheRing({ monsterName, ring: game.getRing(), channel, channelName, userId: user.id })
 			.catch((err: unknown) => game.log(err));
 	});
 }
@@ -253,7 +253,7 @@ function sendMonsterToTheRingAction({
 				ring: game.getRing(),
 				channel,
 				channelName,
-				userId: user?.id,
+				userId: user.id,
 			})
 			.catch((err: unknown) => game.log(err));
 	});

--- a/packages/server/src/quick-actions.test.ts
+++ b/packages/server/src/quick-actions.test.ts
@@ -74,6 +74,18 @@ describe('buildQuickActions', () => {
 		expect(commands).to.not.include('send Fluffy to the ring');
 	});
 
+	it('does not suggest send for a second monster when one is already in the ring', () => {
+		const inRing = { givenName: 'Fluffy', cards: makeCards(9) };
+		const idle = { givenName: 'Rex', cards: makeCards(9) };
+		const game = makeGame({ monsters: [inRing, idle], deck: [] }, [
+			{ userId: USER, monster: inRing },
+		]);
+		const commands = buildQuickActions(game, USER).map((a) => a.command);
+		expect(commands).to.include('look at the ring');
+		expect(commands).to.not.include('send Rex to the ring');
+		expect(commands).to.not.include('send Fluffy to the ring');
+	});
+
 	it('offers to revive a dead monster', () => {
 		const game = makeGame({
 			monsters: [{ givenName: 'Fluffy', dead: true }],

--- a/packages/server/src/quick-actions.test.ts
+++ b/packages/server/src/quick-actions.test.ts
@@ -4,6 +4,9 @@ import { buildQuickActions } from './quick-actions.js';
 
 const USER = 'user-1';
 
+const makeCards = (count: number): Array<{ cardType: string }> =>
+	Array.from({ length: count }, (_, i) => ({ cardType: `Card${i}` }));
+
 const makeGame = (
 	character: Record<string, unknown> | undefined,
 	contestants: Array<{ userId?: string; monster?: unknown; isBoss?: boolean }> = []
@@ -26,10 +29,39 @@ describe('buildQuickActions', () => {
 		expect(actions[0]?.command).to.equal('spawn monster');
 	});
 
-	it('offers to send an idle monster into the ring', () => {
-		const monster = { givenName: 'Fluffy' };
+	it('does not suggest send when the monster has no cards equipped', () => {
+		const monster = { givenName: 'Fluffy', cards: [] };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.not.include('send Fluffy to the ring');
+	});
+
+	it('does not suggest send when the monster has fewer cards than slots', () => {
+		const monster = { givenName: 'Fluffy', cards: makeCards(3) };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.not.include('send Fluffy to the ring');
+	});
+
+	it('suggests send when the monster has a full default deck (9 cards)', () => {
+		const monster = { givenName: 'Fluffy', cards: makeCards(9) };
 		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
 		expect(actions.map((a) => a.command)).to.include('send Fluffy to the ring');
+	});
+
+	it('suggests send when cards meet a custom cardSlots count', () => {
+		const monster = { givenName: 'Fluffy', cards: makeCards(2), cardSlots: 2 };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.include('send Fluffy to the ring');
+	});
+
+	it('suggests equip instead of send when idle monsters are not deck-ready but unequipped cards exist', () => {
+		const monster = { givenName: 'Fluffy', cards: [] };
+		const actions = buildQuickActions(
+			makeGame({ monsters: [monster], deck: [{ cardType: 'Hit' }] }),
+			USER
+		);
+		const commands = actions.map((a) => a.command);
+		expect(commands).to.include('equip Fluffy');
+		expect(commands).to.not.include('send Fluffy to the ring');
 	});
 
 	it('offers the ring view instead of a send for a monster already fighting', () => {
@@ -79,7 +111,7 @@ describe('buildQuickActions', () => {
 	});
 
 	it('ignores ring contestants belonging to other players', () => {
-		const mine = { givenName: 'Fluffy' };
+		const mine = { givenName: 'Fluffy', cards: makeCards(9) };
 		const theirs = { givenName: 'Rex' };
 		const game = makeGame({ monsters: [mine], deck: [] }, [
 			{ userId: 'someone-else', monster: theirs },
@@ -93,8 +125,8 @@ describe('buildQuickActions', () => {
 		const game = makeGame(
 			{
 				monsters: [
-					{ givenName: 'InRing' },
-					{ givenName: 'Idle' },
+					{ givenName: 'InRing', cards: makeCards(9) },
+					{ givenName: 'Idle', cards: makeCards(9) },
 					{ givenName: 'Dead', dead: true },
 				],
 				deck: [{ cardType: 'Hit' }],

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -127,7 +127,8 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 		add('Look at the ring', 'look at the ring');
 	}
 
-	const nextToSend = readyToSend[0];
+	// Engine allows only one of the player's monsters in the ring at a time.
+	const nextToSend = !hasMonsterInRing ? readyToSend[0] : undefined;
 	if (nextToSend) {
 		add(`Send ${monsterName(nextToSend)} to the ring`, `send ${monsterName(nextToSend)} to the ring`);
 	}

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -20,6 +20,7 @@ export interface QuickAction {
 }
 
 const MAX_QUICK_ACTIONS = 4;
+const DEFAULT_CARD_SLOTS = 9;
 
 type LooseRecord = Record<string, unknown>;
 
@@ -43,6 +44,14 @@ const isDead = (monster: unknown): boolean =>
 
 const isDestroyed = (monster: unknown): boolean =>
 	Boolean((monster as LooseRecord | undefined)?.destroyed);
+
+const cardSlots = (monster: unknown): number => {
+	const slots = (monster as LooseRecord | undefined)?.cardSlots;
+	return typeof slots === 'number' && slots > 0 ? slots : DEFAULT_CARD_SLOTS;
+};
+
+const isDeckReady = (monster: unknown): boolean =>
+	asArray((monster as LooseRecord | undefined)?.cards).length >= cardSlots(monster);
 
 /** Defensive read — this runs inside the command pipeline and must never throw. */
 const summonsRemaining = (game: QuickActionsGame, userId: string): number => {
@@ -95,7 +104,8 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 	const deadRevivable = monsters.filter(
 		(monster) => isDead(monster) && !isDestroyed(monster)
 	);
-	const readyToSend = living.filter((monster) => !ringMonsters.has(monster));
+	const idleOutOfRing = living.filter((monster) => !ringMonsters.has(monster));
+	const readyToSend = idleOutOfRing.filter(isDeckReady);
 	const hasMonsterInRing = living.some((monster) => ringMonsters.has(monster));
 	const unequippedCards = asArray(character.deck).length;
 
@@ -129,7 +139,7 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 
 	// Equipping is rejected while a monster is fighting, so only offer it for a
 	// monster that is out of the ring.
-	const nextToEquip = readyToSend[0];
+	const nextToEquip = idleOutOfRing[0];
 	if (unequippedCards > 0 && nextToEquip) {
 		add(`Equip ${monsterName(nextToEquip)}`, `equip ${monsterName(nextToEquip)}`);
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`send … to the ring` failed in one room after succeeding in others. Characters are room-scoped (expected), but quick-action chips made that worse by offering Send when it would always be refused.

## Root cause

`buildQuickActions` suggested `send {name} to the ring` for any living monster not already in the ring, **without checking deck fullness**. In a new room you often spawn (empty deck) while other rooms are fully set up — the chip still offered Send, and the engine refused:

> Only an evil master would send their monster into battle without enough cards.

A related chip bug: Send was still offered for a second monster while one was already in that room’s ring (`You already have a monster in the ring!`).

## Fix

- Gate Send on `cards.length >= cardSlots` (default 9)
- Prefer Equip when idle monsters lack a full deck but unequipped cards exist
- Never suggest Send when the player already has a contestant in the ring
- Harden send/call-out command paths to `user.id` (private countdown/full-ring announces)

## Tests

`quick-actions.test.ts` — 137 passing (deck readiness, equip-vs-send, already-in-ring)

## Note for players

Each room has its own characters/monsters. Completing spawn → equip → send in rooms A/B does not carry over to room C — you still need a fully equipped monster there. After this fix, the console chips should guide Equip first instead of a doomed Send.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7abbdb97-de50-4a23-86ec-dd4852fe42d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7abbdb97-de50-4a23-86ec-dd4852fe42d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

