### PR TITLE
fix(server): Fastify maxParamLength so room Terminal tRPC batches stop 404ing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,4 +139,4 @@ Missing a room filter is a recurring source of bugs. See [`docs/room-scoping.md`
 
 ### Active known bugs
 
-None tracked in `docs/roadmap/10-bug-fixes.md` — the 2026-08-03 audit pass (#3, #51–#84) is archived in `docs/roadmap/10b-bugs-fixed.md`.
+None tracked in `docs/roadmap/10-bug-fixes.md` — the 2026-08-03 audit pass (#3, #51–#84) and Fastify tRPC batch `maxParamLength` fix (#86) are archived in `docs/roadmap/10b-bugs-fixed.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,7 @@ Fight pacing, the serialized engine lanes, `activeFlows`, and the interactive pr
 
 ## Known Issues
 
-No active tracked bugs. Previously listed items are fixed — see `docs/roadmap/10b-bugs-fixed.md` for root causes, including DMG/CARDS content differentiation (#3), fight log not updating (#15), console history missing on reconnect (#16/#17), card shop room-scoping (#26), batch-equip UX (#19), Discord free-text prompts / serialization (#59/#60), workshop↔console same-user guard (#61), dual web `ringFeed` (#63), harness lane alignment (#73), ConnectorAdapter prompt cancellation (#78), the 2026-08-03 audit fixes (#51–#58, #74–#84), and Fastify tRPC batch `maxParamLength` 404s (#86).
+No active tracked bugs. Previously listed items are fixed — see `docs/roadmap/10b-bugs-fixed.md` for root causes, including DMG/CARDS content differentiation (#3), fight log not updating (#15), console history missing on reconnect (#16/#17), card shop room-scoping (#26), batch-equip UX (#19), Discord free-text prompts / serialization (#59/#60), workshop↔console same-user guard (#61), dual web `ringFeed` (#63), harness lane alignment (#73), ConnectorAdapter prompt cancellation (#78), the 2026-08-03 audit fixes (#51–#58, #74–#85), and Fastify tRPC batch `maxParamLength` 404s (#86).
 
 ## Archived / Deferred
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,7 @@ Fight pacing, the serialized engine lanes, `activeFlows`, and the interactive pr
 
 ## Known Issues
 
-No active tracked bugs. Previously listed items are fixed — see `docs/roadmap/10b-bugs-fixed.md` for root causes, including DMG/CARDS content differentiation (#3), fight log not updating (#15), console history missing on reconnect (#16/#17), card shop room-scoping (#26), batch-equip UX (#19), Discord free-text prompts / serialization (#59/#60), workshop↔console same-user guard (#61), dual web `ringFeed` (#63), harness lane alignment (#73), ConnectorAdapter prompt cancellation (#78), and the 2026-08-03 audit fixes (#51–#58, #74–#84).
+No active tracked bugs. Previously listed items are fixed — see `docs/roadmap/10b-bugs-fixed.md` for root causes, including DMG/CARDS content differentiation (#3), fight log not updating (#15), console history missing on reconnect (#16/#17), card shop room-scoping (#26), batch-equip UX (#19), Discord free-text prompts / serialization (#59/#60), workshop↔console same-user guard (#61), dual web `ringFeed` (#63), harness lane alignment (#73), ConnectorAdapter prompt cancellation (#78), the 2026-08-03 audit fixes (#51–#58, #74–#84), and Fastify tRPC batch `maxParamLength` 404s (#86).
 
 ## Archived / Deferred
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -423,3 +423,6 @@ Run `supabase db push --linked` (production) or `supabase db reset` (local) to a
 
 **Docker build fails on `pnpm install --frozen-lockfile`**
 The `pnpm-lock.yaml` is out of sync with package manifests. Run `pnpm install` locally and commit the updated lockfile.
+
+**Room page loads but HTTP tRPC batches 404 (`Route GET:/trpc/room.info,game.…`)**
+Fastify defaults to `maxParamLength: 100`. tRPC `httpBatchLink` puts comma-joined procedure names in that path param; the Terminal room mount’s 7-query batch is ~114 characters, so Fastify 404s the whole batch before tRPC runs (WebSocket subscriptions can still connect). The server sets `routerOptions.maxParamLength: 5000` via `createFastifyOptions` — do not remove it. See `docs/roadmap/10b-bugs-fixed.md` (#86).

--- a/docs/roadmap/10-bug-fixes.md
+++ b/docs/roadmap/10-bug-fixes.md
@@ -2,7 +2,7 @@
 
 **Category**: Bug / Tech Debt
 **Priority**: Medium
-**Status**: Archive — all tracked items from the 2026-08-03 audit pass are resolved. See [`10b-bugs-fixed.md`](10b-bugs-fixed.md) for the full archive (#3, #51–#58, #59–#73, #74–#84).
+**Status**: Archive — all tracked items from the 2026-08-03 audit pass are resolved. See [`10b-bugs-fixed.md`](10b-bugs-fixed.md) for the full archive (#3, #51–#58, #59–#73, #74–#85, #86).
 
 ## Active Items
 

--- a/docs/roadmap/10b-bugs-fixed.md
+++ b/docs/roadmap/10b-bugs-fixed.md
@@ -1347,3 +1347,19 @@ Safe in practice — `sendPrompt` is the only publisher and always uses `scope: 
 Covered by `server/src/quick-actions.test.ts` — deck readiness at default and custom slot counts, equip-instead-of-send, second monster while one is in the ring, dead-contestant-still-in-ring, and equip targeting.
 
 **Status**: Fixed.
+
+---
+
+### 86. Room Terminal HTTP batch 404s under Fastify default `maxParamLength` — FIXED
+
+Opening a room (e.g. production Game Night) issued one `httpBatchLink` GET for seven procedures:
+
+`room.info,game.ringHistory,game.recentFights,game.ringState,game.consoleHistory,game.pendingPrompt,game.myMonsters`
+
+That path is **114 characters**. Fastify’s default `maxParamLength` is **100**, so the framework returned its own `404 Route GET:/trpc/…` **before** the tRPC plugin ran. Single-procedure and short batches still worked; the WebSocket `ringFeed` subscription still connected — so the UI looked half-alive (boss timer via WS) while history, prompts, and monster autocomplete stayed empty / flaky. Non-members separately saw sustained `403 Not a member of this room` and a permanent “RECONNECTING…” banner; that is membership gating, not this bug.
+
+**Why it showed up after recent PRs**: room-mount query count grew (ring history + recent fights + console history + pending prompt + myMonsters + …) until the joined batch path crossed 100 characters. Not a bad deploy of game state — the blob and memberships for Game Night were intact.
+
+**Fixed**: server bootstrap uses `createFastifyOptions` with `routerOptions.maxParamLength: 5000` (official `@trpc/server` Fastify adapter guidance). Documented in `docs/deployment.md` troubleshooting. Regression coverage in `packages/server/src/fastify-batch-path.test.ts` (default Fastify 404s the Terminal path; configured options serve it).
+
+**Status**: Fixed.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -52,13 +52,13 @@ Everything below shipped and is not expected to need revisiting:
 - **Card workshop** — full card management shipped: unequip/move commands, preset save/load/delete, drag-and-drop web workshop at `/workshop`
 - **Battle history persistence** — stored in `options.battles`, capped at 20, survives restarts
 - **Boss encounters** — player boss summoning (3 per rolling 24h, per room) and Ring Events: random encounter modifiers that trigger multi-boss gauntlets, free-for-alls, player alliances, and team battles by surfacing the engine's existing team/targeting machinery. `victoryMode: 'last-team'` for Common Cause and House War: combat ends when one faction survives and all survivors win. Centralized activation (`Ring.activateRingEvent`), quorum-drop event clearing, free-for-all centralized in `getTarget`, contestant-level XP team overrides, and restart-gap fix for the boss summon quota (`bossSummonsPending`). Documented in [`docs/boss-encounters.md`](../boss-encounters.md)
-- **Bug fixes** — all tracked audit items resolved; see `10b-bugs-fixed.md` for the archive, including DMG/CARDS content differentiation (#3), batch-equip UX (#19), per-room card shop scoping (#26), boss-sentinel leaderboard fixes (#27–#33), combat/event findings (#34–#50), and the 2026-08-03 audit fixes (#51–#58, #59–#63, #64, #65–#69, #70–#73, #74–#85).
+- **Bug fixes** — all tracked audit items resolved; see `10b-bugs-fixed.md` for the archive, including DMG/CARDS content differentiation (#3), batch-equip UX (#19), per-room card shop scoping (#26), boss-sentinel leaderboard fixes (#27–#33), combat/event findings (#34–#50), the 2026-08-03 audit fixes (#51–#58, #59–#63, #64, #65–#69, #70–#73, #74–#85), and Fastify tRPC batch `maxParamLength` 404s (#86).
 
 ---
 
 ## Active Work — In Order of Priority
 
-Real-time sync bugs, quick actions, batch-equip UX, card shop room-scoping, DMG/CARDS content differentiation (#3), and the 2026-08-03 audit fixes (#51–#85) are all archived in `10b-bugs-fixed.md`. `10-bug-fixes.md` has no remaining active items.
+Real-time sync bugs, quick actions, batch-equip UX, card shop room-scoping, DMG/CARDS content differentiation (#3), the 2026-08-03 audit fixes (#51–#85), and Fastify tRPC batch `maxParamLength` 404s (#86) are all archived in `10b-bugs-fixed.md`. `10-bug-fixes.md` has no remaining active items.
 
 ### 1. Discord connector polish (05-discord-connector.md)
 

--- a/packages/server/src/fastify-batch-path.test.ts
+++ b/packages/server/src/fastify-batch-path.test.ts
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import Fastify, { type FastifyServerOptions } from 'fastify';
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+import { createFastifyOptions, FASTIFY_MAX_PARAM_LENGTH } from './fastify-options.js';
+
+/**
+ * Builds a path like the web Terminal's room-mount batch:
+ * room.info,game.ringHistory,game.recentFights,game.ringState,
+ * game.consoleHistory,game.pendingPrompt,game.myMonsters (~114 chars).
+ */
+function terminalBatchPath(): string {
+	return [
+		'room.info',
+		'game.ringHistory',
+		'game.recentFights',
+		'game.ringState',
+		'game.consoleHistory',
+		'game.pendingPrompt',
+		'game.myMonsters',
+	].join(',');
+}
+
+function buildMiniRouter() {
+	const t = initTRPC.create();
+	const roomInput = z.object({ roomId: z.string() });
+	const stub = t.procedure.input(roomInput).query(({ input }) => ({ ok: true, roomId: input.roomId }));
+	return t.router({
+		room: t.router({ info: stub }),
+		game: t.router({
+			ringHistory: stub,
+			recentFights: stub,
+			ringState: stub,
+			consoleHistory: stub,
+			pendingPrompt: stub,
+			myMonsters: stub,
+		}),
+	});
+}
+
+async function withServer(
+	fastifyOpts: FastifyServerOptions,
+	run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+	const app = Fastify(fastifyOpts);
+	await app.register(fastifyTRPCPlugin, {
+		prefix: '/trpc',
+		trpcOptions: { router: buildMiniRouter() },
+	});
+	await app.listen({ port: 0, host: '127.0.0.1' });
+	const address = app.server.address();
+	if (!address || typeof address === 'string') {
+		await app.close();
+		throw new Error('expected TCP listen address');
+	}
+	try {
+		await run(`http://127.0.0.1:${address.port}`);
+	} finally {
+		await app.close();
+	}
+}
+
+describe('Fastify tRPC batch path length', () => {
+	const roomId = '11483952-4af5-48dd-bebe-605f22189e1c';
+	const path = terminalBatchPath();
+
+	it('documents that the Terminal batch path exceeds Fastify’s default maxParamLength', () => {
+		expect(path.length).to.be.greaterThan(100);
+		expect(path.length).to.be.lessThan(FASTIFY_MAX_PARAM_LENGTH);
+	});
+
+	it('404s the Terminal batch under Fastify defaults (regression fixture)', async () => {
+		await withServer({ logger: false }, async (baseUrl) => {
+			const input: Record<string, { roomId: string }> = {};
+			for (let i = 0; i < 7; i++) input[String(i)] = { roomId };
+			const url =
+				`${baseUrl}/trpc/${path}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
+			const res = await fetch(url);
+			expect(res.status).to.equal(404);
+		});
+	});
+
+	it('serves the Terminal batch when maxParamLength follows tRPC Fastify guidance', async () => {
+		expect(createFastifyOptions('silent').routerOptions.maxParamLength).to.equal(
+			FASTIFY_MAX_PARAM_LENGTH,
+		);
+		const opts: FastifyServerOptions = {
+			logger: false,
+			routerOptions: { maxParamLength: FASTIFY_MAX_PARAM_LENGTH },
+		};
+		await withServer(opts, async (baseUrl) => {
+			const input: Record<string, { roomId: string }> = {};
+			for (let i = 0; i < 7; i++) input[String(i)] = { roomId };
+			const url =
+				`${baseUrl}/trpc/${path}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
+			const res = await fetch(url);
+			expect(res.status).to.equal(200);
+			const body = (await res.json()) as Array<{ result?: { data?: { ok?: boolean } } }>;
+			expect(body).to.have.length(7);
+			for (const entry of body) {
+				expect(entry.result?.data?.ok).to.equal(true);
+			}
+		});
+	});
+});

--- a/packages/server/src/fastify-batch-path.test.ts
+++ b/packages/server/src/fastify-batch-path.test.ts
@@ -10,6 +10,10 @@ import { createFastifyOptions, FASTIFY_MAX_PARAM_LENGTH } from './fastify-option
  * Builds a path like the web Terminal's room-mount batch:
  * room.info,game.ringHistory,game.recentFights,game.ringState,
  * game.consoleHistory,game.pendingPrompt,game.myMonsters (~114 chars).
+ *
+ * Hardcoded on purpose: documents the production path that crossed Fastify's
+ * default maxParamLength. An 8th room-mount query won't auto-update this list;
+ * headroom vs 5000 makes that low risk.
  */
 function terminalBatchPath(): string {
 	return [
@@ -40,6 +44,12 @@ function buildMiniRouter() {
 	});
 }
 
+function batchUrl(baseUrl: string, path: string, roomId: string, procedureCount: number): string {
+	const input: Record<string, { roomId: string }> = {};
+	for (let i = 0; i < procedureCount; i++) input[String(i)] = { roomId };
+	return `${baseUrl}/trpc/${path}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
+}
+
 async function withServer(
 	fastifyOpts: FastifyServerOptions,
 	run: (baseUrl: string) => Promise<void>,
@@ -65,40 +75,31 @@ async function withServer(
 describe('Fastify tRPC batch path length', () => {
 	const roomId = '11483952-4af5-48dd-bebe-605f22189e1c';
 	const path = terminalBatchPath();
+	const procedureCount = path.split(',').length;
 
 	it('documents that the Terminal batch path exceeds Fastify’s default maxParamLength', () => {
 		expect(path.length).to.be.greaterThan(100);
 		expect(path.length).to.be.lessThan(FASTIFY_MAX_PARAM_LENGTH);
 	});
 
+	// Framework-behavior fixture: Fastify defaults to maxParamLength 100. If that
+	// default ever rises above our Terminal path length, this fails even though
+	// createFastifyOptions still works — keep it as documentation of why we raise.
 	it('404s the Terminal batch under Fastify defaults (regression fixture)', async () => {
 		await withServer({ logger: false }, async (baseUrl) => {
-			const input: Record<string, { roomId: string }> = {};
-			for (let i = 0; i < 7; i++) input[String(i)] = { roomId };
-			const url =
-				`${baseUrl}/trpc/${path}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
-			const res = await fetch(url);
+			const res = await fetch(batchUrl(baseUrl, path, roomId, procedureCount));
 			expect(res.status).to.equal(404);
 		});
 	});
 
-	it('serves the Terminal batch when maxParamLength follows tRPC Fastify guidance', async () => {
-		expect(createFastifyOptions('silent').routerOptions.maxParamLength).to.equal(
-			FASTIFY_MAX_PARAM_LENGTH,
-		);
-		const opts: FastifyServerOptions = {
-			logger: false,
-			routerOptions: { maxParamLength: FASTIFY_MAX_PARAM_LENGTH },
-		};
-		await withServer(opts, async (baseUrl) => {
-			const input: Record<string, { roomId: string }> = {};
-			for (let i = 0; i < 7; i++) input[String(i)] = { roomId };
-			const url =
-				`${baseUrl}/trpc/${path}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
-			const res = await fetch(url);
+	it('serves the Terminal batch when configured via createFastifyOptions', async () => {
+		// Production path: createFastifyOptions sets maxParamLength. logger:false
+		// only quiets Pino in the test process.
+		await withServer({ ...createFastifyOptions('silent'), logger: false }, async (baseUrl) => {
+			const res = await fetch(batchUrl(baseUrl, path, roomId, procedureCount));
 			expect(res.status).to.equal(200);
 			const body = (await res.json()) as Array<{ result?: { data?: { ok?: boolean } } }>;
-			expect(body).to.have.length(7);
+			expect(body).to.have.length(procedureCount);
 			for (const entry of body) {
 				expect(entry.result?.data?.ok).to.equal(true);
 			}

--- a/packages/server/src/fastify-options.ts
+++ b/packages/server/src/fastify-options.ts
@@ -1,0 +1,22 @@
+/**
+ * Fastify instance options shared by the production server bootstrap.
+ *
+ * Why `maxParamLength` is raised: tRPC's `httpBatchLink` encodes multiple
+ * procedure names in a single path parameter
+ * (`/trpc/room.info,game.ringHistory,...`). Fastify defaults to
+ * `maxParamLength: 100`. The Terminal room mount fires 7 queries whose joined
+ * path is ~114 characters, so Fastify returns its own 404 *before* the tRPC
+ * plugin runs — console history, ring history, pending prompts, and myMonsters
+ * all fail to load while the WebSocket subscription still connects. That
+ * surfaced as "RECONNECTING…" / empty panes after room-load query count grew.
+ *
+ * Value matches the official `@trpc/server` Fastify adapter guidance.
+ */
+export const FASTIFY_MAX_PARAM_LENGTH = 5000;
+
+export function createFastifyOptions(logLevel: string) {
+	return {
+		logger: { level: logLevel },
+		routerOptions: { maxParamLength: FASTIFY_MAX_PARAM_LENGTH },
+	} as const;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@ import { createRouter } from './trpc/router.js';
 import { createContext } from './trpc/context.js';
 import { registry } from './metrics/index.js';
 import { createLogger } from './logger.js';
+import { createFastifyOptions } from './fastify-options.js';
 
 const PORT = parseInt(process.env['PORT'] ?? '3000', 10);
 const HOST = process.env['HOST'] ?? '0.0.0.0';
@@ -29,9 +30,8 @@ const log = createLogger('server');
 async function start(): Promise<void> {
 	// LOG_LEVEL controls both our structured logger and Fastify's built-in Pino logger
 	// so HTTP request logs honour the same threshold as application logs.
-	const fastify = Fastify({
-		logger: { level: LOG_LEVEL },
-	});
+	// maxParamLength: see createFastifyOptions — required for tRPC httpBatchLink.
+	const fastify = Fastify(createFastifyOptions(LOG_LEVEL));
 
 	log.debug('server starting', {
 		port: PORT,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening **any** room on production leaves the Terminal half-broken: WebSocket `ringFeed` can connect (boss timer still moves), but the initial HTTP batch for room/history/prompt/monster queries returns Fastify’s own **404**:

```
GET /trpc/room.info,game.ringHistory,game.recentFights,game.ringState,game.consoleHistory,game.pendingPrompt,game.myMonsters?batch=1&…
→ {"message":"Route GET:/trpc/room.info,…","error":"Not Found","statusCode":404}
```

This is **not room-specific** — every room Terminal mounts the same seven queries. Short batches (≤4 procedures) still return 200/207; only the full Terminal mount batch fails.

## Root cause

tRPC `httpBatchLink` encodes multiple procedure names in **one Fastify path parameter**. Fastify defaults to `maxParamLength: 100`. The Terminal’s 7-query joined path is **~114 characters**, so Fastify rejects the route before the tRPC plugin runs.

This became visible after recent room-mount query growth (history + recent fights + console + pending prompt + myMonsters, etc.) pushed the batch path over 100 chars.

(Non-member deep-links separately show sustained `403 Not a member of this room` and a permanent “RECONNECTING…” banner — that is membership gating, not this bug.)

## Fix

- `createFastifyOptions()` sets `routerOptions.maxParamLength: 5000` (official `@trpc/server` Fastify adapter guidance).
- Regression test in `fastify-batch-path.test.ts`: default Fastify 404s the Terminal path; success path spreads `createFastifyOptions` into the server under test.
- Documented in `docs/deployment.md` troubleshooting and archived as #86 in `10b-bugs-fixed.md`.

## Review follow-ups (this push)

- Success case now boots via `{ ...createFastifyOptions('silent'), logger: false }` instead of a hand-rolled options twin.
- Shared `batchUrl()` helper for both HTTP tests.
- CLAUDE.md known-bugs list includes #85 (was skipping it when appending #86).

Left as intentional / deferred: framework-default 404 fixture (documents why we raise), hardcoded path list (114 vs 5000 headroom), client `maxURLLength` defense-in-depth.

## Verification

- `pnpm --filter @deck-monsters/server typecheck`
- `pnpm --filter @deck-monsters/server test` — Fastify batch suite green; full suite previously 144 passing
- Manual prod probe: 4-path batch OK, 7-path batch 404 under current deploy

## Related (applied to prod separately, no code in this PR)

Production migration drift is closed for the two post-RLS files that were still missing:

- `fight_summaries.ring_event` (fixes fight-summary insert failures)
- `guild_user_active_rooms` + one-default-per-guild unique index

Confirmed present after apply.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c344a7f-0c05-47d1-840f-1e45ba586be0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c344a7f-0c05-47d1-840f-1e45ba586be0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

