### PR TITLE
Fix send-to-ring quick actions suggesting monsters without full decks

### DIFF
--- a/docs/roadmap/10b-bugs-fixed.md
+++ b/docs/roadmap/10b-bugs-fixed.md
@@ -1332,3 +1332,18 @@ Safe in practice — `sendPrompt` is the only publisher and always uses `scope: 
 **Fixed**: re-check `event.targetUserId === userId` before prompting. Restores defense in depth without changing the per-user subscription model.
 
 **Status**: Fixed.
+
+---
+
+### 85. Quick-action chips suggested sends the engine always refuses — FIXED
+
+`buildQuickActions` offered `send {name} to the ring` for any living monster that was not already a ring contestant. The engine's `sendMonsterToTheRing` refuses in two further cases the chip builder did not model:
+
+1. `monster.cards.length < monster.cardSlots` → *"Only an evil master would send their monster into battle without enough cards."* Because characters are room-scoped, a player fully set up in rooms A and B still has a freshly spawned, empty-decked monster in room C — exactly where the chip was most likely to be clicked.
+2. `ring.contestants` already holds a contestant for that character → *"You already have a monster in the ring!"* The chip builder's `hasMonsterInRing` was computed over **living** monsters only, so a monster that died in the ring but had not yet been cleared left the guard false and a second send was offered.
+
+**Fixed**: `readyToSend` is gated on a new `isDeckReady()` (`cards.length >= cardSlots`, defaulting to 9 when the field is missing on a partially hydrated entity), and `hasMonsterInRing` is derived from the player's ring contestants directly rather than from their living monsters — mirroring the engine's `contestant.character === character` test. The equip chip now targets the first idle monster that still needs cards, so it points at whatever is actually blocking the send instead of at an already-equipped monster. `send` / `call out of the ring` also pass `user.id` rather than `user?.id`, so a missing id fails loudly instead of turning private countdown and full-ring announces public (same hardening as the `look at the ring` fix).
+
+Covered by `server/src/quick-actions.test.ts` — deck readiness at default and custom slot counts, equip-instead-of-send, second monster while one is in the ring, dead-contestant-still-in-ring, and equip targeting.
+
+**Status**: Fixed.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -52,13 +52,13 @@ Everything below shipped and is not expected to need revisiting:
 - **Card workshop** — full card management shipped: unequip/move commands, preset save/load/delete, drag-and-drop web workshop at `/workshop`
 - **Battle history persistence** — stored in `options.battles`, capped at 20, survives restarts
 - **Boss encounters** — player boss summoning (3 per rolling 24h, per room) and Ring Events: random encounter modifiers that trigger multi-boss gauntlets, free-for-alls, player alliances, and team battles by surfacing the engine's existing team/targeting machinery. `victoryMode: 'last-team'` for Common Cause and House War: combat ends when one faction survives and all survivors win. Centralized activation (`Ring.activateRingEvent`), quorum-drop event clearing, free-for-all centralized in `getTarget`, contestant-level XP team overrides, and restart-gap fix for the boss summon quota (`bossSummonsPending`). Documented in [`docs/boss-encounters.md`](../boss-encounters.md)
-- **Bug fixes** — all tracked audit items resolved; see `10b-bugs-fixed.md` for the archive, including DMG/CARDS content differentiation (#3), batch-equip UX (#19), per-room card shop scoping (#26), boss-sentinel leaderboard fixes (#27–#33), combat/event findings (#34–#50), and the 2026-08-03 audit fixes (#51–#58, #59–#63, #64, #65–#69, #70–#73, #74–#84).
+- **Bug fixes** — all tracked audit items resolved; see `10b-bugs-fixed.md` for the archive, including DMG/CARDS content differentiation (#3), batch-equip UX (#19), per-room card shop scoping (#26), boss-sentinel leaderboard fixes (#27–#33), combat/event findings (#34–#50), and the 2026-08-03 audit fixes (#51–#58, #59–#63, #64, #65–#69, #70–#73, #74–#85).
 
 ---
 
 ## Active Work — In Order of Priority
 
-Real-time sync bugs, quick actions, batch-equip UX, card shop room-scoping, DMG/CARDS content differentiation (#3), and the 2026-08-03 audit fixes (#51–#84) are all archived in `10b-bugs-fixed.md`. `10-bug-fixes.md` has no remaining active items.
+Real-time sync bugs, quick actions, batch-equip UX, card shop room-scoping, DMG/CARDS content differentiation (#3), and the 2026-08-03 audit fixes (#51–#85) are all archived in `10b-bugs-fixed.md`. `10-bug-fixes.md` has no remaining active items.
 
 ### 1. Discord connector polish (05-discord-connector.md)
 

--- a/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room-report.md
+++ b/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room-report.md
@@ -61,3 +61,16 @@ node --input-type=module -e "import { Game } from './packages/engine/dist/index.
 - Send when 9 cards or `cardSlots: 2` with 2 cards
 - Equip (not Send) when living idle monster lacks deck but `character.deck` has cards
 - Existing ring/other-player tests updated to use deck-ready monsters where Send is expected
+
+## Review follow-up (2026-08-03)
+
+Two gaps found reviewing the first pass:
+
+| Issue | Fix |
+|-------|-----|
+| `hasMonsterInRing` counted only **living** monsters, so a monster that died in the ring (still a contestant) let a doomed second Send be suggested — the engine refuses on `contestant.character === character` regardless of `dead` | Derive `hasMonsterInRing` (and `ringMonsters`) from the player's non-boss ring contestants directly |
+| Equip chip targeted `idleOutOfRing[0]`, which can be an already deck-ready monster while a bare one is the actual blocker | Target the first idle monster that is not deck-ready, falling back to the first idle one |
+
+Tests added: dead-contestant-still-in-ring, equip targeting. Full suite: `pnpm build && pnpm test` — all packages passing (server 139, web 91).
+
+Also recorded as bug #85 in `docs/roadmap/10b-bugs-fixed.md`.

--- a/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room-report.md
+++ b/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room-report.md
@@ -1,0 +1,63 @@
+# Report: Fix send-to-ring quick-action false failures
+
+**Date:** 2026-08-03  
+**Branch:** `cursor/fix-send-to-ring-quick-actions-42d2`  
+**Plan:** [`2026-08-03-fix-send-to-ring-room.md`](./2026-08-03-fix-send-to-ring-room.md)
+
+## Summary
+
+Quick-action chips no longer suggest `send {name} to the ring` unless the monster has a full deck (`cards.length >= cardSlots`, default 9). Equip is offered for idle out-of-ring monsters when unequipped cards exist. Send/call-out-of-ring paths now use `user.id` instead of `user?.id`.
+
+## RED (before fix)
+
+Command:
+
+```bash
+pnpm --filter @deck-monsters/server exec mocha --config .mocharc.yml 'src/quick-actions.test.ts'
+```
+
+Result: **3 failing** (of 136 total in suite run)
+
+```
+1) does not suggest send when the monster has no cards equipped
+   AssertionError: expected [ 'send Fluffy to the ring', …(2) ] to not include 'send Fluffy to the ring'
+
+2) does not suggest send when the monster has fewer cards than slots
+   AssertionError: expected [ 'send Fluffy to the ring', …(2) ] to not include 'send Fluffy to the ring'
+
+3) suggests equip instead of send when idle monsters are not deck-ready but unequipped cards exist
+   AssertionError: expected [ 'send Fluffy to the ring', …(3) ] to not include 'send Fluffy to the ring'
+```
+
+## GREEN (after fix)
+
+Command:
+
+```bash
+pnpm --filter @deck-monsters/engine build
+pnpm --filter @deck-monsters/server exec mocha --config .mocharc.yml 'src/quick-actions.test.ts'
+```
+
+Result: **136 passing** (2s)
+
+Engine smoke:
+
+```bash
+node --input-type=module -e "import { Game } from './packages/engine/dist/index.js'; const g = new Game({}, console.log); console.log('Engine OK'); g.dispose();"
+# → Engine OK
+```
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `packages/server/src/quick-actions.ts` | `isDeckReady()` helper; `readyToSend` gated on deck readiness; `idleOutOfRing` for equip targeting |
+| `packages/server/src/quick-actions.test.ts` | New deck-readiness cases; flipped send-with-empty-deck expectations |
+| `packages/engine/src/commands/monster.ts` | `user?.id` → `user.id` on send-to-ring and call-out-of-ring |
+
+## Test coverage added
+
+- No send when `cards: []` or insufficient cards vs default 9 slots
+- Send when 9 cards or `cardSlots: 2` with 2 cards
+- Equip (not Send) when living idle monster lacks deck but `character.deck` has cards
+- Existing ring/other-player tests updated to use deck-ready monsters where Send is expected

--- a/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room.md
+++ b/docs/superpowers/plans/2026-08-03-fix-send-to-ring-room.md
@@ -1,0 +1,31 @@
+# Fix: send-to-ring fails after working in other rooms
+
+## Context
+
+User: `"send monster to the ring" failed in one of my rooms too even after completing in two other rooms`.
+
+Characters are room-scoped — each room needs its own spawn/equip. Investigation also found a real suggestion bug that produces false failures.
+
+## Root causes (ranked)
+
+1. **Quick actions suggest Send without a full deck** (`packages/server/src/quick-actions.ts`)
+   - `readyToSend` only checks living + not already in ring
+   - Engine refuses with: `Only an evil master would send their monster into battle without enough cards.`
+   - Existing tests encode the bad behavior (send suggested with `deck: []` and no cards on monster)
+   - Chip order can put Send above Equip
+
+2. **Expected room-local state** (not a code bug): no monsters / incomplete equip / already in ring / mid-fight in that room only
+
+3. **`user?.id` optional** on send path — if ever undefined, private countdown/full-ring announces become public and the Console tab drops them (echo only)
+
+## Fix scope
+
+1. `buildQuickActions`: only offer Send when `monster.cards.length >= cardSlots` (default 9)
+2. Prefer Equip over Send when living monsters exist but none are deck-ready and unequipped cards exist
+3. Update unit tests (TDD)
+4. Harden send / call-out paths to `user.id` like the look-at-ring fix
+
+## Out of scope
+
+- Changing room-scoped character design
+- Console showing public `ring.add` events

--- a/packages/engine/src/commands/monster.ts
+++ b/packages/engine/src/commands/monster.ts
@@ -64,7 +64,7 @@ function callMonsterOutOfTheRingAction({
 		const { monsterName } = cleanArgs({ monsterName: results[1] });
 
 		return character
-			.callMonsterOutOfTheRing({ monsterName, ring: game.getRing(), channel, channelName, userId: user?.id })
+			.callMonsterOutOfTheRing({ monsterName, ring: game.getRing(), channel, channelName, userId: user.id })
 			.catch((err: unknown) => game.log(err));
 	});
 }
@@ -253,7 +253,7 @@ function sendMonsterToTheRingAction({
 				ring: game.getRing(),
 				channel,
 				channelName,
-				userId: user?.id,
+				userId: user.id,
 			})
 			.catch((err: unknown) => game.log(err));
 	});

--- a/packages/server/src/quick-actions.test.ts
+++ b/packages/server/src/quick-actions.test.ts
@@ -86,6 +86,26 @@ describe('buildQuickActions', () => {
 		expect(commands).to.not.include('send Fluffy to the ring');
 	});
 
+	it('does not suggest send while a dead monster is still in the ring', () => {
+		// The engine refuses on any contestant belonging to the character, dead or alive.
+		const fallen = { givenName: 'Fluffy', dead: true, cards: makeCards(9) };
+		const idle = { givenName: 'Rex', cards: makeCards(9) };
+		const game = makeGame({ monsters: [fallen, idle], deck: [] }, [
+			{ userId: USER, monster: fallen },
+		]);
+		const commands = buildQuickActions(game, USER).map((a) => a.command);
+		expect(commands).to.not.include('send Rex to the ring');
+	});
+
+	it('targets equip at a monster that still needs cards', () => {
+		const equipped = { givenName: 'Fluffy', cards: makeCards(9) };
+		const bare = { givenName: 'Rex', cards: [] };
+		const game = makeGame({ monsters: [equipped, bare], deck: [{ cardType: 'Hit' }] });
+		const commands = buildQuickActions(game, USER).map((a) => a.command);
+		expect(commands).to.include('equip Rex');
+		expect(commands).to.not.include('equip Fluffy');
+	});
+
 	it('offers to revive a dead monster', () => {
 		const game = makeGame({
 			monsters: [{ givenName: 'Fluffy', dead: true }],

--- a/packages/server/src/quick-actions.test.ts
+++ b/packages/server/src/quick-actions.test.ts
@@ -74,6 +74,18 @@ describe('buildQuickActions', () => {
 		expect(commands).to.not.include('send Fluffy to the ring');
 	});
 
+	it('does not suggest send for a second monster when one is already in the ring', () => {
+		const inRing = { givenName: 'Fluffy', cards: makeCards(9) };
+		const idle = { givenName: 'Rex', cards: makeCards(9) };
+		const game = makeGame({ monsters: [inRing, idle], deck: [] }, [
+			{ userId: USER, monster: inRing },
+		]);
+		const commands = buildQuickActions(game, USER).map((a) => a.command);
+		expect(commands).to.include('look at the ring');
+		expect(commands).to.not.include('send Rex to the ring');
+		expect(commands).to.not.include('send Fluffy to the ring');
+	});
+
 	it('offers to revive a dead monster', () => {
 		const game = makeGame({
 			monsters: [{ givenName: 'Fluffy', dead: true }],

--- a/packages/server/src/quick-actions.test.ts
+++ b/packages/server/src/quick-actions.test.ts
@@ -4,6 +4,9 @@ import { buildQuickActions } from './quick-actions.js';
 
 const USER = 'user-1';
 
+const makeCards = (count: number): Array<{ cardType: string }> =>
+	Array.from({ length: count }, (_, i) => ({ cardType: `Card${i}` }));
+
 const makeGame = (
 	character: Record<string, unknown> | undefined,
 	contestants: Array<{ userId?: string; monster?: unknown; isBoss?: boolean }> = []
@@ -26,10 +29,39 @@ describe('buildQuickActions', () => {
 		expect(actions[0]?.command).to.equal('spawn monster');
 	});
 
-	it('offers to send an idle monster into the ring', () => {
-		const monster = { givenName: 'Fluffy' };
+	it('does not suggest send when the monster has no cards equipped', () => {
+		const monster = { givenName: 'Fluffy', cards: [] };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.not.include('send Fluffy to the ring');
+	});
+
+	it('does not suggest send when the monster has fewer cards than slots', () => {
+		const monster = { givenName: 'Fluffy', cards: makeCards(3) };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.not.include('send Fluffy to the ring');
+	});
+
+	it('suggests send when the monster has a full default deck (9 cards)', () => {
+		const monster = { givenName: 'Fluffy', cards: makeCards(9) };
 		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
 		expect(actions.map((a) => a.command)).to.include('send Fluffy to the ring');
+	});
+
+	it('suggests send when cards meet a custom cardSlots count', () => {
+		const monster = { givenName: 'Fluffy', cards: makeCards(2), cardSlots: 2 };
+		const actions = buildQuickActions(makeGame({ monsters: [monster], deck: [] }), USER);
+		expect(actions.map((a) => a.command)).to.include('send Fluffy to the ring');
+	});
+
+	it('suggests equip instead of send when idle monsters are not deck-ready but unequipped cards exist', () => {
+		const monster = { givenName: 'Fluffy', cards: [] };
+		const actions = buildQuickActions(
+			makeGame({ monsters: [monster], deck: [{ cardType: 'Hit' }] }),
+			USER
+		);
+		const commands = actions.map((a) => a.command);
+		expect(commands).to.include('equip Fluffy');
+		expect(commands).to.not.include('send Fluffy to the ring');
 	});
 
 	it('offers the ring view instead of a send for a monster already fighting', () => {
@@ -79,7 +111,7 @@ describe('buildQuickActions', () => {
 	});
 
 	it('ignores ring contestants belonging to other players', () => {
-		const mine = { givenName: 'Fluffy' };
+		const mine = { givenName: 'Fluffy', cards: makeCards(9) };
 		const theirs = { givenName: 'Rex' };
 		const game = makeGame({ monsters: [mine], deck: [] }, [
 			{ userId: 'someone-else', monster: theirs },
@@ -93,8 +125,8 @@ describe('buildQuickActions', () => {
 		const game = makeGame(
 			{
 				monsters: [
-					{ givenName: 'InRing' },
-					{ givenName: 'Idle' },
+					{ givenName: 'InRing', cards: makeCards(9) },
+					{ givenName: 'Idle', cards: makeCards(9) },
 					{ givenName: 'Dead', dead: true },
 				],
 				deck: [{ cardType: 'Hit' }],

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -127,7 +127,8 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 		add('Look at the ring', 'look at the ring');
 	}
 
-	const nextToSend = readyToSend[0];
+	// Engine allows only one of the player's monsters in the ring at a time.
+	const nextToSend = !hasMonsterInRing ? readyToSend[0] : undefined;
 	if (nextToSend) {
 		add(`Send ${monsterName(nextToSend)} to the ring`, `send ${monsterName(nextToSend)} to the ring`);
 	}

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -20,6 +20,7 @@ export interface QuickAction {
 }
 
 const MAX_QUICK_ACTIONS = 4;
+const DEFAULT_CARD_SLOTS = 9;
 
 type LooseRecord = Record<string, unknown>;
 
@@ -43,6 +44,14 @@ const isDead = (monster: unknown): boolean =>
 
 const isDestroyed = (monster: unknown): boolean =>
 	Boolean((monster as LooseRecord | undefined)?.destroyed);
+
+const cardSlots = (monster: unknown): number => {
+	const slots = (monster as LooseRecord | undefined)?.cardSlots;
+	return typeof slots === 'number' && slots > 0 ? slots : DEFAULT_CARD_SLOTS;
+};
+
+const isDeckReady = (monster: unknown): boolean =>
+	asArray((monster as LooseRecord | undefined)?.cards).length >= cardSlots(monster);
 
 /** Defensive read — this runs inside the command pipeline and must never throw. */
 const summonsRemaining = (game: QuickActionsGame, userId: string): number => {
@@ -95,7 +104,8 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 	const deadRevivable = monsters.filter(
 		(monster) => isDead(monster) && !isDestroyed(monster)
 	);
-	const readyToSend = living.filter((monster) => !ringMonsters.has(monster));
+	const idleOutOfRing = living.filter((monster) => !ringMonsters.has(monster));
+	const readyToSend = idleOutOfRing.filter(isDeckReady);
 	const hasMonsterInRing = living.some((monster) => ringMonsters.has(monster));
 	const unequippedCards = asArray(character.deck).length;
 
@@ -129,7 +139,7 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 
 	// Equipping is rejected while a monster is fighting, so only offer it for a
 	// monster that is out of the ring.
-	const nextToEquip = readyToSend[0];
+	const nextToEquip = idleOutOfRing[0];
 	if (unequippedCards > 0 && nextToEquip) {
 		add(`Equip ${monsterName(nextToEquip)}`, `equip ${monsterName(nextToEquip)}`);
 	}

--- a/packages/server/src/quick-actions.ts
+++ b/packages/server/src/quick-actions.ts
@@ -91,13 +91,15 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 		];
 	}
 
-	const ringMonsters = new Set(
-		asArray(game?.ring?.contestants)
-			.filter((contestant) => {
-				const entry = contestant as LooseRecord;
-				return entry?.userId === userId && !entry?.isBoss;
-			})
+	const contestants = asArray(game?.ring?.contestants);
+	const myContestants = contestants.filter((contestant) => {
+		const entry = contestant as LooseRecord;
+		return entry?.userId === userId && !entry?.isBoss;
+	});
+	const ringMonsters = new Set<unknown>(
+		myContestants
 			.map((contestant) => (contestant as LooseRecord).monster)
+			.filter((monster) => monster !== undefined && monster !== null)
 	);
 
 	const living = monsters.filter((monster) => !isDead(monster) && !isDestroyed(monster));
@@ -106,7 +108,10 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 	);
 	const idleOutOfRing = living.filter((monster) => !ringMonsters.has(monster));
 	const readyToSend = idleOutOfRing.filter(isDeckReady);
-	const hasMonsterInRing = living.some((monster) => ringMonsters.has(monster));
+	// `sendMonsterToTheRing` refuses while *any* of this character's contestants is in
+	// the ring — including one that just died there and has not been cleared yet. Match
+	// that condition exactly, or the chips offer a send the engine will always refuse.
+	const hasMonsterInRing = myContestants.length > 0;
 	const unequippedCards = asArray(character.deck).length;
 
 	// Ordered by how likely each is to be the player's actual next move.
@@ -114,7 +119,6 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 		// Waiting in an empty ring is the single most common dead end, so offer the summon
 		// ahead of everything else — but only when there is nothing to fight and the player
 		// still has a charge left.
-		const contestants = asArray(game?.ring?.contestants);
 		const hasOpponent = contestants.some((contestant) => {
 			const entry = contestant as LooseRecord;
 			return entry?.isBoss || entry?.userId !== userId;
@@ -139,8 +143,10 @@ export function buildQuickActions(game: QuickActionsGame, userId: string): Quick
 	}
 
 	// Equipping is rejected while a monster is fighting, so only offer it for a
-	// monster that is out of the ring.
-	const nextToEquip = idleOutOfRing[0];
+	// monster that is out of the ring. Prefer one that still needs cards — pointing the
+	// chip at an already deck-ready monster wastes the suggestion when a bare monster is
+	// the thing actually blocking a send.
+	const nextToEquip = idleOutOfRing.find((monster) => !isDeckReady(monster)) ?? idleOutOfRing[0];
 	if (unequippedCards > 0 && nextToEquip) {
 		add(`Equip ${monsterName(nextToEquip)}`, `equip ${monsterName(nextToEquip)}`);
 	}


### PR DESCRIPTION
Quick-action chips offered "send {name} to the ring" for any living
monster not already in the ring, even when the deck was empty. The engine
then refused with "not enough cards", which looked like a send failure —
especially common in new rooms where the player had already equipped
elsewhere.

Gate Send on isDeckReady (cards.length >= cardSlots, default 9). Offer
Equip for idle out-of-ring monsters when unequipped cards exist. Harden
send/call-out paths to use user.id instead of user?.id.

TDD: 3 failing → 136 passing quick-actions tests.

Co-authored-by: dave <dave@brainerbanker.com>